### PR TITLE
Allow standard cube blocks to be used in painter correctly

### DIFF
--- a/common/crazypants/enderio/machine/painter/BasicPainterTemplate.java
+++ b/common/crazypants/enderio/machine/painter/BasicPainterTemplate.java
@@ -21,7 +21,7 @@ public abstract class BasicPainterTemplate implements IMachineRecipe {
     if(block == null) {
       return false;
     }
-    return Block.isNormalCube(block.blockID) || block.blockID == Block.glass.blockID;
+    return block.isNormalCube(block.blockID) || block.blockID == Block.glass.blockID;
   }
 
   protected final int[] validIds;


### PR DESCRIPTION
Possible typo? Maybe?
