### PR TITLE
Update SAGMillRecipes_Core.xml

### DIFF
--- a/resources/assets/enderio/config/SAGMillRecipes_Core.xml
+++ b/resources/assets/enderio/config/SAGMillRecipes_Core.xml
@@ -308,7 +308,7 @@
         <itemStack itemID="82" />
       </input>
       <output>
-        <itemStack oreDictionary="dustClay" number="4" />
+        <itemStack itemID="337" number="2" />
       </output>
       <output>
         <itemStack itemID="337" number="2" chance="0.1" />


### PR DESCRIPTION
dustClay doesn't work for some people, it seems to be mod-dependent. Reverting back to vanilla itemID for clay-balls.
