### PR TITLE
Change Ouput to Output

### DIFF
--- a/resources/assets/enderio/lang/en_US.lang
+++ b/resources/assets/enderio/lang/en_US.lang
@@ -173,7 +173,7 @@ enderio.gui.capBank.inputRs=Input Redstone Mode
 enderio.gui.capBank.outputRs=Output Redstone Mode
 enderio.gui.capBank.maxIo=Max I/O
 enderio.gui.capBank.maxInput=Max Input
-enderio.gui.capBank.maxOutput=Max Ouput
+enderio.gui.capBank.maxOutput=Max Output
 
 //Transceiver
 enderio.gui.trans.publicChannel=Public Channel


### PR DESCRIPTION
Changed "Ouput" to "Output" in capacitor banks. Not sure if this was intentional? It's been on every version of EnderIO I've played. I could see if maybe this was due to layouting?
