### PR TITLE
Various fixes in en_US.lang

### DIFF
--- a/resources/assets/enderio/lang/en_US.lang
+++ b/resources/assets/enderio/lang/en_US.lang
@@ -12,7 +12,7 @@ tile.blockEnderIo.tooltip.detailed.line1=Allow remote access to near by
 tile.blockEnderIo.tooltip.detailed.line2=blocks
 tile.blockEnderIo.tooltip.detailed.line3=Used with Travel Anchors or
 tile.blockEnderIo.tooltip.detailed.line4=the Staff of Travel
-e
+
 item.enderio.itemEnderface.name=Enderface
 
 //Conduits


### PR DESCRIPTION
I am sure you meant Millibuckets, not Megabuckets.
Also removed free spaces from line endings and a duped "based".
