### PR TITLE
Implemented MFR RedNet support.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -79,6 +79,7 @@ processResources {
 
 jar {
     from { configurations.exportedCompile.collect { it.isDirectory() ? it : zipTree(it) } }
+    exclude 'powercrystals/**'
 }
 
 task sourceJar(type: Jar) {
@@ -94,6 +95,7 @@ task javadocJar(type: Jar, dependsOn: javadoc) {
 task deobfJar(type: Jar) {
     from sourceSets.main.output
     from { configurations.exportedCompile.collect { it.isDirectory() ? it : zipTree(it) } }
+    exclude 'powercrystals/**'
     classifier = 'dev'
 }
 

--- a/src/main/java/crazypants/enderio/EnderIO.java
+++ b/src/main/java/crazypants/enderio/EnderIO.java
@@ -147,7 +147,7 @@ import crazypants.enderio.teleport.ItemTravelStaff;
 import crazypants.enderio.teleport.TeleportRecipes;
 import crazypants.util.EntityUtil;
 
-@Mod(modid = MODID, name = MOD_NAME, version = VERSION, dependencies = "required-after:Forge@10.13.0.1150,);", guiFactory = "crazypants.enderio.config.ConfigFactoryEIO")
+@Mod(modid = MODID, name = MOD_NAME, version = VERSION, dependencies = "required-after:Forge@10.13.0.1150,);after:MineFactoryReloaded", guiFactory = "crazypants.enderio.config.ConfigFactoryEIO")
 public class EnderIO {
 
   public static final String MODID = "EnderIO";

--- a/src/main/java/crazypants/enderio/conduit/redstone/IRedstoneConduit.java
+++ b/src/main/java/crazypants/enderio/conduit/redstone/IRedstoneConduit.java
@@ -30,8 +30,11 @@ public interface IRedstoneConduit extends IConduit {
 
   void updateNetwork();
 
+  // MFR RedNet
+
   int[] getOutputValues(World world, int x, int y, int z, ForgeDirection side);
 
   int getOutputValue(World world, int x, int y, int z, ForgeDirection side, int subnet);
 
+  void onInputsChanged(World world, int x, int y, int z, ForgeDirection side, int[] inputValues);
 }

--- a/src/main/java/powercrystals/minefactoryreloaded/api/rednet/IRedNetInfo.java
+++ b/src/main/java/powercrystals/minefactoryreloaded/api/rednet/IRedNetInfo.java
@@ -1,0 +1,28 @@
+package powercrystals.minefactoryreloaded.api.rednet;
+
+import java.util.List;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.util.IChatComponent;
+import net.minecraft.world.IBlockAccess;
+import net.minecraftforge.common.util.ForgeDirection;
+
+/**
+ * Defines a Block that can print information about itself using the RedNet Meter. This must be implemented on your Block class.
+ */
+public interface IRedNetInfo
+{
+	/**
+	 * This function appends information to a list provided to it.
+	 * 
+	 * @param world Reference to the world.
+	 * @param x X coordinate of the block.
+	 * @param y Y coordinate of the block.
+	 * @param z Z coordinate of the block.
+	 * @param side The side of the block that is being queried.
+	 * @param player Player doing the querying - this can be NULL.
+	 * @param info The list that the information should be appended to.
+	 */
+	public void getRedNetInfo(IBlockAccess world, int x, int y, int z,
+			ForgeDirection side, EntityPlayer player, List<IChatComponent> info);
+}

--- a/src/main/java/powercrystals/minefactoryreloaded/api/rednet/IRedNetInputNode.java
+++ b/src/main/java/powercrystals/minefactoryreloaded/api/rednet/IRedNetInputNode.java
@@ -1,0 +1,52 @@
+package powercrystals.minefactoryreloaded.api.rednet;
+
+import powercrystals.minefactoryreloaded.api.rednet.connectivity.IRedNetConnection;
+
+import net.minecraft.world.World;
+import net.minecraftforge.common.util.ForgeDirection;
+
+/**
+ * Defines a Block that can connect to RedNet cables. This must be implemented on your Block class.
+ * <p>
+ * Note that when you implement this, the RedNet network makes several assumptions about your code -
+ * It will not clamp values to 0 <= x <= 15. This means you must be able to accept any possible integer
+ * without crashing, even negatives. It will also assume that calling the onInput(s)Changed() methods
+ * are sufficient, and will not issue block updates. In Single mode, it will call onInputChanged.
+ * <p>
+ * RedNet cables have their subnets indicated to the user by colored bands on the cable.
+ * The color of a given subnet is the same as the wool with metadata equal to the subnet number.
+ * <p>
+ * For reference:<br>
+ * 0:White, 1:Orange, 2:Magenta, 3:LightBlue, 4:Yellow, 5:Lime, 6:Pink, 7:Gray,
+ * 8:LightGray, 9:Cyan, 10:Purple, 11:Blue, 12:Brown, 13:Green, 14:Red, 15:Black
+ */
+public interface IRedNetInputNode extends IRedNetConnection
+{
+	/**
+	 * Called when the input values to this block change. Only called if your block is connected in "All" mode.
+	 * Do not issue a network value update from inside this method call; it will be ignored. Issue your updates
+	 * on the next tick.
+	 * 
+	 * @param world The world this block is in.
+	 * @param x This block's X coordinate.
+	 * @param y This block's Y coordinate.
+	 * @param z This block's Z coordinate.
+	 * @param side The side the input values are being changed on.
+	 * @param inputValues The new set of input values. This array will be 16 elements long. Do not alter or cache.
+	 */
+	public void onInputsChanged(World world, int x, int y, int z, ForgeDirection side, int[] inputValues);
+
+	/**
+	 * Called when the input value to this block changes. Only called if your block is connected in "Single" mode.
+	 * Do not issue a network value update from inside this method call; it will be ignored. Issue your updates
+	 * on the next tick.
+	 * 
+	 * @param world The world this block is in.
+	 * @param x This block's X coordinate.
+	 * @param y This block's Y coordinate.
+	 * @param z This block's Z coordinate.
+	 * @param side The side the input values are being changed on.
+	 * @param inputValue The new input value
+	 */
+	public void onInputChanged(World world, int x, int y, int z, ForgeDirection side, int inputValue);
+}

--- a/src/main/java/powercrystals/minefactoryreloaded/api/rednet/IRedNetLogicCircuit.java
+++ b/src/main/java/powercrystals/minefactoryreloaded/api/rednet/IRedNetLogicCircuit.java
@@ -1,0 +1,19 @@
+package powercrystals.minefactoryreloaded.api.rednet;
+
+import net.minecraft.nbt.NBTTagCompound;
+
+public interface IRedNetLogicCircuit
+{
+	public byte getInputCount();
+	
+	public byte getOutputCount();
+	
+	public int[] recalculateOutputValues(long worldTime, int[] inputValues);
+	
+	public String getUnlocalizedName();
+	public String getInputPinLabel(int pin);
+	public String getOutputPinLabel(int pin);
+	
+	public void readFromNBT(NBTTagCompound tag);
+	public void writeToNBT(NBTTagCompound tag);
+}

--- a/src/main/java/powercrystals/minefactoryreloaded/api/rednet/IRedNetLogicPoint.java
+++ b/src/main/java/powercrystals/minefactoryreloaded/api/rednet/IRedNetLogicPoint.java
@@ -1,0 +1,36 @@
+package powercrystals.minefactoryreloaded.api.rednet;
+
+/**
+ * 
+ * @author skyboy
+ */
+public interface IRedNetLogicPoint
+{
+	/**
+	 * 
+	 * @param out
+	 * @return
+	 */
+	public void transformOutput(int[] out);
+
+	/**
+	 * 
+	 * @param out
+	 * @return
+	 */
+	public void transformOutput(int out);
+
+	/**
+	 * 
+	 * @param in
+	 * @return
+	 */
+	public int[] transformInput(int[] in);
+
+	/**
+	 * 
+	 * @param in
+	 * @return
+	 */
+	public int transformInput(int in);
+}

--- a/src/main/java/powercrystals/minefactoryreloaded/api/rednet/IRedNetNetworkContainer.java
+++ b/src/main/java/powercrystals/minefactoryreloaded/api/rednet/IRedNetNetworkContainer.java
@@ -1,0 +1,32 @@
+package powercrystals.minefactoryreloaded.api.rednet;
+
+import net.minecraft.world.World;
+import net.minecraftforge.common.util.ForgeDirection;
+
+/**
+ * 
+ * You should not implement this yourself. Instead, use this to look for cables to notify from your IRedNetOmniNode as this does not
+ * require a block update. This will be implemented on the cable's Block class.
+ *
+ */
+public interface IRedNetNetworkContainer
+{
+	/**
+	 * Tells the network to recalculate all subnets.
+	 * @param world The world this cable is in.
+	 * @param x The x-coordinate of this cable.
+	 * @param x The y-coordinate of this cable.
+	 * @param x The z-coordinate of this cable.
+	 */
+	public void updateNetwork(World world, int x, int y, int z, ForgeDirection from);
+	
+	/**
+	 * Tells the network to recalculate a specific subnet.
+	 * @param world The world this cable is in.
+	 * @param x The x-coordinate of this cable.
+	 * @param x The y-coordinate of this cable.
+	 * @param x The z-coordinate of this cable.
+	 * @param subnet The subnet to recalculate.
+	 */
+	public void updateNetwork(World world, int x, int y, int z, int subnet, ForgeDirection from);
+}

--- a/src/main/java/powercrystals/minefactoryreloaded/api/rednet/IRedNetOmniNode.java
+++ b/src/main/java/powercrystals/minefactoryreloaded/api/rednet/IRedNetOmniNode.java
@@ -1,0 +1,22 @@
+package powercrystals.minefactoryreloaded.api.rednet;
+
+/**
+ * Defines a Block that can connect to RedNet cables. This must be implemented on your Block class.
+ * <p>
+ * Note that when you implement this, the RedNet network makes several assumptions about your code -
+ * It will not clamp values to 0 <= x <= 15. This means you must be able to accept any possible integer
+ * without crashing, even negatives. It will also assume that calling the onInput(s)Changed() methods
+ * are sufficient, and will not issue block updates. It will never call the vanilla redstone output
+ * methods, and will only query the methods contained in this interface.
+ * <p>
+ * RedNet cables have their subnets indicated to the user by colored bands on the cable.
+ * The color of a given subnet is the same as the wool with metadata equal to the subnet number.
+ * <p>
+ * For reference:<br>
+ * 0:White, 1:Orange, 2:Magenta, 3:LightBlue, 4:Yellow, 5:Lime, 6:Pink, 7:Gray,
+ * 8:LightGray, 9:Cyan, 10:Purple, 11:Blue, 12:Brown, 13:Green, 14:Red, 15:Black
+ */
+public interface IRedNetOmniNode extends IRedNetInputNode, IRedNetOutputNode
+{
+	// this is merely provided for convenience
+}

--- a/src/main/java/powercrystals/minefactoryreloaded/api/rednet/IRedNetOutputNode.java
+++ b/src/main/java/powercrystals/minefactoryreloaded/api/rednet/IRedNetOutputNode.java
@@ -1,0 +1,51 @@
+package powercrystals.minefactoryreloaded.api.rednet;
+
+import net.minecraft.world.World;
+import net.minecraftforge.common.util.ForgeDirection;
+
+import powercrystals.minefactoryreloaded.api.rednet.connectivity.IRedNetConnection;
+
+/**
+ * Defines a Block that can connect to RedNet cables. This must be implemented on your Block class.
+ * <p>
+ * Note that when you implement this, the RedNet network makes several assumptions about your code -
+ * It will never call the vanilla redstone output methods, querying only the methods contained in
+ * this interface, and will not issue block updates.
+ * <p>
+ * RedNet cables have their subnets indicated to the user by colored bands on the cable.
+ * The color of a given subnet is the same as the wool with metadata equal to the subnet number.
+ * <p>
+ * For reference:<br>
+ * 0:White, 1:Orange, 2:Magenta, 3:LightBlue, 4:Yellow, 5:Lime, 6:Pink, 7:Gray,
+ * 8:LightGray, 9:Cyan, 10:Purple, 11:Blue, 12:Brown, 13:Green, 14:Red, 15:Black
+ */
+public interface IRedNetOutputNode extends IRedNetConnection
+{
+	/**
+	 * Returns the output values of this RedNet node. 
+	 * This array must be 16 elements long. 
+	 * Only called if your block is connected in "All" mode.
+	 * 
+	 * @param world The world this block is in.
+	 * @param x This block's X coordinate.
+	 * @param y This block's Y coordinate.
+	 * @param z This block's Z coordinate.
+	 * @param side The side the output values are required for.
+	 * @return The output values.
+	 */
+	public int[] getOutputValues(World world, int x, int y, int z, ForgeDirection side);
+
+	/**
+	 * Returns the output value of this RedNet node for a given subnet.
+	 * Must be the same as getOutputValues(world, x, y, z, side)[subnet].
+	 * 
+	 * @param world The world this block is in.
+	 * @param x This block's X coordinate.
+	 * @param y This block's Y coordinate.
+	 * @param z This block's Z coordinate.
+	 * @param side The side the output value is required for.
+	 * @param subnet The subnet to get the output value for (0-15).
+	 * @return The output value.
+	 */
+	public int getOutputValue(World world, int x, int y, int z, ForgeDirection side, int subnet);
+}

--- a/src/main/java/powercrystals/minefactoryreloaded/api/rednet/connectivity/IRedNetConnection.java
+++ b/src/main/java/powercrystals/minefactoryreloaded/api/rednet/connectivity/IRedNetConnection.java
@@ -1,0 +1,26 @@
+package powercrystals.minefactoryreloaded.api.rednet.connectivity;
+
+import net.minecraft.world.World;
+import net.minecraftforge.common.util.ForgeDirection;
+
+/**
+ * Defines a Block that can connect to RedNet cables. This must be implemented on your Block class.
+ */
+public interface IRedNetConnection
+{
+	/**
+	 * Returns the connection type of this Block. If this value must be changed
+	 * while the block is alive, it must notify neighbors of a change.
+	 * <p>
+	 * For nodes that want to interact with rednet,
+	 * see IRedNetInputNode, IRedNetOutputNode, and IRedNetOmniNode
+	 * 
+	 * @param world The world this block is in.
+	 * @param x This block's X coordinate.
+	 * @param y This block's Y coordinate.
+	 * @param z This block's Z coordinate.
+	 * @param side The side that connection information is required for.
+	 * @return The connection type.
+	 */
+	public RedNetConnectionType getConnectionType(World world, int x, int y, int z, ForgeDirection side);
+}

--- a/src/main/java/powercrystals/minefactoryreloaded/api/rednet/connectivity/IRedNetDecorative.java
+++ b/src/main/java/powercrystals/minefactoryreloaded/api/rednet/connectivity/IRedNetDecorative.java
@@ -1,0 +1,11 @@
+package powercrystals.minefactoryreloaded.api.rednet.connectivity;
+
+/**
+ * This must be implemented on your Block class.
+ * <p>
+ * RedNet cables will treat your block similar to a vanilla block that's not redstone active.
+ */
+public interface IRedNetDecorative
+{
+
+}

--- a/src/main/java/powercrystals/minefactoryreloaded/api/rednet/connectivity/IRedNetNoConnection.java
+++ b/src/main/java/powercrystals/minefactoryreloaded/api/rednet/connectivity/IRedNetNoConnection.java
@@ -1,0 +1,13 @@
+package powercrystals.minefactoryreloaded.api.rednet.connectivity;
+
+/**
+ * This must be implemented on your Block class.
+ * <p>
+ * RedNet cables will not connect to your block.
+ * <br>
+ * This behavior can be overridden in subclasses by IRedNetConnection
+ */
+public interface IRedNetNoConnection
+{
+	
+}

--- a/src/main/java/powercrystals/minefactoryreloaded/api/rednet/connectivity/IRedstoneAlike.java
+++ b/src/main/java/powercrystals/minefactoryreloaded/api/rednet/connectivity/IRedstoneAlike.java
@@ -1,0 +1,10 @@
+package powercrystals.minefactoryreloaded.api.rednet.connectivity;
+
+/**
+ * This must be implemented on your Block class.
+ * <p>
+ * RedNet cables will treat your block similar to a redstone dust, and subtract one from the power value.
+ */
+public interface IRedstoneAlike {
+
+}

--- a/src/main/java/powercrystals/minefactoryreloaded/api/rednet/connectivity/RedNetConnectionType.java
+++ b/src/main/java/powercrystals/minefactoryreloaded/api/rednet/connectivity/RedNetConnectionType.java
@@ -1,0 +1,86 @@
+package powercrystals.minefactoryreloaded.api.rednet.connectivity;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Defines how RedNet cable connects to a block
+ * <p>
+ * None:                 RedNet will never connect to this block (if this is all you want: use IRedNetNoConnection)
+ * <p>
+ * CableSingle:          Connections will use the cable renderer with a single band, best used for whole blocks
+ * <br>
+ * PlateSingle:          Connections will use the plate renderer with a single band, used for conveyers and rails
+ * <p>
+ * CableAll:             Connections permit access to all 16 bands
+ * <br>
+ * PlateAll:             Connections permit access to all 16 bands
+ * <p><p>
+ * Forced connection modes are best used for decoration blocks: RedNet will not connect normally,
+ * but will if the user forces it. Typically, IRedNetDecorative is desired for this instead
+ * <p>
+ * ForcedCableSingle:    Connections permit access to a single band, only when the cable is in forced connection mode
+ * <br>
+ * ForcedPlateSingle:    Connections permit access to a single band, only when the cable is in forced connection mode
+ * <p>
+ * ForcedCableAll:       Connections permit access to all 16 bands, only when the cable is in forced connection mode
+ * <br>
+ * ForcedPlateAll:       Connections permit access to all 16 bands, only when the cable is in forced connection mode
+ * <p><p>
+ * The decorative nodes are for when you want rednet to decide how to connect to your block,
+ * but also need to receive full updates from the network.
+ * <p>
+ * DecorativeSingle:        Connections permit access to a single band, using standard connection logic
+ * <br>
+ * DecorativeAll:           Connections permit access to all 16 bands, using standard connection logic
+ * <br>
+ * ForcedDecorativeSingle:  Connections permit access to a single band, only when the cable is in forced connection mode
+ * <br>
+ * ForcedDecorativeAll:     Connections permit access to all 16 bands, only when the cable is in forced connection mode
+ */
+public enum RedNetConnectionType
+{
+	None,                   //  0; 0000000
+	CableSingle,            // 11; 0001011
+	PlateSingle,            // 13; 0001101
+	CableAll,               // 19; 0010011
+	PlateAll,               // 21; 0010101
+	ForcedCableSingle,      // 43; 0101011
+	ForcedPlateSingle,      // 45; 0101101
+	ForcedCableAll,         // 51; 0110011
+	ForcedPlateAll,         // 53; 0110101
+	DecorativeSingle,       // NA; 0001001
+	DecorativeAll,          // NA; 0010001
+	ForcedDecorativeSingle, // NA; 0101001
+	ForcedDecorativeAll;    // NA; 0110001
+	
+	public final boolean isConnected = this.ordinal() != 0; // 0 bit (mask: 1)
+	public final boolean isSingleSubnet = this.name().endsWith("Single"); // 3 bit (mask: 8)
+	public final boolean isAllSubnets = this.name().endsWith("All"); // 4 bit (mask: 16) 
+	public final boolean isPlate = this.name().contains("Plate"); // 2 bit (mask: 4)
+	public final boolean isCable = this.name().contains("Cable"); // 1 bit (mask: 2)
+	public final boolean isConnectionForced = this.name().startsWith("Forced"); // 5 bit (mask: 32)
+	public final boolean isDecorative = this.name().contains("Decorative");
+	public final short flags = toFlags(isConnected, isCable, isPlate,
+			isSingleSubnet, isAllSubnets, isConnectionForced);
+	
+	public static final RedNetConnectionType fromFlags(short flags)
+	{
+		return connections.get(flags);
+	}
+	
+	private static final short toFlags(boolean ...flags)
+	{
+		short ret = 0;
+		for (int i = flags.length; i --> 0;)
+			ret |= (flags[i] ? 1 : 0) << i;
+		return ret;
+	}
+	
+	private static final Map<Short, RedNetConnectionType> connections = new HashMap<Short, RedNetConnectionType>();
+	
+	static {
+		for (RedNetConnectionType type : RedNetConnectionType.values())
+			connections.put(type.flags, type);
+	}
+}


### PR DESCRIPTION
As discussed in IRC here's my shot at implementing MFR's RedNet API for the redstone conduits.
Tested with MFR latest (and without) and it works well in both directions as far as I can tell.

A few remarks:
- If there are "cycles" (i.e. two connections between a conduit network and a RedNet cable network), signals will stay high even if the original source dies. This state is _stable_ however, i.e. it has no performance overhead, at least not as far as I can tell, so I think this is acceptable (also, I don't know what could be done about this, realistically). It's kind of like two repeaters operating at infinite speed ;-)
- ~~The API will be shipped as it is now. If this is not desirable, some `Optional` interfaces would have to be added. This way, however, it can work even if MFR is not present, which seems preferable. The main problem with this is, that the MFR/RedNet API does not use an API annotation, so other mods cannot check for it directly (meaning they'll probably check for MFR, meaning it'll only work if MFR is also present).~~ API is not being shipped, MFR has to be present for this functionality to be available.
- I am not 100% sure about the use of `canConnectToExternal` in `BlockConduitBundle` line 878 (in particular the `ignoreConnectionMode` parameter). It seems to work fine, but some confirmation that this is correct would be nice.
