### PR TITLE
Added Biomes O' Plenty support for Farming Station

### DIFF
--- a/src/main/java/crazypants/enderio/item/darksteel/ItemDarkSteelAxe.java
+++ b/src/main/java/crazypants/enderio/item/darksteel/ItemDarkSteelAxe.java
@@ -152,7 +152,7 @@ public class ItemDarkSteelAxe extends ItemAxe implements IEnergyContainerItem, I
     if(itemDrops != null) {
       for (ItemStack stack : itemDrops) {                
         worldObj.spawnEntityInWorld(new EntityItem(worldObj, bc.x + 0.5, bc.y + 0.5, bc.z + 0.5, stack.copy()));                
-        if(TreeHarvestUtil.canDropApples(block, meta)) {
+        if(TreeHarvestUtil.canDropFood(block, meta)) {
           if(worldObj.rand.nextInt(200) == 0) {            
             worldObj.spawnEntityInWorld(new EntityItem(worldObj, bc.x + 0.5, bc.y + 0.5, bc.z + 0.5, new ItemStack(Items.apple)));
           }

--- a/src/main/java/crazypants/enderio/machine/farm/FarmersRegistry.java
+++ b/src/main/java/crazypants/enderio/machine/farm/FarmersRegistry.java
@@ -22,6 +22,7 @@ public final class FarmersRegistry {
     addIC2();
     addMFR();
     addThaumcraft();
+    addBoP();
 
     FarmersCommune.joinCommune(new StemFarmer(Blocks.reeds, new ItemStack(Items.reeds)));
     FarmersCommune.joinCommune(new StemFarmer(Blocks.cactus, new ItemStack(Blocks.cactus)));
@@ -134,9 +135,10 @@ public final class FarmersRegistry {
     Block saplingBlock = GameRegistry.findBlock(mod, blockName);
     if(saplingBlock != null) {
       FarmersCommune.joinCommune(new TreeFarmer(saplingBlock,
-          GameRegistry.findBlock(mod, "tree"),
-          GameRegistry.findBlock(mod, "willow"),
-          GameRegistry.findBlock(mod, "Dark Tree")));
+              GameRegistry.findBlock(mod, "tree"),
+              GameRegistry.findBlock(mod, "willow"),
+              GameRegistry.findBlock(mod, "Saguaro"),
+              GameRegistry.findBlock(mod, "Dark Tree")));
     }
     blockName = "Rare Sapling";
     saplingBlock = GameRegistry.findBlock(mod, blockName);
@@ -188,6 +190,34 @@ public final class FarmersRegistry {
     CustomSeedFarmer farmer = addSeed(mod, name, name, Blocks.end_stone, GameRegistry.findBlock(mod, "decorativeBlock1"));
     if(farmer != null) {
       farmer.setIgnoreGroundCanSustainCheck(true);
+    }
+  }
+
+  //Support for Biomes o' Plenty plants
+  private static void addBoP() {
+    String mod = "BiomesOPlenty";
+    String blockName = "saplings";
+    String blockColorizedName = "colorizedSaplings";
+
+    Block saplingBlock = GameRegistry.findBlock(mod, blockName);
+    Block colorizedSaplingBlock = GameRegistry.findBlock(mod, blockColorizedName);
+
+    if (saplingBlock != null) {
+      FarmersCommune.joinCommune(new TreeFarmer(saplingBlock,
+              GameRegistry.findBlock(mod, "logs1"),
+              GameRegistry.findBlock(mod, "logs2"),
+              GameRegistry.findBlock(mod, "logs3"),
+              GameRegistry.findBlock(mod, "logs4"),
+              GameRegistry.findBlock(mod, "bamboo")));
+    }
+
+    if (colorizedSaplingBlock != null){
+      FarmersCommune.joinCommune(new TreeFarmer(colorizedSaplingBlock,
+              GameRegistry.findBlock(mod, "logs1"),
+              GameRegistry.findBlock(mod, "logs2"),
+              GameRegistry.findBlock(mod, "logs3"),
+              GameRegistry.findBlock(mod, "logs4"),
+              GameRegistry.findBlock(mod, "bamboo")));
     }
   }
 

--- a/src/main/java/crazypants/enderio/machine/farm/farmers/TreeFarmer.java
+++ b/src/main/java/crazypants/enderio/machine/farm/farmers/TreeFarmer.java
@@ -8,7 +8,6 @@ import java.util.List;
 import net.minecraft.block.Block;
 import net.minecraft.entity.item.EntityItem;
 import net.minecraft.init.Blocks;
-import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
 import net.minecraft.world.World;
 import net.minecraftforge.common.IPlantable;
@@ -126,11 +125,9 @@ public class TreeFarmer implements IFarmerJoe {
       if(!isWood(blk)) { //leaves
         isWood = Config.farmAxeDamageOnLeafBreak;
         int leaveMeta = farm.getBlockMeta(coord);
-        if(TreeHarvestUtil.canDropApples(blk, leaveMeta)) {
-          if(farm.getWorldObj().rand.nextInt(200) == 0) {
-            res.drops.add(new EntityItem(farm.getWorldObj(), bc.x + 0.5, bc.y + 0.5, bc.z + 0.5, new ItemStack(Items.apple)));
-          }
-        }        
+        if(TreeHarvestUtil.canDropFood(blk, leaveMeta)) {
+          res.drops.add(TreeHarvestUtil.dropFoodAsItemWithChance(farm.getWorldObj(), bc, blk, leaveMeta));
+        }
       } 
       farm.actionPerformed(isWood);      
       if(isWood) {

--- a/src/main/java/crazypants/enderio/machine/farm/farmers/TreeHarvestUtil.java
+++ b/src/main/java/crazypants/enderio/machine/farm/farmers/TreeHarvestUtil.java
@@ -1,17 +1,64 @@
 package crazypants.enderio.machine.farm.farmers;
 
 import net.minecraft.block.*;
+import cpw.mods.fml.common.Loader;
+import cpw.mods.fml.common.registry.GameRegistry;
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockLeaves;
+import net.minecraft.block.BlockNewLeaf;
+import net.minecraft.block.BlockOldLeaf;
+import net.minecraft.entity.item.EntityItem;
+import net.minecraft.init.Items;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 import crazypants.enderio.machine.farm.TileFarmStation;
 import crazypants.util.BlockCoord;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class TreeHarvestUtil {
 
-  public static boolean canDropApples(Block block, int meta) {
-    return 
-        (block instanceof BlockOldLeaf && (meta == 0 || meta == 8)) || //oak
-            (block instanceof BlockNewLeaf && (meta == 1 || meta == 9)); //giant oak
+  // Determine if harvested leaves can drop fruit items.
+  public static boolean canDropFood(Block block, int meta){
+    if (isBlockBOPFruitLeaf(block)) {
+      // Block is either BoP Apple or Persimmon leaf
+      return true;
+    } else if (block instanceof BlockOldLeaf && (meta == 0 || meta == 4 || meta == 8 || meta == 12)) {
+      // Block is vanilla Minecraft Oak Leaf
+      return true;
+    } else if (block instanceof BlockNewLeaf && (meta == 1 || meta == 5 || meta == 9 || meta == 13)){
+      // Block is vanilla Minecraft Dark Oak Leaf
+      return true;
+    }
+    return false;
+  }
+
+  // Calculate Drop chance for fruit when harvesting leaves.
+  public static EntityItem dropFoodAsItemWithChance(World world, BlockCoord bc, Block block, int meta) {
+    ItemStack fruit = new ItemStack(Items.apple);
+
+    // Biomes O' Plenty
+    if (isBlockBOPFruitLeaf(block)) {
+      Class<?> LeafClass = block.getClass();
+      Class<?> BlockBOPPersimmonLeaves = GameRegistry.findBlock("BiomesOPlenty", "persimmonLeaves").getClass();
+
+      Item food = GameRegistry.findItem("BiomesOPlenty", "food");
+      if (LeafClass == BlockBOPPersimmonLeaves) fruit = new ItemStack(food, 1, 8); // Change fruit to Persimmon.
+
+      if ((meta & 3) == 3 && world.rand.nextInt(10) == 0) return new EntityItem(world, bc.x + 0.5, bc.y + 0.5, bc.z + 0.5, fruit);
+      else if ((meta & 3) == 2 && world.rand.nextInt(50) == 0) return new EntityItem(world, bc.x + 0.5, bc.y + 0.5, bc.z + 0.5, fruit);
+      else if ((meta & 3) == 1 && world.rand.nextInt(100) == 0) return new EntityItem(world, bc.x + 0.5, bc.y + 0.5, bc.z + 0.5, fruit);
+      else if ((meta & 3) == 0 && world.rand.nextInt(200) == 0) return new EntityItem(world, bc.x + 0.5, bc.y + 0.5, bc.z + 0.5, fruit);
+    }
+
+    // Vanilla Oak and Dark Oak trees.
+    if(world.rand.nextInt(200) == 0) {
+      return new EntityItem(world, bc.x + 0.5, bc.y + 0.5, bc.z + 0.5, fruit);
+    }
+    return null;
   }
   
   private int horizontalRange;
@@ -57,7 +104,7 @@ public class TreeHarvestUtil {
     }
 
     Block blk = world.getBlock(bc.x, bc.y,bc.z);
-    boolean isLeaves = blk instanceof BlockLeaves;
+    boolean isLeaves = areTheseLeaves(blk);
     if(target.isTarget(blk, world.getBlockMetadata(bc.x, bc.y, bc.z)) || isLeaves) {
       res.harvestedBlocks.add(bc);
       for (ForgeDirection dir : ForgeDirection.VALID_DIRECTIONS) {
@@ -109,6 +156,46 @@ public class TreeHarvestUtil {
       return false;
     }
     return true;
+  }
+
+  private boolean areTheseLeaves(Block blk){
+    List<Class<?>> leafTypes = new ArrayList<Class<?>>();
+
+    // Leaf Blocks that subclass standard vanilla Minecraft BlockLeaves
+    if (blk instanceof BlockLeaves) return true;
+
+    // Add Biomes O' Plenty custom leaves
+    if (Loader.isModLoaded("BiomesOPlenty")) try {
+      Class<?> BlockBOPAppleLeaves = Class.forName("biomesoplenty.common.blocks.BlockBOPAppleLeaves");
+      Class<?> BlockBOPColorizedLeaves = Class.forName("biomesoplenty.common.blocks.BlockBOPColorizedLeaves");
+      Class<?> BlockBOPLeaves = Class.forName("biomesoplenty.common.blocks.BlockBOPLeaves");
+      Class<?> BlockBOPPersimmonLeaves = Class.forName("biomesoplenty.common.blocks.BlockBOPPersimmonLeaves");
+
+      leafTypes.add(BlockBOPAppleLeaves);
+      leafTypes.add(BlockBOPColorizedLeaves);
+      leafTypes.add(BlockBOPLeaves);
+      leafTypes.add(BlockBOPPersimmonLeaves);
+    } catch (Exception e) {
+      // No BoP leaf blocks found... Carry on.
+    }
+    return leafTypes.contains(blk.getClass());
+  }
+
+  private static boolean isBlockBOPFruitLeaf(Block block) {
+    String bop = "BiomesOPlenty";
+    if (Loader.isModLoaded(bop)) {
+      try {
+        Class<?> LeafClass = block.getClass();
+        Class<?> BlockBOPAppleLeaves = GameRegistry.findBlock(bop, "appleLeaves").getClass();
+        Class<?> BlockBOPPersimmonLeaves = GameRegistry.findBlock(bop, "persimmonLeaves").getClass();
+        if (LeafClass == BlockBOPAppleLeaves || LeafClass == BlockBOPPersimmonLeaves) {
+          return true;
+        }
+      } catch (Exception e) {
+        // Not a BoP fruit bearing leaf block... Carry on.
+      }
+    }
+    return false;
   }
   
   private static final class HarvestTarget extends BaseHarvestTarget


### PR DESCRIPTION
Added Biomes O' Plenty saplings to FarmersRegistry.java. Modified TreeHarvestUtil.java and TreeFarmer.java because Biomes O' Plenty trees don't inherit from vanilla Minecraft's BlockLeaves. Also added support to harvest drops from BoP apple and persimmon trees. Modified ItemDarkSteelAxe.java where it called methods in TreeHarvestUtil class. Cleaned up commit history and closed previous pull request.