### PR TITLE
Update TileEntitySolarPanel.java

### DIFF
--- a/common/crazypants/enderio/machine/solar/TileEntitySolarPanel.java
+++ b/common/crazypants/enderio/machine/solar/TileEntitySolarPanel.java
@@ -99,7 +99,7 @@ public class TileEntitySolarPanel extends TileEntity implements IInternalPowerRe
     lightValue = Math.round(lightValue * MathHelper.cos(sunAngle));
 
     lightValue = MathHelper.clamp_int(lightValue, 0, 15);
-    return lightValue / 15f;
+    return lightValue / 30f;
   }
 
   private boolean transmitEnergy() {


### PR DESCRIPTION
Halving the output of the solar panel, if I'm not mistaken. They've gotten wayyyy cheaper and should be a bit nerfed in power output.

So at lightvalue 15 it's 15/15 = 1 which translates to 1MJ/t, aye? Well, with 15/30 you'll get 0.5 MJ/t, then. Fairly reasonable in my opinion.

I know there's the option to turn off solar panels entirely, but that's not the point.

I might be wrong.
