### PR TITLE
Update build.xml to reobfuscate with Searge names

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -124,11 +124,11 @@
 		
 		<!-- Reobfuscate -->
 		<exec dir="${mcp.dir}" executable="cmd" osfamily="windows">
-			<arg line="/c reobfuscate.bat"/>
+			<arg line="/c reobfuscate_srg.bat"/>
 		</exec>
 
 		<exec dir="${mcp.dir}" executable="sh" osfamily="unix">
-			<arg value="reobfuscate.sh"/>
+			<arg value="reobfuscate_srg.sh"/>
 		</exec>
 
 		<!-- Copy classes -->


### PR DESCRIPTION
Reobfuscating with Searge names (as opposed to the Obfuscated Minecraft classnames) will give the mod a pretty great chance of running on 1.6.4 even if compiled for 1.6.2, or any of the 1.6.x versions.
