### PR TITLE
Crash-Bugfix

### DIFF
--- a/common/crazypants/enderio/conduit/power/PowerConduit.java
+++ b/common/crazypants/enderio/conduit/power/PowerConduit.java
@@ -362,7 +362,7 @@ public class PowerConduit extends AbstractConduit implements IPowerConduit {
   @Override
   public boolean onNeighborBlockChange(int blockId) {
     redstoneStateDirty = true;
-    if(network != null) {
+    if(network != null && network.powerManager != null) {
       network.powerManager.receptorsChanged();
     }
     return super.onNeighborBlockChange(blockId);


### PR DESCRIPTION
Prevents a NPE in some cases. I can't really tell the exact cause as it crashed our server on startup. Seems apropriate however as the field is checked for null everywhere else.
