### PR TITLE
Steel in machine chassi option

### DIFF
--- a/src/main/java/crazypants/enderio/Config.java
+++ b/src/main/java/crazypants/enderio/Config.java
@@ -34,6 +34,8 @@ public final class Config {
   public static File configDirectory;
 
   public static boolean useHardRecipes = false;
+  
+  public static boolean useSteelInChassi = false;
 
   public static boolean detailedPowerTrackingEnabled = false;
 
@@ -173,6 +175,9 @@ public final class Config {
 
     useHardRecipes = config.get("Recipe Settings", "useHardRecipes", useHardRecipes, "When enabled machines cost significantly more.")
         .getBoolean(useHardRecipes);
+    
+    useSteelInChassi = config.get("Recipe Settings", "useSteelInChassi", useSteelInChassi, "When enabled machine chassis will require steel instead of iron.")
+            .getBoolean(useSteelInChassi);
 
     numConduitsPerRecipe = config.get("Recipe Settings", "numConduitsPerRecipe", numConduitsPerRecipe,
         "The number of conduits crafted per recipe.").getInt(numConduitsPerRecipe);

--- a/src/main/java/crazypants/enderio/material/MaterialRecipes.java
+++ b/src/main/java/crazypants/enderio/material/MaterialRecipes.java
@@ -120,7 +120,16 @@ public class MaterialRecipes {
     GameRegistry.addRecipe(new ShapedOreRecipe(fusedQuartzFrame, "bsb", "s s", "bsb", 'b', conduitBinder, 's', "woodStick"));
 
     // Machine Chassi
+
+    ArrayList<ItemStack> steelIngots = OreDictionary.getOres("ingotSteel");
+    
+    if(Config.useSteelInChassi == true && steelIngots != null && !steelIngots.isEmpty()) {
+    GameRegistry.addRecipe(new ShapedOreRecipe(machineChassi, "fif", "i i", "fif", 'f', Blocks.iron_bars, 'i', "ingotSteel"));
+    }
+    else {
     GameRegistry.addShapedRecipe(machineChassi, "fif", "i i", "fif", 'f', Blocks.iron_bars, 'i', Items.iron_ingot);
+    }
+
 
     // Basic Gear
     GameRegistry.addRecipe(new ShapedOreRecipe(basicGear, "scs", "c c", "scs", 's', "stickWood", 'c', Blocks.cobblestone));


### PR DESCRIPTION
Added config option to allow for ore-dictionary recipe using steel for the machine chassi instead of iron.
Not a huge change but could be pretty big for balance down the road in packs with slower progression (unifies with railcraft well).
*If there is no registered steel entry, it will use the original recipe.
