### PR TITLE
EnchanterRecipes_Core.xml: Add repair enchant (thaumcraft)

### DIFF
--- a/resources/assets/enderio/config/EnchanterRecipes_Core.xml
+++ b/resources/assets/enderio/config/EnchanterRecipes_Core.xml
@@ -124,4 +124,8 @@ for (int i = 0; i < level; i++) {
     <itemStack modID="minecraft" itemName="potion" itemMeta="8203"/>
   </enchantment>
 
+  <enchantment name="enchantment.repair" costPerLevel="6">
+    <itemStack modID="minecraft" itemName="anvil"/>
+  </enchantment>
+
 </enchaterRecipes>


### PR DESCRIPTION
Thaumcraft's "repair" enchant can be created consistently using
Infusion Enchantment, with salis mundus and an anvil. The anvil
struck me as more evocative. Level cost is 6/12 for levels 1/2,
so I kept costPerLevel = 6.
