### PR TITLE
Energy Conduit connection to a block which is both BC emitter and receiver

### DIFF
--- a/src/main/java/crazypants/enderio/power/PowerInterfaceBC.java
+++ b/src/main/java/crazypants/enderio/power/PowerInterfaceBC.java
@@ -23,7 +23,7 @@ public class PowerInterfaceBC implements IPowerInterface {
   public boolean canConduitConnect(ForgeDirection direction) {
     if(bcPower != null) {
       if(bcPower instanceof IPowerEmitter) {
-        return ((IPowerEmitter) bcPower).canEmitPowerFrom(direction.getOpposite());
+        if ((IPowerEmitter) bcPower).canEmitPowerFrom(direction.getOpposite()) return true;
       }
       return PowerHandlerUtil.canConnectRecievePower(bcPower);
     }


### PR DESCRIPTION
Hey, to introduce myself I'm co-developer of Galacticraft (with micdoodle8).  We like EnderIO and we are aiming for full compatibility with all the EnderIO conduits in Galacticraft.  If any issues come up, we will be very happy to co-operate with you to try to find a fix.

One issue I'm aware of: if there is a block (for example, a Galacticraft Energy Storage Module) which can both receive and emit BC power, right now an EnderIO Power Conduit can connect only to the emitting side.

This pull request should fix that - though maybe it goes too far, because I noticed that PowerHandlerUtil.canConnectRecievePower() will return true pretty much all the time?
https://github.com/CrazyPants/EnderIO/blob/master/src/main/java/crazypants/enderio/power/PowerHandlerUtil.java#L40
