### PR TITLE
Split off client side GuiHandlers

### DIFF
--- a/src/main/java/crazypants/enderio/ClientGuiHandler.java
+++ b/src/main/java/crazypants/enderio/ClientGuiHandler.java
@@ -1,0 +1,25 @@
+package crazypants.enderio;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.world.World;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+
+@SideOnly(Side.CLIENT)
+public class ClientGuiHandler extends GuiHandler {
+
+  @Override
+  public Object getServerGuiElement(int id, EntityPlayer player, World world, int x, int y, int z) {
+    return null;
+  }
+
+  @Override
+  public Object getClientGuiElement(int id, EntityPlayer player, World world, int x, int y, int z) {
+    ISidedGuiHandler handler = guiHandlers.get(id);
+    if(handler != null) {
+      return handler.getClientGuiElement(id, player, world, x, y, z);
+    }
+    return null;
+  }
+
+}

--- a/src/main/java/crazypants/enderio/ClientProxy.java
+++ b/src/main/java/crazypants/enderio/ClientProxy.java
@@ -141,6 +141,10 @@ import crazypants.render.IconUtil;
 @SideOnly(Side.CLIENT)
 public class ClientProxy extends CommonProxy {
 
+  static {
+    guiHandler = new ClientGuiHandler();
+  }
+
   // @formatter:off
   public static int[][] sideAndFacingToSpriteOffset = new int[][] {
     { 3, 2, 0, 0, 0, 0 }, 

--- a/src/main/java/crazypants/enderio/CommonProxy.java
+++ b/src/main/java/crazypants/enderio/CommonProxy.java
@@ -14,13 +14,15 @@ import cpw.mods.fml.common.gameevent.TickEvent.ServerTickEvent;
 import crazypants.enderio.conduit.IConduit;
 import crazypants.enderio.conduit.render.ConduitRenderer;
 
-public class CommonProxy {
+abstract public class CommonProxy {
 
   private static final DecimalFormat FORMAT = new DecimalFormat("########0.000");
 
   protected long serverTickCount = 0;
   protected long clientTickCount = 0;
   protected final TickTimer tickTimer = new TickTimer();
+
+  public static GuiHandler guiHandler = new GuiHandler();
 
   public CommonProxy() {
   }

--- a/src/main/java/crazypants/enderio/EnderIO.java
+++ b/src/main/java/crazypants/enderio/EnderIO.java
@@ -171,8 +171,6 @@ public class EnderIO {
 
   public static final PacketHandler packetPipeline = new PacketHandler();
 
-  public static GuiHandler guiHandler = new GuiHandler();
-
   // Materials
   public static ItemCapacitor itemBasicCapacitor;
   public static ItemAlloy itemAlloy;
@@ -483,7 +481,7 @@ public class EnderIO {
     PacketHandler.INSTANCE.registerMessage(MessageTileNBT.class, MessageTileNBT.class, PacketHandler.nextID(), Side.SERVER);
     PacketHandler.INSTANCE.registerMessage(PacketRedstoneMode.class, PacketRedstoneMode.class, PacketHandler.nextID(), Side.SERVER);
 
-    NetworkRegistry.INSTANCE.registerGuiHandler(this, guiHandler);
+    NetworkRegistry.INSTANCE.registerGuiHandler(this, CommonProxy.guiHandler);
     MinecraftForge.EVENT_BUS.register(this);
 
     //Register Custom Dungeon Loot here
@@ -586,7 +584,7 @@ public class EnderIO {
     SoulBinderRecipeManager.getInstance().addDefaultRecipes();
     PaintSourceValidator.instance.loadConfig();
 
-    if(fluidXpJuice == null) { //should have been registered by open blocks 
+    if(fluidXpJuice == null) { //should have been registered by open blocks
       fluidXpJuice = FluidRegistry.getFluid(getXPJuiceName());
       if(fluidXpJuice == null) {
         Log.error("Liquid XP Juice registration left to open blocks but could not be found.");

--- a/src/main/java/crazypants/enderio/GuiHandler.java
+++ b/src/main/java/crazypants/enderio/GuiHandler.java
@@ -57,15 +57,15 @@ public class GuiHandler implements IGuiHandler {
 
   public static final int GUI_ID_CAP_BANK = 142; // leave room for more machines
 
-  protected final Map<Integer, IGuiHandler> guiHandlers = new HashMap<Integer, IGuiHandler>();
+  protected final Map<Integer, ISidedGuiHandler> guiHandlers = new HashMap<Integer, ISidedGuiHandler>();
 
-  public void registerGuiHandler(int id, IGuiHandler handler) {
+  public void registerGuiHandler(int id, ISidedGuiHandler handler) {
     guiHandlers.put(id, handler);
   }
 
   @Override
   public Object getServerGuiElement(int id, EntityPlayer player, World world, int x, int y, int z) {
-    IGuiHandler handler = guiHandlers.get(id);
+    ISidedGuiHandler handler = guiHandlers.get(id);
     if(handler != null) {
       return handler.getServerGuiElement(id, player, world, x, y, z);
     }
@@ -74,10 +74,6 @@ public class GuiHandler implements IGuiHandler {
 
   @Override
   public Object getClientGuiElement(int id, EntityPlayer player, World world, int x, int y, int z) {
-    IGuiHandler handler = guiHandlers.get(id);
-    if(handler != null) {
-      return handler.getClientGuiElement(id, player, world, x, y, z);
-    }
     return null;
   }
 

--- a/src/main/java/crazypants/enderio/ISidedGuiHandler.java
+++ b/src/main/java/crazypants/enderio/ISidedGuiHandler.java
@@ -1,0 +1,38 @@
+package crazypants.enderio;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.world.World;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+
+public interface ISidedGuiHandler {
+
+  /**
+   * Returns a Server side Container to be displayed to the user.
+   *
+   * @param ID The Gui ID Number
+   * @param player The player viewing the Gui
+   * @param world The current world
+   * @param x X Position
+   * @param y Y Position
+   * @param z Z Position
+   * @return A GuiScreen/Container to be displayed to the user, null if none.
+   */
+  public Object getServerGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z);
+  /**
+   * Returns a Container to be displayed to the user. On the client side, this
+   * needs to return a instance of GuiScreen On the server side, this needs to
+   * return a instance of Container
+   *
+   * @param ID The Gui ID Number
+   * @param player The player viewing the Gui
+   * @param world The current world
+   * @param x X Position
+   * @param y Y Position
+   * @param z Z Position
+   * @return A GuiScreen/Container to be displayed to the user, null if none.
+   */
+  @SideOnly(Side.CLIENT)
+  public Object getClientGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z);
+
+}

--- a/src/main/java/crazypants/enderio/block/BlockDarkSteelAnvil.java
+++ b/src/main/java/crazypants/enderio/block/BlockDarkSteelAnvil.java
@@ -9,13 +9,14 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.util.IIcon;
 import net.minecraft.util.MovingObjectPosition;
 import net.minecraft.world.World;
-import cpw.mods.fml.common.network.IGuiHandler;
 import cpw.mods.fml.common.registry.GameRegistry;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import crazypants.enderio.GuiHandler;
+import crazypants.enderio.CommonProxy;
 import crazypants.enderio.EnderIO;
 import crazypants.enderio.EnderIOTab;
-import crazypants.enderio.GuiHandler;
+import crazypants.enderio.ISidedGuiHandler;
 import crazypants.enderio.ModObject;
 import crazypants.enderio.gui.IResourceTooltipProvider;
 
@@ -45,7 +46,7 @@ public class BlockDarkSteelAnvil extends BlockAnvil implements IResourceTooltipP
 
   protected void init() {
     GameRegistry.registerBlock(this, ItemAnvilBlock.class, ModObject.blockDarkSteelAnvil.unlocalisedName);
-    EnderIO.guiHandler.registerGuiHandler(GuiHandler.GUI_ID_ANVIL, new IGuiHandler() {
+    CommonProxy.guiHandler.registerGuiHandler(GuiHandler.GUI_ID_ANVIL, new ISidedGuiHandler() {
 
       @Override
       public Object getServerGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z) {
@@ -53,6 +54,7 @@ public class BlockDarkSteelAnvil extends BlockAnvil implements IResourceTooltipP
       }
 
       @Override
+      @SideOnly(Side.CLIENT)
       public Object getClientGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z) {
         return new GuiRepair(player.inventory, world, x, y, z);
       }
@@ -70,6 +72,7 @@ public class BlockDarkSteelAnvil extends BlockAnvil implements IResourceTooltipP
     return true;
   }
 
+  @Override
   @SideOnly(Side.CLIENT)
   public IIcon getIcon(int p_149691_1_, int p_149691_2_)
   {
@@ -84,6 +87,7 @@ public class BlockDarkSteelAnvil extends BlockAnvil implements IResourceTooltipP
     }
   }
 
+  @Override
   @SideOnly(Side.CLIENT)
   public void registerBlockIcons(IIconRegister register)
   {

--- a/src/main/java/crazypants/enderio/conduit/BlockConduitBundle.java
+++ b/src/main/java/crazypants/enderio/conduit/BlockConduitBundle.java
@@ -29,12 +29,13 @@ import powercrystals.minefactoryreloaded.api.rednet.connectivity.RedNetConnectio
 import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.common.Optional;
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
-import cpw.mods.fml.common.network.IGuiHandler;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import crazypants.enderio.BlockEio;
-import crazypants.enderio.EnderIO;
 import crazypants.enderio.GuiHandler;
+import crazypants.enderio.CommonProxy;
+import crazypants.enderio.EnderIO;
+import crazypants.enderio.ISidedGuiHandler;
 import crazypants.enderio.ModObject;
 import crazypants.enderio.api.tool.ITool;
 import crazypants.enderio.conduit.facade.ItemConduitFacade.FacadeType;
@@ -67,7 +68,7 @@ import crazypants.util.IFacade;
 import crazypants.util.Util;
 
 @Optional.Interface(iface = "powercrystals.minefactoryreloaded.api.rednet.IRedNetOmniNode", modid = "MineFactoryReloaded")
-public class BlockConduitBundle extends BlockEio implements IGuiHandler, IFacade, IRotatableFacade, IRedNetOmniNode {
+public class BlockConduitBundle extends BlockEio implements ISidedGuiHandler, IFacade, IRotatableFacade, IRedNetOmniNode {
 
   private static final String KEY_CONNECTOR_ICON = "enderIO:conduitConnector";
   private static final String KEY_CONNECTOR_ICON_EXTERNAL = "enderIO:conduitConnectorExternal";
@@ -187,9 +188,9 @@ public class BlockConduitBundle extends BlockEio implements IGuiHandler, IFacade
   protected void init() {
     super.init();
     for (ForgeDirection dir : ForgeDirection.VALID_DIRECTIONS) {
-      EnderIO.guiHandler.registerGuiHandler(GuiHandler.GUI_ID_EXTERNAL_CONNECTION_BASE + dir.ordinal(), this);
+      CommonProxy.guiHandler.registerGuiHandler(GuiHandler.GUI_ID_EXTERNAL_CONNECTION_BASE + dir.ordinal(), this);
     }
-    EnderIO.guiHandler.registerGuiHandler(GuiHandler.GUI_ID_EXTERNAL_CONNECTION_SELECTOR, this);
+    CommonProxy.guiHandler.registerGuiHandler(GuiHandler.GUI_ID_EXTERNAL_CONNECTION_SELECTOR, this);
   }
 
   @Override
@@ -665,6 +666,7 @@ public class BlockConduitBundle extends BlockEio implements IGuiHandler, IFacade
   }
 
   @Override
+  @SideOnly(Side.CLIENT)
   public Object getClientGuiElement(int id, EntityPlayer player, World world, int x, int y, int z) {
     TileEntity te = world.getTileEntity(x, y, z);
     if(te instanceof IConduitBundle) {

--- a/src/main/java/crazypants/enderio/conduit/facade/ItemConduitFacade.java
+++ b/src/main/java/crazypants/enderio/conduit/facade/ItemConduitFacade.java
@@ -100,6 +100,7 @@ public class ItemConduitFacade extends Item implements IAdvancedTooltipProvider,
   }
 
   @Override
+  @SideOnly(Side.CLIENT)
   public IIcon getIcon(ItemStack stack, int renderPass, EntityPlayer player, ItemStack usingItem, int useRemaining) {
     return getIconFromDamage(stack.getItemDamage());
   }

--- a/src/main/java/crazypants/enderio/conduit/gui/GuiExternalConnection.java
+++ b/src/main/java/crazypants/enderio/conduit/gui/GuiExternalConnection.java
@@ -15,6 +15,9 @@ import net.minecraftforge.common.util.ForgeDirection;
 
 import org.lwjgl.opengl.GL11;
 
+import cpw.mods.fml.common.Optional;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import crazypants.enderio.conduit.IConduit;
 import crazypants.enderio.conduit.IConduitBundle;
 import crazypants.enderio.conduit.gas.IGasConduit;
@@ -28,8 +31,7 @@ import crazypants.enderio.gui.IconEIO;
 import crazypants.gui.GuiContainerBase;
 import crazypants.render.RenderUtil;
 
-import cpw.mods.fml.common.Optional;
-
+@SideOnly(Side.CLIENT)
 public class GuiExternalConnection extends GuiContainerBase {
 
   private static final int TAB_HEIGHT = 24;

--- a/src/main/java/crazypants/enderio/conduit/gui/GuiExternalConnectionSelector.java
+++ b/src/main/java/crazypants/enderio/conduit/gui/GuiExternalConnectionSelector.java
@@ -11,8 +11,10 @@ import net.minecraft.client.gui.GuiButton;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.client.renderer.Tessellator;
 import net.minecraftforge.common.util.ForgeDirection;
-import crazypants.enderio.EnderIO;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import crazypants.enderio.GuiHandler;
+import crazypants.enderio.EnderIO;
 import crazypants.enderio.conduit.IConduit;
 import crazypants.enderio.conduit.IConduitBundle;
 import crazypants.enderio.conduit.redstone.IInsulatedRedstoneConduit;
@@ -20,6 +22,7 @@ import crazypants.enderio.network.PacketHandler;
 import crazypants.render.ColorUtil;
 import crazypants.util.BlockCoord;
 
+@SideOnly(Side.CLIENT)
 public class GuiExternalConnectionSelector extends GuiScreen {
 
   Set<ForgeDirection> cons;
@@ -36,8 +39,8 @@ public class GuiExternalConnectionSelector extends GuiScreen {
             cons.add(dir);
           }
         }
-        
-      } else {        
+
+      } else {
         cons.addAll(con.getExternalConnections());
       }
     }

--- a/src/main/java/crazypants/enderio/config/GuiConfigFactoryEIO.java
+++ b/src/main/java/crazypants/enderio/config/GuiConfigFactoryEIO.java
@@ -1,6 +1,6 @@
 package crazypants.enderio.config;
 
-import static crazypants.enderio.config.Config.*;
+import static crazypants.enderio.config.Config.config;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -10,11 +10,14 @@ import net.minecraftforge.common.config.ConfigCategory;
 import net.minecraftforge.common.config.ConfigElement;
 import cpw.mods.fml.client.config.GuiConfig;
 import cpw.mods.fml.client.config.IConfigElement;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import crazypants.enderio.EnderIO;
 import crazypants.enderio.config.Config.Section;
 import crazypants.util.Lang;
 
 @SuppressWarnings({ "rawtypes" })
+@SideOnly(Side.CLIENT)
 public class GuiConfigFactoryEIO extends GuiConfig {
 
   public GuiConfigFactoryEIO(GuiScreen parentScreen)
@@ -26,11 +29,11 @@ public class GuiConfigFactoryEIO extends GuiConfig {
   {
     List<IConfigElement> list = new ArrayList<IConfigElement>();
     String prefix = Lang.prefix + "config.";
-    
+
     for (Section section : Config.sections) {
       list.add(new ConfigElement<ConfigCategory>(config.getCategory(section.lc()).setLanguageKey(prefix + section.lang)));
     }
-    
+
     return list;
   }
 }

--- a/src/main/java/crazypants/enderio/enderface/BlockEnderIO.java
+++ b/src/main/java/crazypants/enderio/enderface/BlockEnderIO.java
@@ -9,11 +9,14 @@ import net.minecraft.util.IIcon;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 import cpw.mods.fml.common.network.IGuiHandler;
+import net.minecraftforge.common.UsernameCache;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import crazypants.enderio.BlockEio;
-import crazypants.enderio.EnderIO;
 import crazypants.enderio.GuiHandler;
+import crazypants.enderio.CommonProxy;
+import crazypants.enderio.EnderIO;
+import crazypants.enderio.ISidedGuiHandler;
 import crazypants.enderio.Log;
 import crazypants.enderio.ModObject;
 import crazypants.enderio.api.teleport.ITravelAccessable;
@@ -26,7 +29,7 @@ public class BlockEnderIO extends BlockEio implements IResourceTooltipProvider {
 
   public static BlockEnderIO create() {
 
-    EnderIO.guiHandler.registerGuiHandler(GuiHandler.GUI_ID_ME_ACCESS_TERMINAL, new IGuiHandler() {
+    CommonProxy.guiHandler.registerGuiHandler(GuiHandler.GUI_ID_ME_ACCESS_TERMINAL, new ISidedGuiHandler() {
 
       @Override
       public Object getServerGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z) {

--- a/src/main/java/crazypants/enderio/enderface/ItemEnderface.java
+++ b/src/main/java/crazypants/enderio/enderface/ItemEnderface.java
@@ -6,15 +6,15 @@ import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.world.World;
-import cpw.mods.fml.common.network.IGuiHandler;
 import cpw.mods.fml.common.registry.GameRegistry;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
-import crazypants.enderio.EnderIO;
 import crazypants.enderio.GuiHandler;
+import crazypants.enderio.CommonProxy;
+import crazypants.enderio.ISidedGuiHandler;
 import crazypants.enderio.ModObject;
 
-public class ItemEnderface extends Item implements IGuiHandler {
+public class ItemEnderface extends Item implements ISidedGuiHandler {
 
   public static final String KEY_IO_SET = "enderFaceIoSet";
   public static final String KEY_IO_X = "enderFaceIoX";
@@ -36,7 +36,7 @@ public class ItemEnderface extends Item implements IGuiHandler {
 
   protected void init() {
     GameRegistry.registerItem(this, ModObject.itemEnderface.unlocalisedName);
-    EnderIO.guiHandler.registerGuiHandler(GuiHandler.GUI_ID_ENDERFACE, this);
+    CommonProxy.guiHandler.registerGuiHandler(GuiHandler.GUI_ID_ENDERFACE, this);
   }
 
   @Override
@@ -69,6 +69,7 @@ public class ItemEnderface extends Item implements IGuiHandler {
   }
 
   @Override
+  @SideOnly(Side.CLIENT)
   public Object getClientGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z) {
     return new GuiEnderface(player, world, x, y, z);
   }

--- a/src/main/java/crazypants/enderio/item/ItemSoulVessel.java
+++ b/src/main/java/crazypants/enderio/item/ItemSoulVessel.java
@@ -76,6 +76,7 @@ public class ItemSoulVessel extends Item implements IResourceTooltipProvider {
   }
 
   @Override
+  @SideOnly(Side.CLIENT)
   public IIcon getIcon(ItemStack item, int arg1, EntityPlayer arg2, ItemStack arg3, int arg4) {
      if(containsSoul(item)) {
        return filledIcon;

--- a/src/main/java/crazypants/enderio/machine/AbstractMachineBlock.java
+++ b/src/main/java/crazypants/enderio/machine/AbstractMachineBlock.java
@@ -16,21 +16,22 @@ import net.minecraft.util.MathHelper;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
-import cpw.mods.fml.common.network.IGuiHandler;
 import cpw.mods.fml.common.registry.GameRegistry;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import crazypants.enderio.BlockEio;
 import crazypants.enderio.ClientProxy;
+import crazypants.enderio.CommonProxy;
 import crazypants.enderio.EnderIO;
 import crazypants.enderio.EnderIOTab;
+import crazypants.enderio.ISidedGuiHandler;
 import crazypants.enderio.ModObject;
 import crazypants.enderio.TileEntityEio;
 import crazypants.enderio.gui.IResourceTooltipProvider;
 import crazypants.enderio.network.PacketHandler;
 import crazypants.enderio.waila.IWailaInfoProvider;
 
-public abstract class AbstractMachineBlock<T extends AbstractMachineEntity> extends BlockEio implements IGuiHandler, IResourceTooltipProvider,
+public abstract class AbstractMachineBlock<T extends AbstractMachineEntity> extends BlockEio implements ISidedGuiHandler, IResourceTooltipProvider,
     IWailaInfoProvider {
 
   public static int renderId;
@@ -71,10 +72,11 @@ public abstract class AbstractMachineBlock<T extends AbstractMachineEntity> exte
     this(mo, teClass, new Material(MapColor.ironColor));
   }
 
+  @Override
   protected void init() {
     GameRegistry.registerBlock(this, modObject.unlocalisedName);
     GameRegistry.registerTileEntity(teClass, modObject.unlocalisedName + "TileEntity");
-    EnderIO.guiHandler.registerGuiHandler(getGuiId(), this);
+    CommonProxy.guiHandler.registerGuiHandler(getGuiId(), this);
   }
 
   @Override
@@ -82,13 +84,14 @@ public abstract class AbstractMachineBlock<T extends AbstractMachineEntity> exte
     return renderId;
   }
 
+  @Override
   public boolean openGui(World world, int x, int y, int z, EntityPlayer entityPlayer, int side) {
     if(!world.isRemote) {
       entityPlayer.openGui(EnderIO.instance, getGuiId(), world, x, y, z);
     }
     return true;
   }
-  
+
   @Override
   public boolean canSilkHarvest(World world, EntityPlayer player, int x, int y, int z, int metadata) {
     return false;
@@ -301,7 +304,7 @@ public abstract class AbstractMachineBlock<T extends AbstractMachineEntity> exte
   public int getDefaultDisplayMask(World world, int x, int y, int z) {
     return IWailaInfoProvider.ALL_BITS;
   }
-  
+
   protected void setObeliskBounds() {
     setBlockBounds(0.11f, 0, 0.11f, 0.91f, 0.48f, 0.91f);
   }

--- a/src/main/java/crazypants/enderio/machine/alloy/BlockAlloySmelter.java
+++ b/src/main/java/crazypants/enderio/machine/alloy/BlockAlloySmelter.java
@@ -52,6 +52,7 @@ public class BlockAlloySmelter extends AbstractMachineBlock<TileAlloySmelter> {
   }
 
   @Override
+  @SideOnly(Side.CLIENT)
   public Object getClientGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z) {
     TileEntity te = world.getTileEntity(x, y, z);
     return new GuiAlloySmelter(player.inventory, (TileAlloySmelter) te);

--- a/src/main/java/crazypants/enderio/machine/alloy/GuiAlloySmelter.java
+++ b/src/main/java/crazypants/enderio/machine/alloy/GuiAlloySmelter.java
@@ -1,7 +1,6 @@
 package crazypants.enderio.machine.alloy;
 
 import java.awt.Rectangle;
-import java.text.MessageFormat;
 
 import net.minecraft.client.gui.GuiButton;
 import net.minecraft.entity.player.InventoryPlayer;
@@ -9,6 +8,8 @@ import net.minecraft.util.IIcon;
 
 import org.lwjgl.opengl.GL11;
 
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import crazypants.enderio.EnderIO;
 import crazypants.enderio.machine.alloy.TileAlloySmelter.Mode;
 import crazypants.enderio.machine.gui.GuiPoweredMachineBase;
@@ -19,6 +20,7 @@ import crazypants.render.RenderUtil;
 import crazypants.util.Lang;
 import crazypants.vecmath.Vector4f;
 
+@SideOnly(Side.CLIENT)
 public class GuiAlloySmelter extends GuiPoweredMachineBase<TileAlloySmelter> {
 
   private final IconButton vanillaFurnaceButton;

--- a/src/main/java/crazypants/enderio/machine/attractor/BlockAttractor.java
+++ b/src/main/java/crazypants/enderio/machine/attractor/BlockAttractor.java
@@ -17,13 +17,13 @@ import crazypants.enderio.machine.AbstractMachineBlock;
 public class BlockAttractor extends AbstractMachineBlock<TileAttractor> {
 
   public static int renderId;
-  
+
   public static BlockAttractor create() {
     BlockAttractor res = new BlockAttractor();
     res.init();
     return res;
   }
-  
+
   protected BlockAttractor() {
     super(ModObject.blockAttractor, TileAttractor.class);
     setObeliskBounds();
@@ -37,13 +37,14 @@ public class BlockAttractor extends AbstractMachineBlock<TileAttractor> {
     }
     return null;
   }
-  
+
   @SideOnly(Side.CLIENT)
   public IIcon getOnIcon() {
     return iconBuffer[0][6];
   }
 
   @Override
+  @SideOnly(Side.CLIENT)
   public Object getClientGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z) {
     TileEntity te = world.getTileEntity(x, y, z);
     if(te instanceof TileAttractor) {
@@ -53,7 +54,7 @@ public class BlockAttractor extends AbstractMachineBlock<TileAttractor> {
   }
 
   @Override
-  protected int getGuiId() {    
+  protected int getGuiId() {
     return GuiHandler.GUI_ID_ATTRACTOR;
   }
 
@@ -64,7 +65,7 @@ public class BlockAttractor extends AbstractMachineBlock<TileAttractor> {
     }
     return "enderio:blockAttractorSide";
   }
-  
+
   @Override
   protected String getSideIconKey(boolean active) {
     if(active) {
@@ -95,14 +96,14 @@ public class BlockAttractor extends AbstractMachineBlock<TileAttractor> {
   public boolean isOpaqueCube() {
     return false;
   }
-  
+
   @Override
   public int getLightOpacity() {
     return 0;
   }
-  
+
   @Override
-  public int getRenderType() {    
+  public int getRenderType() {
     return renderId;
   }
 
@@ -116,14 +117,14 @@ public class BlockAttractor extends AbstractMachineBlock<TileAttractor> {
       for (int i = 0; i < 1; i++) {
         float xOffset = -0.2F - rand.nextFloat() * 0.6F;
         float yOffset = -0.1F + rand.nextFloat() * 0.2F;
-        float zOffset = -0.2F - rand.nextFloat() * 0.6F;        
-        
+        float zOffset = -0.2F - rand.nextFloat() * 0.6F;
+
         EntityFX fx = Minecraft.getMinecraft().renderGlobal.doSpawnParticle("spell", startX + xOffset, startY + yOffset, startZ + zOffset, 0.0D, 0.0D, 0.0D);
         if(fx != null) {
-          fx.setRBGColorF(0.2f, 0.2f, 0.8f);          
+          fx.setRBGColorF(0.2f, 0.2f, 0.8f);
           fx.motionY *= 0.5f;
         }
       }
     }
-  }  
+  }
 }

--- a/src/main/java/crazypants/enderio/machine/attractor/GuiAttractor.java
+++ b/src/main/java/crazypants/enderio/machine/attractor/GuiAttractor.java
@@ -7,6 +7,8 @@ import net.minecraft.entity.player.InventoryPlayer;
 
 import org.lwjgl.opengl.GL11;
 
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import crazypants.enderio.gui.IconEIO;
 import crazypants.enderio.gui.ToggleButtonEIO;
 import crazypants.enderio.machine.gui.GuiPoweredMachineBase;
@@ -14,12 +16,13 @@ import crazypants.render.ColorUtil;
 import crazypants.render.RenderUtil;
 import crazypants.util.Lang;
 
+@SideOnly(Side.CLIENT)
 public class GuiAttractor extends GuiPoweredMachineBase<TileAttractor> {
 
   private static final int RANGE_ID = 8738924;
 
   private ToggleButtonEIO showRangeB;
-  
+
   public GuiAttractor(InventoryPlayer par1InventoryPlayer, TileAttractor te) {
     super(te, new ContainerAttractor(par1InventoryPlayer, te));
 
@@ -28,7 +31,7 @@ public class GuiAttractor extends GuiPoweredMachineBase<TileAttractor> {
     showRangeB.setSize(BUTTON_SIZE, BUTTON_SIZE);
     showRangeB.setToolTip(Lang.localize("gui.spawnGurad.showRange"));
   }
-  
+
   @Override
   public void initGui() {
     super.initGui();
@@ -52,15 +55,15 @@ public class GuiAttractor extends GuiPoweredMachineBase<TileAttractor> {
     int sy = (height - ySize) / 2;
 
     drawTexturedModalRect(sx, sy, 0, 0, xSize, ySize);
-    
+
     super.drawGuiContainerBackgroundLayer(par1, par2, par3);
-    
+
     int range = (int) getTileEntity().getRange();
     drawCenteredString(fontRendererObj, Lang.localize("gui.spawnGurad.range") + " " + range, getGuiLeft() + sx/2 + 9, getGuiTop() + 68, ColorUtil.getRGB(Color.white));
   }
 
   @Override
-  protected boolean showRecipeButton() {    
+  protected boolean showRecipeButton() {
     return false;
   }
 

--- a/src/main/java/crazypants/enderio/machine/buffer/BlockBuffer.java
+++ b/src/main/java/crazypants/enderio/machine/buffer/BlockBuffer.java
@@ -14,8 +14,8 @@ import net.minecraft.world.World;
 import cpw.mods.fml.common.registry.GameRegistry;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
-import crazypants.enderio.EnderIO;
 import crazypants.enderio.GuiHandler;
+import crazypants.enderio.CommonProxy;
 import crazypants.enderio.ModObject;
 import crazypants.enderio.machine.AbstractMachineBlock;
 import crazypants.enderio.machine.MachineRecipeInput;
@@ -46,7 +46,7 @@ public class BlockBuffer extends AbstractMachineBlock<TileBuffer> implements IFa
   protected void init() {
     GameRegistry.registerBlock(this, BlockItemBuffer.class, modObject.unlocalisedName);
     GameRegistry.registerTileEntity(teClass, modObject.unlocalisedName + "TileEntity");
-    EnderIO.guiHandler.registerGuiHandler(getGuiId(), this);
+    CommonProxy.guiHandler.registerGuiHandler(getGuiId(), this);
     MachineRecipeRegistry.instance.registerRecipe(ModObject.blockPainter.unlocalisedName, new PainterTemplate());
   }
 
@@ -60,6 +60,7 @@ public class BlockBuffer extends AbstractMachineBlock<TileBuffer> implements IFa
   }
 
   @Override
+  @SideOnly(Side.CLIENT)
   public Object getClientGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z) {
     TileEntity te = world.getTileEntity(x, y, z);
     if(te instanceof TileBuffer) {

--- a/src/main/java/crazypants/enderio/machine/buffer/GuiBuffer.java
+++ b/src/main/java/crazypants/enderio/machine/buffer/GuiBuffer.java
@@ -8,6 +8,8 @@ import net.minecraft.inventory.Slot;
 import org.lwjgl.opengl.GL11;
 
 import crazypants.enderio.gui.TextFieldEIO;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import crazypants.enderio.machine.IoMode;
 import crazypants.enderio.machine.gui.GuiPoweredMachineBase;
 import crazypants.enderio.machine.power.PowerDisplayUtil;
@@ -15,6 +17,7 @@ import crazypants.enderio.network.PacketHandler;
 import crazypants.render.RenderUtil;
 import crazypants.util.Lang;
 
+@SideOnly(Side.CLIENT)
 public class GuiBuffer extends GuiPoweredMachineBase<TileBuffer> {
 
   private static final String TEXTURE_SIMPLE = "enderio:textures/gui/buffer.png";
@@ -170,11 +173,12 @@ public class GuiBuffer extends GuiPoweredMachineBase<TileBuffer> {
     return getTileEntity().hasInventory() && getTileEntity().hasPower();
   }
 
+  @Override
   public void renderSlotHighlights(IoMode mode) {
     if (!getTileEntity().hasInventory()) {
       return;
     }
-    
+
     for (int slot = 0; slot < getTileEntity().getSizeInventory(); slot++) {
       renderSlotHighlight(slot, mode);
     }

--- a/src/main/java/crazypants/enderio/machine/capbank/BlockCapBank.java
+++ b/src/main/java/crazypants/enderio/machine/capbank/BlockCapBank.java
@@ -20,13 +20,14 @@ import net.minecraft.util.MathHelper;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
-import cpw.mods.fml.common.network.IGuiHandler;
 import cpw.mods.fml.common.registry.GameRegistry;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import crazypants.enderio.BlockEio;
-import crazypants.enderio.EnderIO;
 import crazypants.enderio.GuiHandler;
+import crazypants.enderio.CommonProxy;
+import crazypants.enderio.EnderIO;
+import crazypants.enderio.ISidedGuiHandler;
 import crazypants.enderio.ModObject;
 import crazypants.enderio.TileEntityEio;
 import crazypants.enderio.api.redstone.IRedstoneConnectable;
@@ -52,7 +53,7 @@ import crazypants.util.Lang;
 import crazypants.util.Util;
 import crazypants.vecmath.Vector3d;
 
-public class BlockCapBank extends BlockEio implements IGuiHandler, IAdvancedTooltipProvider, IWailaInfoProvider, IRedstoneConnectable {
+public class BlockCapBank extends BlockEio implements ISidedGuiHandler, IAdvancedTooltipProvider, IWailaInfoProvider, IRedstoneConnectable {
 
   public static int renderId = -1;
 
@@ -101,7 +102,7 @@ public class BlockCapBank extends BlockEio implements IGuiHandler, IAdvancedTool
       GameRegistry.registerTileEntity(teClass, name + "TileEntity");
     }
 
-    EnderIO.guiHandler.registerGuiHandler(GuiHandler.GUI_ID_CAP_BANK, this);
+    CommonProxy.guiHandler.registerGuiHandler(GuiHandler.GUI_ID_CAP_BANK, this);
     setLightOpacity(255);
   }
 
@@ -218,6 +219,7 @@ public class BlockCapBank extends BlockEio implements IGuiHandler, IAdvancedTool
   }
 
   @Override
+  @SideOnly(Side.CLIENT)
   public Object getClientGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z) {
     TileEntity te = world.getTileEntity(x, y, z);
     if(te instanceof TileCapBank) {

--- a/src/main/java/crazypants/enderio/machine/capbank/GuiCapBank.java
+++ b/src/main/java/crazypants/enderio/machine/capbank/GuiCapBank.java
@@ -13,6 +13,8 @@ import net.minecraft.util.EnumChatFormatting;
 
 import org.lwjgl.opengl.GL11;
 
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import crazypants.enderio.EnderIO;
 import crazypants.enderio.gui.RedstoneModeButton;
 import crazypants.enderio.gui.TextFieldEIO;
@@ -34,6 +36,7 @@ import crazypants.util.BlockCoord;
 import crazypants.util.Lang;
 import crazypants.vecmath.VecmathUtil;
 
+@SideOnly(Side.CLIENT)
 public class GuiCapBank extends GuiContainerBase {
 
   private static final CapBankClientNetwork NULL_NETWORK = new CapBankClientNetwork(-1);

--- a/src/main/java/crazypants/enderio/machine/crafter/BlockCrafter.java
+++ b/src/main/java/crazypants/enderio/machine/crafter/BlockCrafter.java
@@ -4,6 +4,8 @@ import cpw.mods.fml.relauncher.Side;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.world.World;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import crazypants.enderio.GuiHandler;
 import crazypants.enderio.ModObject;
 import crazypants.enderio.machine.AbstractMachineBlock;
@@ -17,7 +19,7 @@ public class BlockCrafter extends AbstractMachineBlock<TileCrafter> {
     res.init();
     return res;
   }
-  
+
   protected BlockCrafter() {
     super(ModObject.blockCrafter, TileCrafter.class);
   }
@@ -32,6 +34,7 @@ public class BlockCrafter extends AbstractMachineBlock<TileCrafter> {
   }
 
   @Override
+  @SideOnly(Side.CLIENT)
   public Object getClientGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z) {
     TileEntity te = world.getTileEntity(x, y, z);
     if(te instanceof TileCrafter) {
@@ -49,7 +52,7 @@ public class BlockCrafter extends AbstractMachineBlock<TileCrafter> {
   protected String getMachineFrontIconKey(boolean active) {
     return "enderio:crafter";
   }
-  
+
   @Override
   protected String getSideIconKey(boolean active) {
     return "enderio:crafterSide";

--- a/src/main/java/crazypants/enderio/machine/crafter/GuiCrafter.java
+++ b/src/main/java/crazypants/enderio/machine/crafter/GuiCrafter.java
@@ -7,6 +7,8 @@ import net.minecraft.entity.player.InventoryPlayer;
 
 import org.lwjgl.opengl.GL11;
 
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import crazypants.enderio.config.Config;
 import crazypants.enderio.gui.IconEIO;
 import crazypants.enderio.gui.ToggleButtonEIO;
@@ -20,6 +22,7 @@ import crazypants.util.Lang;
 import net.minecraft.client.Minecraft;
 import net.minecraft.item.ItemStack;
 
+@SideOnly(Side.CLIENT)
 public class GuiCrafter extends GuiPoweredMachineBase<TileCrafter>  {
 
   private final ToggleButtonEIO bufferSizeB;
@@ -76,17 +79,17 @@ public class GuiCrafter extends GuiPoweredMachineBase<TileCrafter>  {
   public final int getXSize() {
     return 219;
   }
-  
+
   @Override
   protected int getPowerU() {
     return 220;
   }
 
   @Override
-  protected int getPowerX() {    
+  protected int getPowerX() {
     return 9;
-  }  
-  
+  }
+
   @Override
   protected void updatePowerBarTooltip(List<String> text) {
     text.add(PowerDisplayUtil.formatPower(Config.crafterRfPerCraft) + " " + PowerDisplayUtil.abrevation()
@@ -101,9 +104,9 @@ public class GuiCrafter extends GuiPoweredMachineBase<TileCrafter>  {
     int sx = (width - xSize) / 2;
     int sy = (height - ySize) / 2;
 
-    drawTexturedModalRect(sx, sy, 0, 0, xSize, ySize);    
+    drawTexturedModalRect(sx, sy, 0, 0, xSize, ySize);
 
     super.drawGuiContainerBackgroundLayer(par1, par2, par3);
   }
-  
+
 }

--- a/src/main/java/crazypants/enderio/machine/crusher/BlockCrusher.java
+++ b/src/main/java/crazypants/enderio/machine/crusher/BlockCrusher.java
@@ -39,6 +39,7 @@ public class BlockCrusher extends AbstractMachineBlock {
   }
 
   @Override
+  @SideOnly(Side.CLIENT)
   public Object getClientGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z) {
     TileEntity te = world.getTileEntity(x, y, z);
     if(te instanceof TileCrusher) {

--- a/src/main/java/crazypants/enderio/machine/crusher/GuiCrusher.java
+++ b/src/main/java/crazypants/enderio/machine/crusher/GuiCrusher.java
@@ -6,10 +6,13 @@ import net.minecraft.entity.player.InventoryPlayer;
 
 import org.lwjgl.opengl.GL11;
 
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import crazypants.enderio.machine.gui.GuiPoweredMachineBase;
 import crazypants.gui.GuiToolTip;
 import crazypants.render.RenderUtil;
 
+@SideOnly(Side.CLIENT)
 public class GuiCrusher extends GuiPoweredMachineBase<TileCrusher> {
 
   public GuiCrusher(InventoryPlayer par1InventoryPlayer, TileCrusher inventory) {

--- a/src/main/java/crazypants/enderio/machine/enchanter/BlockEnchanter.java
+++ b/src/main/java/crazypants/enderio/machine/enchanter/BlockEnchanter.java
@@ -4,24 +4,23 @@ import java.util.Random;
 
 import net.minecraft.block.Block;
 import net.minecraft.entity.EntityLivingBase;
-import net.minecraft.entity.item.EntityItem;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.MathHelper;
 import net.minecraft.world.World;
-import cpw.mods.fml.common.network.IGuiHandler;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import crazypants.enderio.BlockEio;
-import crazypants.enderio.EnderIO;
 import crazypants.enderio.GuiHandler;
+import crazypants.enderio.CommonProxy;
+import crazypants.enderio.EnderIO;
+import crazypants.enderio.ISidedGuiHandler;
 import crazypants.enderio.ModObject;
-import crazypants.enderio.api.tool.ITool;
 import crazypants.enderio.gui.IResourceTooltipProvider;
-import crazypants.enderio.machine.AbstractMachineEntity;
-import crazypants.enderio.tool.ToolUtil;
 import crazypants.util.Util;
 
-public class BlockEnchanter extends BlockEio implements IGuiHandler, IResourceTooltipProvider {
+public class BlockEnchanter extends BlockEio implements ISidedGuiHandler, IResourceTooltipProvider {
 
   public static BlockEnchanter create() {
     BlockEnchanter res = new BlockEnchanter();
@@ -40,7 +39,7 @@ public class BlockEnchanter extends BlockEio implements IGuiHandler, IResourceTo
   @Override
   protected void init() {
     super.init();
-    EnderIO.guiHandler.registerGuiHandler(GuiHandler.GUI_ID_ENCHANTER, this);
+    CommonProxy.guiHandler.registerGuiHandler(GuiHandler.GUI_ID_ENCHANTER, this);
   }
 
   @Override
@@ -69,7 +68,7 @@ public class BlockEnchanter extends BlockEio implements IGuiHandler, IResourceTo
     }
     world.markBlockForUpdate(x, y, z);
   }
-  
+
   @Override
   protected boolean openGui(World world, int x, int y, int z, EntityPlayer entityPlayer, int side) {
     if(!world.isRemote) {
@@ -87,6 +86,7 @@ public class BlockEnchanter extends BlockEio implements IGuiHandler, IResourceTo
     super.breakBlock(world, x, y, z, block, meta);
   }
 
+  @Override
   public boolean doNormalDrops(World world, int x, int y, int z) {
     return false;
   }
@@ -130,6 +130,7 @@ public class BlockEnchanter extends BlockEio implements IGuiHandler, IResourceTo
   }
 
   @Override
+  @SideOnly(Side.CLIENT)
   public Object getClientGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z) {
     TileEntity te = world.getTileEntity(x, y, z);
     if(te instanceof TileEnchanter) {
@@ -137,7 +138,7 @@ public class BlockEnchanter extends BlockEio implements IGuiHandler, IResourceTo
     }
     return null;
   }
-  
+
   @Override
   public String getUnlocalizedNameForTooltip(ItemStack itemStack) {
     return getUnlocalizedName();

--- a/src/main/java/crazypants/enderio/machine/enchanter/GuiEnchanter.java
+++ b/src/main/java/crazypants/enderio/machine/enchanter/GuiEnchanter.java
@@ -1,31 +1,31 @@
 package crazypants.enderio.machine.enchanter;
 
-import java.awt.Color;
-
-import org.lwjgl.opengl.GL11;
-
-import crazypants.enderio.EnderIO;
-import crazypants.enderio.gui.IconEIO;
-import crazypants.enderio.machine.vacuum.ContainerVacuumChest;
-import crazypants.render.ColorUtil;
-import crazypants.render.RenderUtil;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.inventory.GuiContainer;
 import net.minecraft.client.resources.I18n;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.InventoryPlayer;
 
+import org.lwjgl.opengl.GL11;
+
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+import crazypants.enderio.EnderIO;
+import crazypants.enderio.gui.IconEIO;
+import crazypants.render.RenderUtil;
+
+@SideOnly(Side.CLIENT)
 public class GuiEnchanter extends GuiContainer {
 
   private TileEnchanter te;
   private ContainerEnchanter container;
-  
+
   public GuiEnchanter(EntityPlayer player, InventoryPlayer inventory, TileEnchanter te) {
     super(new ContainerEnchanter(player, inventory, te));
     container = (ContainerEnchanter)inventorySlots;
     this.te = te;
   }
-  
+
   @Override
   protected void drawGuiContainerBackgroundLayer(float var1, int var2, int var3) {
     GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
@@ -33,15 +33,15 @@ public class GuiEnchanter extends GuiContainer {
     int sx = (width - xSize) / 2;
     int sy = (height - ySize) / 2;
     drawTexturedModalRect(sx, sy, 0, 0, this.xSize, this.ySize);
-    
+
     if(EnderIO.proxy.isNeiInstalled()) {
       IconEIO.RECIPE.renderIcon(sx + 155, sy + 8, 16, 16, 0, true);
     }
-    
-    int curCost = te.getCurrentEnchantmentCost();    
+
+    int curCost = te.getCurrentEnchantmentCost();
     if(curCost > 0) {
       GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
-      
+
       int col;
       if(container.playerHasEnoughLevels(Minecraft.getMinecraft().thePlayer)) {
         col = 8453920; //all good
@@ -49,7 +49,7 @@ public class GuiEnchanter extends GuiContainer {
         col  = 16736352; //not enough levels
         RenderUtil.bindTexture("enderio:textures/gui/enchanter.png");
         drawTexturedModalRect(sx + 99, sy + 33, 176, 0, 28, 21);
-      }            
+      }
       String s = I18n.format("container.repair.cost", new Object[] {Integer.valueOf(curCost)});
       drawCenteredString(Minecraft.getMinecraft().fontRenderer, s, sx + xSize/2, sy + 57, col);
     }

--- a/src/main/java/crazypants/enderio/machine/farm/BlockFarmStation.java
+++ b/src/main/java/crazypants/enderio/machine/farm/BlockFarmStation.java
@@ -47,6 +47,7 @@ public class BlockFarmStation extends AbstractMachineBlock<TileFarmStation> {
   }
 
   @Override
+  @SideOnly(Side.CLIENT)
   public Object getClientGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z) {
     TileEntity te = world.getTileEntity(x, y, z);
     if(te instanceof TileFarmStation) {
@@ -124,6 +125,7 @@ public class BlockFarmStation extends AbstractMachineBlock<TileFarmStation> {
     return false;
   }
 
+  @SideOnly(Side.CLIENT)
   public IIcon getFrontIcon() {
     return iconBuffer[0][3];
   }

--- a/src/main/java/crazypants/enderio/machine/farm/GuiFarmStation.java
+++ b/src/main/java/crazypants/enderio/machine/farm/GuiFarmStation.java
@@ -8,6 +8,8 @@ import net.minecraft.inventory.Slot;
 
 import org.lwjgl.opengl.GL11;
 
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import crazypants.enderio.gui.IconButtonEIO;
 import crazypants.enderio.gui.IconEIO;
 import crazypants.enderio.gui.ToggleButtonEIO;
@@ -17,6 +19,7 @@ import crazypants.render.RenderUtil;
 import crazypants.util.Lang;
 import crazypants.vecmath.Vector4f;
 
+@SideOnly(Side.CLIENT)
 public class GuiFarmStation extends GuiPoweredMachineBase<TileFarmStation> {
 
   private static final int LOCK_ID = 1234;
@@ -24,12 +27,12 @@ public class GuiFarmStation extends GuiPoweredMachineBase<TileFarmStation> {
   public GuiFarmStation(InventoryPlayer par1InventoryPlayer, TileFarmStation machine) {
     super(machine, new FarmStationContainer(par1InventoryPlayer, machine));
   }
-  
+
   @SuppressWarnings("unchecked")
   @Override
   public void initGui() {
     super.initGui();
-    
+
     int x = getGuiLeft() + 36;
     int y = getGuiTop()  + 43;
     
@@ -57,7 +60,7 @@ public class GuiFarmStation extends GuiPoweredMachineBase<TileFarmStation> {
       }
     }
   }
-  
+
   @Override
   protected void drawGuiContainerBackgroundLayer(float par1, int par2, int par3) {
     GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
@@ -68,18 +71,18 @@ public class GuiFarmStation extends GuiPoweredMachineBase<TileFarmStation> {
     drawTexturedModalRect(sx, sy, 0, 0, this.xSize, this.ySize);
 
     FontRenderer fr = Minecraft.getMinecraft().fontRenderer;
-    
+
     GL11.glEnable(GL11.GL_BLEND);
     fr.drawString("SW", sx + 55, sy + 48, ColorUtil.getARGB(1f,1f,0.35f,1f), true);    
     fr.drawString("NW", sx + 55, sy + 66, ColorUtil.getARGB(1f,1f,0.35f,1f), true);
     fr.drawString("SE", sx + 73, sy + 48, ColorUtil.getARGB(1f,1f,0.35f,1f), true);
     fr.drawString("NE", sx + 73, sy + 66, ColorUtil.getARGB(1f,1f,0.35f,1f), true);        
     GL11.glDisable(GL11.GL_BLEND);
-    
+
     RenderUtil.bindTexture("enderio:textures/gui/farmStation.png");
     super.drawGuiContainerBackgroundLayer(par1, par2, par3);
   }
-  
+
   @Override
   protected void actionPerformed(GuiButton b) {
     if (b.id >= LOCK_ID+TileFarmStation.minSupSlot && b.id <= LOCK_ID+TileFarmStation.maxSupSlot) {

--- a/src/main/java/crazypants/enderio/machine/generator/combustion/BlockCombustionGenerator.java
+++ b/src/main/java/crazypants/enderio/machine/generator/combustion/BlockCombustionGenerator.java
@@ -84,6 +84,7 @@ public class BlockCombustionGenerator extends AbstractMachineBlock<TileCombustio
   }
 
   @Override
+  @SideOnly(Side.CLIENT)
   public Object getClientGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z) {
     TileEntity te = world.getTileEntity(x, y, z);
     if(te instanceof TileCombustionGenerator) {

--- a/src/main/java/crazypants/enderio/machine/generator/combustion/GuiCombustionGenerator.java
+++ b/src/main/java/crazypants/enderio/machine/generator/combustion/GuiCombustionGenerator.java
@@ -8,6 +8,8 @@ import net.minecraft.entity.player.InventoryPlayer;
 
 import org.lwjgl.opengl.GL11;
 
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import crazypants.enderio.fluid.Fluids;
 import crazypants.enderio.machine.IoMode;
 import crazypants.enderio.machine.gui.GuiPoweredMachineBase;
@@ -17,6 +19,7 @@ import crazypants.render.ColorUtil;
 import crazypants.render.RenderUtil;
 import crazypants.util.Lang;
 
+@SideOnly(Side.CLIENT)
 public class GuiCombustionGenerator extends GuiPoweredMachineBase<TileCombustionGenerator> {
 
   public GuiCombustionGenerator(InventoryPlayer par1InventoryPlayer, TileCombustionGenerator te) {

--- a/src/main/java/crazypants/enderio/machine/generator/stirling/BlockStirlingGenerator.java
+++ b/src/main/java/crazypants/enderio/machine/generator/stirling/BlockStirlingGenerator.java
@@ -33,6 +33,7 @@ public class BlockStirlingGenerator extends AbstractMachineBlock<TileEntityStirl
   }
 
   @Override
+  @SideOnly(Side.CLIENT)
   public Object getClientGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z) {
     return new GuiStirlingGenerator(player.inventory, (TileEntityStirlingGenerator) world.getTileEntity(x, y, z));
   }
@@ -63,7 +64,7 @@ public class BlockStirlingGenerator extends AbstractMachineBlock<TileEntityStirl
         double v = 0.05;
         double vx = 0;
         double vz = 0;
-        
+
         if(front == ForgeDirection.NORTH || front == ForgeDirection.SOUTH) {
           px += world.rand.nextFloat() * 0.9 - 0.45;
           vz += front == ForgeDirection.NORTH ? -v : v;

--- a/src/main/java/crazypants/enderio/machine/generator/zombie/BlockZombieGenerator.java
+++ b/src/main/java/crazypants/enderio/machine/generator/zombie/BlockZombieGenerator.java
@@ -15,15 +15,15 @@ import net.minecraftforge.common.util.ForgeDirection;
 import net.minecraftforge.fluids.FluidStack;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
-import crazypants.enderio.EnderIO;
 import crazypants.enderio.GuiHandler;
+import crazypants.enderio.EnderIO;
 import crazypants.enderio.ModObject;
 import crazypants.enderio.config.Config;
 import crazypants.enderio.machine.AbstractMachineBlock;
 import crazypants.enderio.network.PacketHandler;
 import crazypants.util.FluidUtil;
-import crazypants.util.Util;
 import crazypants.util.Lang;
+import crazypants.util.Util;
 
 public class BlockZombieGenerator extends AbstractMachineBlock<TileZombieGenerator> {
 
@@ -86,6 +86,7 @@ public class BlockZombieGenerator extends AbstractMachineBlock<TileZombieGenerat
   }
 
   @Override
+  @SideOnly(Side.CLIENT)
   public Object getClientGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z) {
     return new GuiZombieGenerator(player.inventory, (TileZombieGenerator) world.getTileEntity(x, y, z));
   }

--- a/src/main/java/crazypants/enderio/machine/generator/zombie/GuiZombieGenerator.java
+++ b/src/main/java/crazypants/enderio/machine/generator/zombie/GuiZombieGenerator.java
@@ -8,6 +8,8 @@ import net.minecraft.entity.player.InventoryPlayer;
 
 import org.lwjgl.opengl.GL11;
 
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import crazypants.enderio.fluid.Fluids;
 import crazypants.enderio.machine.IoMode;
 import crazypants.enderio.machine.gui.GuiPoweredMachineBase;
@@ -17,11 +19,12 @@ import crazypants.render.ColorUtil;
 import crazypants.render.RenderUtil;
 import crazypants.util.Lang;
 
+@SideOnly(Side.CLIENT)
 public class GuiZombieGenerator extends GuiPoweredMachineBase<TileZombieGenerator> {
 
   public GuiZombieGenerator(InventoryPlayer inventory, TileZombieGenerator tileEntity) {
     super(tileEntity, new ContainerZombieGenerator(inventory, tileEntity));
-    
+
     addToolTip(new GuiToolTip(new Rectangle(80, 21, 15, 47), "") {
 
       @Override

--- a/src/main/java/crazypants/enderio/machine/gui/GuiMachineBase.java
+++ b/src/main/java/crazypants/enderio/machine/gui/GuiMachineBase.java
@@ -11,6 +11,8 @@ import net.minecraft.inventory.Slot;
 
 import org.lwjgl.opengl.GL11;
 
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import crazypants.enderio.EnderIO;
 import crazypants.enderio.gui.IconButtonEIO;
 import crazypants.enderio.gui.IconEIO;
@@ -26,6 +28,7 @@ import crazypants.util.BlockCoord;
 import crazypants.util.Lang;
 import crazypants.vecmath.Vector4f;
 
+@SideOnly(Side.CLIENT)
 public abstract class GuiMachineBase<T extends AbstractMachineEntity> extends GuiContainerBase {
 
   public static final Vector4f PUSH_COLOR = new Vector4f(0.8f, 0.4f, 0.1f, 0.5f);
@@ -42,7 +45,7 @@ public abstract class GuiMachineBase<T extends AbstractMachineEntity> extends Gu
   private final GuiOverlayIoConfig configOverlay;
 
   protected final GuiButtonIoConfig configB;
-  
+
   protected IconButtonEIO recipeButton;
 
   protected List<GuiToolTip> progressTooltips;
@@ -51,7 +54,7 @@ public abstract class GuiMachineBase<T extends AbstractMachineEntity> extends Gu
   protected GuiMachineBase(T machine, Container par1Container) {
     super(par1Container);
     tileEntity = machine;
-    
+
     xSize = getXSize();
     ySize = getYSize();
     int x = getXSize() - 5 - BUTTON_SIZE;
@@ -136,11 +139,11 @@ public abstract class GuiMachineBase<T extends AbstractMachineEntity> extends Gu
     RenderUtil.renderQuad2D(getGuiLeft() + x, getGuiTop() + y, 0, width, height, col);
     GL11.glDisable(GL11.GL_BLEND);
   }
-  
+
   protected boolean isConfigOverlayEnabled() {
     return configOverlay.isVisible();
   }
-  
+
   protected T getTileEntity() {
     return tileEntity;
   }

--- a/src/main/java/crazypants/enderio/machine/gui/GuiPoweredMachineBase.java
+++ b/src/main/java/crazypants/enderio/machine/gui/GuiPoweredMachineBase.java
@@ -2,16 +2,19 @@ package crazypants.enderio.machine.gui;
 
 import java.awt.Rectangle;
 import java.util.List;
-import net.minecraft.util.StatCollector;
 
 import net.minecraft.inventory.Container;
+import net.minecraft.util.StatCollector;
 
 import org.lwjgl.opengl.GL11;
 
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import crazypants.enderio.machine.AbstractPoweredMachineEntity;
 import crazypants.enderio.machine.power.PowerDisplayUtil;
 import crazypants.gui.GuiToolTip;
 
+@SideOnly(Side.CLIENT)
 public abstract class GuiPoweredMachineBase<T extends AbstractPoweredMachineEntity> extends GuiMachineBase<T> {
 
   protected static final int POWER_Y = 14;
@@ -40,11 +43,11 @@ public abstract class GuiPoweredMachineBase<T extends AbstractPoweredMachineEnti
   protected String getPowerOutputLabel() {
     return StatCollector.translateToLocal("enderio.gui.max");
   }
-  
+
   protected int getPowerOutputValue() {
     return getTileEntity().getPowerUsePerTick();
   }
-  
+
   protected void updatePowerBarTooltip(List<String> text) {
     text.add(getPowerOutputLabel() + " " + PowerDisplayUtil.formatPower(getPowerOutputValue()) + " " + PowerDisplayUtil.abrevation()
         + PowerDisplayUtil.perTickStr());
@@ -52,8 +55,8 @@ public abstract class GuiPoweredMachineBase<T extends AbstractPoweredMachineEnti
   }
 
   public void renderPowerBar(int k, int l) {
-    if(renderPowerBar()) {      
-      int i1 = getTileEntity().getEnergyStoredScaled(getPowerHeight());      
+    if(renderPowerBar()) {
+      int i1 = getTileEntity().getEnergyStoredScaled(getPowerHeight());
       // x, y, u, v, width, height
       drawTexturedModalRect(k + getPowerX(), l + (getPowerY() + getPowerHeight()) - i1, getPowerU(), getPowerV(), getPowerWidth(), i1);
     }

--- a/src/main/java/crazypants/enderio/machine/hypercube/BlockHyperCube.java
+++ b/src/main/java/crazypants/enderio/machine/hypercube/BlockHyperCube.java
@@ -20,12 +20,13 @@ import net.minecraft.world.World;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.util.ForgeDirection;
 import cpw.mods.fml.common.FMLCommonHandler;
-import cpw.mods.fml.common.network.IGuiHandler;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import crazypants.enderio.BlockEio;
-import crazypants.enderio.EnderIO;
 import crazypants.enderio.GuiHandler;
+import crazypants.enderio.CommonProxy;
+import crazypants.enderio.EnderIO;
+import crazypants.enderio.ISidedGuiHandler;
 import crazypants.enderio.ModObject;
 import crazypants.enderio.gui.IResourceTooltipProvider;
 import crazypants.enderio.machine.hypercube.TileHyperCube.IoMode;
@@ -35,7 +36,7 @@ import crazypants.enderio.power.PowerHandlerUtil;
 import crazypants.util.PlayerUtil;
 import crazypants.util.Util;
 
-public class BlockHyperCube extends BlockEio implements IGuiHandler, IResourceTooltipProvider {
+public class BlockHyperCube extends BlockEio implements ISidedGuiHandler, IResourceTooltipProvider {
 
   static final NumberFormat NF = NumberFormat.getIntegerInstance();
 
@@ -66,9 +67,10 @@ public class BlockHyperCube extends BlockEio implements IGuiHandler, IResourceTo
   @Override
   protected void init() {
     super.init();
-    EnderIO.guiHandler.registerGuiHandler(GuiHandler.GUI_ID_HYPER_CUBE, this);
+    CommonProxy.guiHandler.registerGuiHandler(GuiHandler.GUI_ID_HYPER_CUBE, this);
   }
 
+  @SideOnly(Side.CLIENT)
   public IIcon getPortalIcon() {
     return blockIcon;
   }
@@ -245,6 +247,7 @@ public class BlockHyperCube extends BlockEio implements IGuiHandler, IResourceTo
   }
 
   @Override
+  @SideOnly(Side.CLIENT)
   public Object getClientGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z) {
     TileEntity te = world.getTileEntity(x, y, z);
     if(te instanceof TileHyperCube) {

--- a/src/main/java/crazypants/enderio/machine/hypercube/GuiHyperCube.java
+++ b/src/main/java/crazypants/enderio/machine/hypercube/GuiHyperCube.java
@@ -10,6 +10,8 @@ import net.minecraft.client.gui.GuiButton;
 
 import org.lwjgl.opengl.GL11;
 
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import crazypants.enderio.gui.IGuiOverlay;
 import crazypants.enderio.gui.IconButtonEIO;
 import crazypants.enderio.gui.IconEIO;
@@ -30,6 +32,7 @@ import crazypants.util.BlockCoord;
 import crazypants.util.Lang;
 import crazypants.util.PlayerUtil;
 
+@SideOnly(Side.CLIENT)
 public class GuiHyperCube extends GuiContainerBase {
 
   protected static final int POWER_INPUT_BUTTON_ID = 1;

--- a/src/main/java/crazypants/enderio/machine/killera/BlockKillerJoe.java
+++ b/src/main/java/crazypants/enderio/machine/killera/BlockKillerJoe.java
@@ -12,17 +12,10 @@ import net.minecraftforge.event.entity.player.PlayerEvent;
 import net.minecraftforge.fluids.FluidStack;
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import crazypants.enderio.GuiHandler;
 import crazypants.enderio.ModObject;
-import crazypants.enderio.gui.IResourceTooltipProvider;
 import crazypants.enderio.machine.AbstractMachineBlock;
-import crazypants.enderio.machine.generator.zombie.ContainerZombieGenerator;
-import crazypants.enderio.machine.generator.zombie.GuiZombieGenerator;
-import crazypants.enderio.machine.generator.zombie.PacketZombieTank;
-import crazypants.enderio.machine.generator.zombie.TileZombieGenerator;
-import crazypants.enderio.machine.tank.BlockTank;
-import crazypants.enderio.machine.tank.PacketTank;
-import crazypants.enderio.machine.tank.TileTank;
 import crazypants.enderio.network.PacketHandler;
 import crazypants.enderio.xp.PacketExperianceContainer;
 import crazypants.enderio.xp.PacketGivePlayerXP;
@@ -35,13 +28,13 @@ import crazypants.util.Util;
 public class BlockKillerJoe extends AbstractMachineBlock<TileKillerJoe> {
 
   static final String USERNAME = "KillerJoe";
-  
+
   public static BlockKillerJoe create() {
     PacketHandler.INSTANCE.registerMessage(PacketNutrientLevel.class, PacketNutrientLevel.class, PacketHandler.nextID(), Side.CLIENT);
-    PacketHandler.INSTANCE.registerMessage(PacketSwing.class, PacketSwing.class, PacketHandler.nextID(), Side.CLIENT);    
+    PacketHandler.INSTANCE.registerMessage(PacketSwing.class, PacketSwing.class, PacketHandler.nextID(), Side.CLIENT);
     PacketGivePlayerXP.register();
     PacketExperianceContainer.register();
-    
+
     BlockKillerJoe res = new BlockKillerJoe();
     MinecraftForge.EVENT_BUS.register(res);
     res.init();
@@ -50,21 +43,21 @@ public class BlockKillerJoe extends AbstractMachineBlock<TileKillerJoe> {
 
   protected BlockKillerJoe() {
     super(ModObject.blockKillerJoe, TileKillerJoe.class);
-    setStepSound(Block.soundTypeGlass);    
+    setStepSound(Block.soundTypeGlass);
   }
-  
+
   @Override
   public float getExplosionResistance(Entity par1Entity, World world, int x, int y, int z, double explosionX, double explosionY, double explosionZ) {
     return 2000;
   }
-  
+
   @SubscribeEvent
   public void getKillDisplayName(PlayerEvent.NameFormat nameEvt)  {
     if(nameEvt.username != null && nameEvt.username.startsWith(USERNAME)) {
       nameEvt.displayname = getLocalizedName();
     }
   }
-  
+
   @Override
   public boolean onBlockActivated(World world, int x, int y, int z, EntityPlayer entityPlayer, int par6, float par7, float par8, float par9) {
 
@@ -101,6 +94,7 @@ public class BlockKillerJoe extends AbstractMachineBlock<TileKillerJoe> {
   }
 
   @Override
+  @SideOnly(Side.CLIENT)
   public Object getClientGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z) {
     return new GuiKillerJoe(player.inventory, (TileKillerJoe) world.getTileEntity(x, y, z));
   }
@@ -114,7 +108,7 @@ public class BlockKillerJoe extends AbstractMachineBlock<TileKillerJoe> {
   protected String getMachineFrontIconKey(boolean active) {
     return "enderio:blankMachinePanel";
   }
-  
+
   @Override
   public int getRenderType() {
     return -1;
@@ -129,7 +123,8 @@ public class BlockKillerJoe extends AbstractMachineBlock<TileKillerJoe> {
   public boolean isOpaqueCube() {
     return false;
   }
-  
+
+  @Override
   protected short getFacingForHeading(int heading) {
     switch (heading) {
     case 0:
@@ -137,11 +132,11 @@ public class BlockKillerJoe extends AbstractMachineBlock<TileKillerJoe> {
     case 1:
       return 4;
     case 2:
-      return 2;      
+      return 2;
     case 3:
     default:
-      return 5;    
+      return 5;
     }
   }
-  
+
 }

--- a/src/main/java/crazypants/enderio/machine/killera/GuiKillerJoe.java
+++ b/src/main/java/crazypants/enderio/machine/killera/GuiKillerJoe.java
@@ -7,6 +7,8 @@ import net.minecraft.entity.player.InventoryPlayer;
 
 import org.lwjgl.opengl.GL11;
 
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import crazypants.enderio.fluid.Fluids;
 import crazypants.enderio.gui.IconButtonEIO;
 import crazypants.enderio.gui.IconEIO;
@@ -20,6 +22,7 @@ import crazypants.render.RenderUtil;
 import crazypants.util.Lang;
 import crazypants.util.SoundUtil;
 
+@SideOnly(Side.CLIENT)
 public class GuiKillerJoe extends GuiMachineBase<TileKillerJoe> {
 
   private static final int XP_ID = 3489;

--- a/src/main/java/crazypants/enderio/machine/monitor/BlockPowerMonitor.java
+++ b/src/main/java/crazypants/enderio/machine/monitor/BlockPowerMonitor.java
@@ -6,6 +6,7 @@ import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import crazypants.enderio.GuiHandler;
 import crazypants.enderio.ModObject;
 import crazypants.enderio.machine.AbstractMachineBlock;
@@ -30,10 +31,11 @@ public class BlockPowerMonitor extends AbstractMachineBlock<TilePowerMonitor> {
 
   @Override
   public Object getServerGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z) {
-    return new ContainerPowerMonitor();    
+    return new ContainerPowerMonitor();
   }
 
   @Override
+  @SideOnly(Side.CLIENT)
   public Object getClientGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z) {
     TileEntity te = world.getTileEntity(x, y, z);
     if(te instanceof TilePowerMonitor) {

--- a/src/main/java/crazypants/enderio/machine/monitor/GuiPowerMonitor.java
+++ b/src/main/java/crazypants/enderio/machine/monitor/GuiPowerMonitor.java
@@ -1,6 +1,7 @@
 package crazypants.enderio.machine.monitor;
 
-import static crazypants.enderio.machine.power.PowerDisplayUtil.*;
+import static crazypants.enderio.machine.power.PowerDisplayUtil.formatPower;
+import static crazypants.enderio.machine.power.PowerDisplayUtil.formatPowerFloat;
 
 import java.awt.Color;
 import java.awt.Rectangle;
@@ -12,6 +13,8 @@ import net.minecraft.client.gui.GuiTextField;
 
 import org.lwjgl.opengl.GL11;
 
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import crazypants.enderio.gui.CheckBoxEIO;
 import crazypants.enderio.gui.TextFieldEIO;
 import crazypants.enderio.machine.power.PowerDisplayUtil;
@@ -22,6 +25,7 @@ import crazypants.render.ColorUtil;
 import crazypants.render.RenderUtil;
 import crazypants.util.Lang;
 
+@SideOnly(Side.CLIENT)
 public class GuiPowerMonitor extends GuiContainerBase {
 
   private static final NumberFormat INT_NF = NumberFormat.getIntegerInstance();
@@ -69,7 +73,7 @@ public class GuiPowerMonitor extends GuiContainerBase {
     super(new ContainerPowerMonitor());
     this.te = te;
     xSize = WIDTH;
-    ySize = HEIGHT;    
+    ySize = HEIGHT;
 
     titleStr = Lang.localize("gui.powerMonitor.engineControl");
     engineTxt1 = Lang.localize("gui.powerMonitor.engineSection1");
@@ -140,7 +144,7 @@ public class GuiPowerMonitor extends GuiContainerBase {
   }
 
   @Override
-  public int getOverlayOffsetX() {  
+  public int getOverlayOffsetX() {
     return 0;
   }
 
@@ -168,7 +172,7 @@ public class GuiPowerMonitor extends GuiContainerBase {
 
   @Override
   protected void drawGuiContainerBackgroundLayer(float ptick, int mouseX, int mouseY) {
-  
+
     GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
     RenderUtil.bindTexture("enderio:textures/gui/powerMonitor.png");
     int sx = (width - xSize) / 2;

--- a/src/main/java/crazypants/enderio/machine/power/BlockCapacitorBank.java
+++ b/src/main/java/crazypants/enderio/machine/power/BlockCapacitorBank.java
@@ -20,13 +20,14 @@ import net.minecraft.util.IIcon;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
-import cpw.mods.fml.common.network.IGuiHandler;
 import cpw.mods.fml.common.registry.GameRegistry;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import crazypants.enderio.BlockEio;
-import crazypants.enderio.EnderIO;
 import crazypants.enderio.GuiHandler;
+import crazypants.enderio.CommonProxy;
+import crazypants.enderio.EnderIO;
+import crazypants.enderio.ISidedGuiHandler;
 import crazypants.enderio.ModObject;
 import crazypants.enderio.gui.IAdvancedTooltipProvider;
 import crazypants.enderio.gui.TooltipAddera;
@@ -40,7 +41,7 @@ import crazypants.util.Lang;
 import crazypants.util.Util;
 import crazypants.vecmath.Vector3d;
 
-public class BlockCapacitorBank extends BlockEio implements IGuiHandler, IAdvancedTooltipProvider, IWailaInfoProvider {
+public class BlockCapacitorBank extends BlockEio implements ISidedGuiHandler, IAdvancedTooltipProvider, IWailaInfoProvider {
 
   public static int renderId = -1;
 
@@ -74,7 +75,7 @@ public class BlockCapacitorBank extends BlockEio implements IGuiHandler, IAdvanc
       GameRegistry.registerTileEntity(teClass, name + "TileEntity");
     }
 
-    EnderIO.guiHandler.registerGuiHandler(GuiHandler.GUI_ID_CAPACITOR_BANK, this);
+    CommonProxy.guiHandler.registerGuiHandler(GuiHandler.GUI_ID_CAPACITOR_BANK, this);
     setLightOpacity(255);
   }
 
@@ -160,6 +161,7 @@ public class BlockCapacitorBank extends BlockEio implements IGuiHandler, IAdvanc
   }
 
   @Override
+  @SideOnly(Side.CLIENT)
   public Object getClientGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z) {
     TileEntity te = world.getTileEntity(x, y, z);
     if(te instanceof TileCapacitorBank) {

--- a/src/main/java/crazypants/enderio/machine/power/GuiCapacitorBank.java
+++ b/src/main/java/crazypants/enderio/machine/power/GuiCapacitorBank.java
@@ -14,14 +14,16 @@ import net.minecraft.entity.player.InventoryPlayer;
 
 import org.lwjgl.opengl.GL11;
 
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import crazypants.enderio.gui.IconButtonEIO;
 import crazypants.enderio.gui.IconEIO;
 import crazypants.enderio.gui.RedstoneModeButton;
 import crazypants.enderio.machine.IRedstoneModeControlable;
 import crazypants.enderio.machine.IoMode;
 import crazypants.enderio.machine.RedstoneControlMode;
-import crazypants.enderio.machine.gui.GuiPoweredMachineBase;
 import crazypants.enderio.machine.gui.GuiOverlayIoConfig;
+import crazypants.enderio.machine.gui.GuiPoweredMachineBase;
 import crazypants.enderio.network.PacketHandler;
 import crazypants.gui.GuiContainerBase;
 import crazypants.gui.GuiToolTip;
@@ -29,6 +31,7 @@ import crazypants.render.RenderUtil;
 import crazypants.util.BlockCoord;
 import crazypants.util.Lang;
 
+@SideOnly(Side.CLIENT)
 public class GuiCapacitorBank extends GuiContainerBase {
 
   protected static final int INPUT_BUTTON_ID = 18;

--- a/src/main/java/crazypants/enderio/machine/slicensplice/BlockSliceAndSplice.java
+++ b/src/main/java/crazypants/enderio/machine/slicensplice/BlockSliceAndSplice.java
@@ -14,7 +14,6 @@ import crazypants.enderio.GuiHandler;
 import crazypants.enderio.ModObject;
 import crazypants.enderio.machine.AbstractMachineBlock;
 import crazypants.enderio.machine.AbstractMachineEntity;
-import crazypants.enderio.machine.AbstractPoweredMachineEntity;
 
 public class BlockSliceAndSplice extends AbstractMachineBlock<TileSliceAndSplice> {
 
@@ -38,6 +37,7 @@ public class BlockSliceAndSplice extends AbstractMachineBlock<TileSliceAndSplice
   }
 
   @Override
+  @SideOnly(Side.CLIENT)
   public Object getClientGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z) {
     TileEntity te = world.getTileEntity(x, y, z);
     if(te instanceof TileSliceAndSplice) {
@@ -58,12 +58,12 @@ public class BlockSliceAndSplice extends AbstractMachineBlock<TileSliceAndSplice
     }
     return "enderio:sliceAndSpliceFront";
   }
-  
+
   @Override
   protected String getSideIconKey(boolean active) {
     return "enderio:blockSoulMachineSide";
   }
-  
+
   @Override
   protected String getTopIconKey(boolean active) {
     return "enderio:blockSoulMachineTop";
@@ -79,7 +79,7 @@ public class BlockSliceAndSplice extends AbstractMachineBlock<TileSliceAndSplice
   public void randomDisplayTick(World world, int x, int y, int z, Random rand) {
     TileSliceAndSplice te = (TileSliceAndSplice) world.getTileEntity(x, y, z);
     if(isActive(world, x, y, z) && te != null) {
-      
+
       ForgeDirection front = ForgeDirection.values()[te.facing];
 
       for (int i = 0; i < 2; i++) {
@@ -88,7 +88,7 @@ public class BlockSliceAndSplice extends AbstractMachineBlock<TileSliceAndSplice
         double v = 0.05;
         double vx = 0;
         double vz = 0;
-        
+
         if(front == ForgeDirection.NORTH || front == ForgeDirection.SOUTH) {
           px += world.rand.nextFloat() * 0.9 - 0.45;
           vz += front == ForgeDirection.NORTH ? -v : v;

--- a/src/main/java/crazypants/enderio/machine/slicensplice/GuiSliceAndSplice.java
+++ b/src/main/java/crazypants/enderio/machine/slicensplice/GuiSliceAndSplice.java
@@ -4,9 +4,12 @@ import net.minecraft.entity.player.InventoryPlayer;
 
 import org.lwjgl.opengl.GL11;
 
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import crazypants.enderio.machine.gui.GuiPoweredMachineBase;
 import crazypants.render.RenderUtil;
 
+@SideOnly(Side.CLIENT)
 public class GuiSliceAndSplice extends GuiPoweredMachineBase<TileSliceAndSplice> {
 
   public GuiSliceAndSplice(InventoryPlayer par1InventoryPlayer, TileSliceAndSplice te) {

--- a/src/main/java/crazypants/enderio/machine/soul/BlockSoulBinder.java
+++ b/src/main/java/crazypants/enderio/machine/soul/BlockSoulBinder.java
@@ -2,8 +2,6 @@ package crazypants.enderio.machine.soul;
 
 import java.util.Random;
 
-import cpw.mods.fml.relauncher.Side;
-import cpw.mods.fml.relauncher.SideOnly;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.particle.EntityFX;
 import net.minecraft.client.renderer.texture.IIconRegister;
@@ -11,26 +9,19 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.IIcon;
 import net.minecraft.world.World;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import crazypants.enderio.GuiHandler;
 import crazypants.enderio.ModObject;
 import crazypants.enderio.machine.AbstractMachineBlock;
 import crazypants.enderio.machine.AbstractMachineEntity;
-import crazypants.enderio.machine.MachineRecipeRegistry;
-import crazypants.enderio.machine.farm.BlockFarmStation;
-import crazypants.enderio.machine.farm.PacketFarmAction;
-import crazypants.enderio.machine.farm.PacketUpdateNotification;
-import crazypants.enderio.machine.farm.TileFarmStation;
-import crazypants.enderio.machine.painter.GuiPainter;
-import crazypants.enderio.machine.painter.PainterContainer;
-import crazypants.enderio.machine.painter.TileEntityPainter;
-import crazypants.enderio.network.PacketHandler;
 import crazypants.enderio.xp.PacketDrainPlayerXP;
 import crazypants.enderio.xp.PacketExperianceContainer;
 
 public class BlockSoulBinder extends AbstractMachineBlock<TileSoulBinder> {
-  
+
   public static int renderId;
-  
+
   public static BlockSoulBinder create() {
     PacketDrainPlayerXP.register();
     PacketExperianceContainer.register();
@@ -44,11 +35,11 @@ public class BlockSoulBinder extends AbstractMachineBlock<TileSoulBinder> {
   IIcon creeperSkullIcon;
   IIcon endermanSkullIcon;
   IIcon endermanSkullIconOn;
-  
+
   protected BlockSoulBinder() {
     super(ModObject.blockSoulBinder, TileSoulBinder.class);
-  }  
-  
+  }
+
   @Override
   public Object getServerGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z) {
     TileEntity te = world.getTileEntity(x, y, z);
@@ -59,6 +50,7 @@ public class BlockSoulBinder extends AbstractMachineBlock<TileSoulBinder> {
   }
 
   @Override
+  @SideOnly(Side.CLIENT)
   public Object getClientGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z) {
     TileEntity te = world.getTileEntity(x, y, z);
     if(te instanceof TileSoulBinder) {
@@ -81,15 +73,15 @@ public class BlockSoulBinder extends AbstractMachineBlock<TileSoulBinder> {
   public boolean isOpaqueCube() {
     return false;
   }
-  
+
   @Override
   public int getLightOpacity() {
     return 0;
   }
-  
+
   @Override
   @SideOnly(Side.CLIENT)
-  public void registerBlockIcons(IIconRegister iIconRegister) {    
+  public void registerBlockIcons(IIconRegister iIconRegister) {
     super.registerBlockIcons(iIconRegister);
     zombieSkullIcon = iIconRegister.registerIcon("enderio:skullZombie");
     creeperSkullIcon = iIconRegister.registerIcon("enderio:skullCreeper");
@@ -99,7 +91,7 @@ public class BlockSoulBinder extends AbstractMachineBlock<TileSoulBinder> {
   }
 
   @Override
-  protected String getMachineFrontIconKey(boolean active) {   
+  protected String getMachineFrontIconKey(boolean active) {
     return "enderio:blockSoulMachineBlank";
   }
 
@@ -107,16 +99,17 @@ public class BlockSoulBinder extends AbstractMachineBlock<TileSoulBinder> {
   protected String getSideIconKey(boolean active) {
     return "enderio:blockSoulMachineBlank";
   }
-  
+
+  @Override
   protected String getTopIconKey(boolean active) {
     return "enderio:blockSoulMachineTop";
   }
 
   @Override
-  public int getRenderType() {    
+  public int getRenderType() {
     return renderId;
   }
-  
+
   @SideOnly(Side.CLIENT)
   @Override
   public void randomDisplayTick(World world, int x, int y, int z, Random rand) {
@@ -128,18 +121,18 @@ public class BlockSoulBinder extends AbstractMachineBlock<TileSoulBinder> {
       for (int i = 0; i < 2; i++) {
         float xOffset = -0.2F - rand.nextFloat() * 0.6F;
         float yOffset = -0.1F + rand.nextFloat() * 0.2F;
-        float zOffset = -0.2F - rand.nextFloat() * 0.6F;        
-        
+        float zOffset = -0.2F - rand.nextFloat() * 0.6F;
+
         EntityFX fx = Minecraft.getMinecraft().renderGlobal.doSpawnParticle("spell", startX + xOffset, startY + yOffset, startZ + zOffset, 0.0D, 0.0D, 0.0D);
         //EntityFX fx = Minecraft.getMinecraft().renderGlobal.doSpawnParticle("instantSpell", startX + xOffset, startY + yOffset, startZ + zOffset, 0.0D, 0.0D, 0.0D);
         if(fx != null) {
-          fx.setRBGColorF(0.2f, 0.2f, 0.8f);          
+          fx.setRBGColorF(0.2f, 0.2f, 0.8f);
           //fx.setRBGColorF(0.1f, 0.4f, 0.1f);
           fx.motionY *= 0.5f;
         }
 
       }
     }
-  }  
+  }
 
 }

--- a/src/main/java/crazypants/enderio/machine/soul/GuiSoulBinder.java
+++ b/src/main/java/crazypants/enderio/machine/soul/GuiSoulBinder.java
@@ -6,6 +6,8 @@ import net.minecraft.entity.player.InventoryPlayer;
 
 import org.lwjgl.opengl.GL11;
 
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import crazypants.enderio.gui.IconButtonEIO;
 import crazypants.enderio.gui.IconEIO;
 import crazypants.enderio.machine.gui.GuiPoweredMachineBase;
@@ -16,35 +18,36 @@ import crazypants.enderio.xp.XpUtil;
 import crazypants.render.RenderUtil;
 import crazypants.util.SoundUtil;
 
+@SideOnly(Side.CLIENT)
 public class GuiSoulBinder extends GuiPoweredMachineBase<TileSoulBinder> {
 
   private static final int PLAYER_XP_ID = 985162394;
-  
+
   private final IconButtonEIO usePlayerXP;
 
   public GuiSoulBinder(InventoryPlayer par1InventoryPlayer, TileSoulBinder te) {
     super(te, new ContainerSoulBinder(par1InventoryPlayer, te));
     usePlayerXP = new IconButtonEIO(this, PLAYER_XP_ID, 125, 57, IconEIO.XP);
     usePlayerXP.visible = false;
-    usePlayerXP.setToolTip("Use Player XP");    
+    usePlayerXP.setToolTip("Use Player XP");
 
     addProgressTooltip(80, 34, 24, 16);
   }
 
   @Override
-  public void initGui() {    
+  public void initGui() {
     super.initGui();
     usePlayerXP.onGuiInit();
   }
 
   @Override
-  protected void actionPerformed(GuiButton b) {    
+  protected void actionPerformed(GuiButton b) {
     super.actionPerformed(b);
     if(b.id == PLAYER_XP_ID) {
       int xp = XpUtil.getPlayerXP(Minecraft.getMinecraft().thePlayer);
       if(xp > 0 || Minecraft.getMinecraft().thePlayer.capabilities.isCreativeMode) {
         PacketHandler.INSTANCE.sendToServer(new PacketDrainPlayerXP(getTileEntity(), getTileEntity().getCurrentlyRequiredLevel(), true));
-        SoundUtil.playClientSoundFX("random.orb", getTileEntity());        
+        SoundUtil.playClientSoundFX("random.orb", getTileEntity());
       }
     }
   }
@@ -64,20 +67,20 @@ public class GuiSoulBinder extends GuiPoweredMachineBase<TileSoulBinder> {
     int i1;
 
     TileSoulBinder binder = getTileEntity();
-    
+
     if(shouldRenderProgress()) {
       i1 = binder.getProgressScaled(24);
       drawTexturedModalRect(k + 80, l + 34, 176, 14, i1 + 1, 16);
     }
 
     boolean needsXp = binder.getCurrentlyRequiredLevel() > 0 && binder.getCurrentlyRequiredLevel() > binder.getContainer().getExperienceLevel();
-    usePlayerXP.visible = needsXp;        
-    
+    usePlayerXP.visible = needsXp;
+
     ExperienceBarRenderer.render(this, getGuiLeft() + 56, getGuiTop() + 68, 65, binder.getContainer(), binder.getCurrentlyRequiredLevel());
-    
+
     RenderUtil.bindTexture("enderio:textures/gui/soulFuser.png");
     super.drawGuiContainerBackgroundLayer(par1, par2, par3);
-    
+
   }
 
 }

--- a/src/main/java/crazypants/enderio/machine/spawner/BlockPoweredSpawner.java
+++ b/src/main/java/crazypants/enderio/machine/spawner/BlockPoweredSpawner.java
@@ -121,7 +121,7 @@ public class BlockPoweredSpawner extends AbstractMachineBlock<TilePoweredSpawner
           if(Math.random() > Config.brokenSpawnerDropChance) {
             return;
           }
-          
+
           ItemStack equipped = evt.getPlayer().getCurrentEquippedItem();
           if(equipped != null) {
             for (UniqueIdentifier uid : toolBlackList) {
@@ -218,6 +218,7 @@ public class BlockPoweredSpawner extends AbstractMachineBlock<TilePoweredSpawner
   }
 
   @Override
+  @SideOnly(Side.CLIENT)
   public Object getClientGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z) {
     TileEntity te = world.getTileEntity(x, y, z);
     if(te instanceof TilePoweredSpawner) {

--- a/src/main/java/crazypants/enderio/machine/spawner/GuiPoweredSpawner.java
+++ b/src/main/java/crazypants/enderio/machine/spawner/GuiPoweredSpawner.java
@@ -8,6 +8,8 @@ import net.minecraft.entity.player.InventoryPlayer;
 
 import org.lwjgl.opengl.GL11;
 
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import crazypants.enderio.gui.IconButtonEIO;
 import crazypants.enderio.gui.IconEIO;
 import crazypants.enderio.machine.gui.GuiPoweredMachineBase;
@@ -16,6 +18,7 @@ import crazypants.render.ColorUtil;
 import crazypants.render.RenderUtil;
 import crazypants.util.Lang;
 
+@SideOnly(Side.CLIENT)
 public class GuiPoweredSpawner extends GuiPoweredMachineBase<TilePoweredSpawner> {
 
   private IconButtonEIO modeB;
@@ -55,7 +58,7 @@ public class GuiPoweredSpawner extends GuiPoweredMachineBase<TilePoweredSpawner>
     super.drawGuiContainerBackgroundLayer(par1, par2, par3);
 
     TilePoweredSpawner spawner = getTileEntity();
-    
+
     int left = getGuiLeft();
     int top = getGuiTop();
 

--- a/src/main/java/crazypants/enderio/machine/spawnguard/BlockSpawnGuard.java
+++ b/src/main/java/crazypants/enderio/machine/spawnguard/BlockSpawnGuard.java
@@ -6,7 +6,6 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.particle.EntityFX;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.tileentity.TileEntity;
-import net.minecraft.util.AxisAlignedBB;
 import net.minecraft.world.World;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
@@ -17,17 +16,17 @@ import crazypants.enderio.machine.AbstractMachineBlock;
 public class BlockSpawnGuard extends AbstractMachineBlock<TileSpawnGuard> {
 
   public static int renderId;
-  
+
   public static BlockSpawnGuard create() {
     BlockSpawnGuard res = new BlockSpawnGuard();
     res.init();
-    
+
     //Just making sure its loaded
     SpawnGuardController.instance.toString();
-    
+
     return res;
   }
-  
+
   protected BlockSpawnGuard() {
     super(ModObject.blockSpawnGuard, TileSpawnGuard.class);
     setObeliskBounds();
@@ -43,6 +42,7 @@ public class BlockSpawnGuard extends AbstractMachineBlock<TileSpawnGuard> {
   }
 
   @Override
+  @SideOnly(Side.CLIENT)
   public Object getClientGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z) {
     TileEntity te = world.getTileEntity(x, y, z);
     if(te instanceof TileSpawnGuard) {
@@ -52,7 +52,7 @@ public class BlockSpawnGuard extends AbstractMachineBlock<TileSpawnGuard> {
   }
 
   @Override
-  protected int getGuiId() {    
+  protected int getGuiId() {
     return GuiHandler.GUI_ID_SPAWN_GUARD;
   }
 
@@ -63,7 +63,7 @@ public class BlockSpawnGuard extends AbstractMachineBlock<TileSpawnGuard> {
     }
     return "enderio:blockAttractorSide";
   }
-  
+
   @Override
   protected String getSideIconKey(boolean active) {
     if(active) {
@@ -94,14 +94,14 @@ public class BlockSpawnGuard extends AbstractMachineBlock<TileSpawnGuard> {
   public boolean isOpaqueCube() {
     return false;
   }
-  
+
   @Override
   public int getLightOpacity() {
     return 0;
   }
-  
+
   @Override
-  public int getRenderType() {    
+  public int getRenderType() {
     return renderId;
   }
 
@@ -115,16 +115,16 @@ public class BlockSpawnGuard extends AbstractMachineBlock<TileSpawnGuard> {
       for (int i = 0; i < 1; i++) {
         float xOffset = -0.2F - rand.nextFloat() * 0.6F;
         float yOffset = -0.1F + rand.nextFloat() * 0.2F;
-        float zOffset = -0.2F - rand.nextFloat() * 0.6F;        
-        
+        float zOffset = -0.2F - rand.nextFloat() * 0.6F;
+
         EntityFX fx = Minecraft.getMinecraft().renderGlobal.doSpawnParticle("spell", startX + xOffset, startY + yOffset, startZ + zOffset, 0.0D, 0.0D, 0.0D);
         if(fx != null) {
-          fx.setRBGColorF(0.2f, 0.2f, 0.8f);          
+          fx.setRBGColorF(0.2f, 0.2f, 0.8f);
           fx.motionY *= 0.5f;
         }
 
       }
     }
-  }  
+  }
 
 }

--- a/src/main/java/crazypants/enderio/machine/spawnguard/GuiSpawnGurad.java
+++ b/src/main/java/crazypants/enderio/machine/spawnguard/GuiSpawnGurad.java
@@ -7,6 +7,8 @@ import net.minecraft.entity.player.InventoryPlayer;
 
 import org.lwjgl.opengl.GL11;
 
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import crazypants.enderio.gui.IconEIO;
 import crazypants.enderio.gui.ToggleButtonEIO;
 import crazypants.enderio.machine.gui.GuiPoweredMachineBase;
@@ -14,23 +16,24 @@ import crazypants.render.ColorUtil;
 import crazypants.render.RenderUtil;
 import crazypants.util.Lang;
 
+@SideOnly(Side.CLIENT)
 public class GuiSpawnGurad extends GuiPoweredMachineBase<TileSpawnGuard> {
 
   ToggleButtonEIO showRangeB;
-  
+
   private static final int RANGE_ID = 8738924;
-  
+
   public GuiSpawnGurad(InventoryPlayer par1InventoryPlayer, TileSpawnGuard te) {
     super(te, new ContainerSpawnGuard(par1InventoryPlayer, te));
-    
+
     int x = getXSize() - 5 - BUTTON_SIZE;
     showRangeB = new ToggleButtonEIO(this, RANGE_ID, x, 44, IconEIO.ADD_BUT, IconEIO.ADD_BUT);
     showRangeB.setSize(BUTTON_SIZE, BUTTON_SIZE);
     showRangeB.setToolTip(Lang.localize("gui.spawnGurad.showRange"));
   }
-  
+
   @Override
-  public void initGui() {    
+  public void initGui() {
     super.initGui();
     showRangeB.onGuiInit();
     showRangeB.setSelected(getTileEntity().isShowingRange());
@@ -44,23 +47,23 @@ public class GuiSpawnGurad extends GuiPoweredMachineBase<TileSpawnGuard> {
     int sy = (height - ySize) / 2;
 
     drawTexturedModalRect(sx, sy, 0, 0, xSize, ySize);
-    
+
     super.drawGuiContainerBackgroundLayer(par1, par2, par3);
-    
+
     int range = (int) getTileEntity().getRange();
     drawCenteredString(fontRendererObj, Lang.localize("gui.spawnGurad.range") + " " + range, getGuiLeft() + sx/2 + 9, getGuiTop() + 68, ColorUtil.getRGB(Color.white));
   }
 
   @Override
-  protected void actionPerformed(GuiButton b) {    
+  protected void actionPerformed(GuiButton b) {
     super.actionPerformed(b);
     if(b.id == RANGE_ID) {
-      getTileEntity().setShowRange(showRangeB.isSelected());      
+      getTileEntity().setShowRange(showRangeB.isSelected());
     }
   }
 
   @Override
-  protected boolean showRecipeButton() {    
+  protected boolean showRecipeButton() {
     return false;
   }
 

--- a/src/main/java/crazypants/enderio/machine/tank/BlockTank.java
+++ b/src/main/java/crazypants/enderio/machine/tank/BlockTank.java
@@ -22,8 +22,8 @@ import cpw.mods.fml.common.registry.GameRegistry;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import crazypants.enderio.ClientProxy;
-import crazypants.enderio.EnderIO;
 import crazypants.enderio.GuiHandler;
+import crazypants.enderio.CommonProxy;
 import crazypants.enderio.ModObject;
 import crazypants.enderio.gui.IAdvancedTooltipProvider;
 import crazypants.enderio.gui.TooltipAddera;
@@ -54,7 +54,7 @@ public class BlockTank extends AbstractMachineBlock<TileTank> implements IAdvanc
   protected void init() {
     GameRegistry.registerBlock(this, BlockItemTank.class, modObject.unlocalisedName);
     GameRegistry.registerTileEntity(teClass, modObject.unlocalisedName + "TileEntity");
-    EnderIO.guiHandler.registerGuiHandler(getGuiId(), this);
+    CommonProxy.guiHandler.registerGuiHandler(getGuiId(), this);
   }
 
   @Override
@@ -156,6 +156,7 @@ public class BlockTank extends AbstractMachineBlock<TileTank> implements IAdvanc
   }
 
   @Override
+  @SideOnly(Side.CLIENT)
   public Object getClientGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z) {
     TileEntity te = world.getTileEntity(x, y, z);
     if(!(te instanceof TileTank)) {

--- a/src/main/java/crazypants/enderio/machine/tank/GuiTank.java
+++ b/src/main/java/crazypants/enderio/machine/tank/GuiTank.java
@@ -6,12 +6,15 @@ import net.minecraft.entity.player.InventoryPlayer;
 
 import org.lwjgl.opengl.GL11;
 
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import crazypants.enderio.fluid.Fluids;
 import crazypants.enderio.machine.gui.GuiMachineBase;
 import crazypants.gui.GuiToolTip;
 import crazypants.render.RenderUtil;
 import crazypants.util.Lang;
 
+@SideOnly(Side.CLIENT)
 public class GuiTank extends GuiMachineBase<TileTank> {
 
   private TileTank entity;
@@ -19,7 +22,7 @@ public class GuiTank extends GuiMachineBase<TileTank> {
   public GuiTank(InventoryPlayer par1InventoryPlayer, TileTank te) {
     super(te, new ContainerTank(par1InventoryPlayer, te));
     entity = te;
-    
+
     addToolTip(new GuiToolTip(new Rectangle(80, 21, 16, 47), "") {
 
       @Override
@@ -51,9 +54,9 @@ public class GuiTank extends GuiMachineBase<TileTank> {
     drawTexturedModalRect(sx, sy, 0, 0, xSize, ySize);
 
     super.drawGuiContainerBackgroundLayer(par1, par2, par3);
-    
+
     RenderUtil.bindBlockTexture();
-    RenderUtil.renderGuiTank(entity.tank, guiLeft + 80, guiTop + 21, zLevel, 16,47);    
+    RenderUtil.renderGuiTank(entity.tank, guiLeft + 80, guiTop + 21, zLevel, 16,47);
 
   }
 

--- a/src/main/java/crazypants/enderio/machine/transceiver/BlockTransceiver.java
+++ b/src/main/java/crazypants/enderio/machine/transceiver/BlockTransceiver.java
@@ -70,6 +70,7 @@ public class BlockTransceiver extends AbstractMachineBlock<TileTransceiver> {
   }
 
   @Override
+  @SideOnly(Side.CLIENT)
   public Object getClientGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z) {
     TileEntity te = world.getTileEntity(x, y, z);
     return new GuiTransceiver(player.inventory, (TileTransceiver) te);

--- a/src/main/java/crazypants/enderio/machine/transceiver/gui/GuiTransceiver.java
+++ b/src/main/java/crazypants/enderio/machine/transceiver/gui/GuiTransceiver.java
@@ -11,7 +11,8 @@ import net.minecraft.entity.player.InventoryPlayer;
 import org.lwjgl.opengl.GL11;
 
 import cpw.mods.fml.common.Optional;
-
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import crazypants.enderio.config.Config;
 import crazypants.enderio.gui.IGuiOverlay;
 import crazypants.enderio.gui.ITabPanel;
@@ -21,6 +22,7 @@ import crazypants.enderio.machine.transceiver.ChannelType;
 import crazypants.enderio.machine.transceiver.TileTransceiver;
 import crazypants.render.RenderUtil;
 
+@SideOnly(Side.CLIENT)
 public class GuiTransceiver extends GuiPoweredMachineBase<TileTransceiver> {
 
   private static final int TAB_HEIGHT = 24;
@@ -33,13 +35,13 @@ public class GuiTransceiver extends GuiPoweredMachineBase<TileTransceiver> {
   public GuiTransceiver(InventoryPlayer par1InventoryPlayer, TileTransceiver te) {
     super(te, new ContainerTransceiver(par1InventoryPlayer, te));
 
-    generalTab = new GeneralTab(this); 
+    generalTab = new GeneralTab(this);
     tabs.add(generalTab);
     FilterTab filterTab = new FilterTab(this);
     tabs.add(filterTab);
     tabs.add(new ChannelTab(this, ChannelType.POWER));
     tabs.add(new ChannelTab(this, ChannelType.ITEM));
-    tabs.add(new ChannelTab(this, ChannelType.FLUID));  
+    tabs.add(new ChannelTab(this, ChannelType.FLUID));
     if(Config.enderRailEnabled) {
       tabs.add(new ChannelTab(this, ChannelType.RAIL));
     }
@@ -47,7 +49,7 @@ public class GuiTransceiver extends GuiPoweredMachineBase<TileTransceiver> {
 
   @Override
   protected void updatePowerBarTooltip(List<String> text) {
-    generalTab.updatePowerBarTooltip(text);    
+    generalTab.updatePowerBarTooltip(text);
   }
 
   @Override
@@ -132,7 +134,7 @@ public class GuiTransceiver extends GuiPoweredMachineBase<TileTransceiver> {
   public int getPowerY() {
     return super.getPowerY();
   }
-  
+
   @Override
   public int getPowerWidth() {
     return POWER_WIDTH;
@@ -148,7 +150,7 @@ public class GuiTransceiver extends GuiPoweredMachineBase<TileTransceiver> {
     return 246;
   }
 
-  
+
   @Override
   public String getPowerOutputLabel() {
     return super.getPowerOutputLabel();
@@ -228,11 +230,11 @@ public class GuiTransceiver extends GuiPoweredMachineBase<TileTransceiver> {
       tes.draw();
     }
   }
-  
+
   public TileTransceiver getTransciever() {
     return getTileEntity();
   }
-  
+
   public ContainerTransceiver getContainer() {
     return (ContainerTransceiver) inventorySlots;
   }

--- a/src/main/java/crazypants/enderio/machine/vacuum/BlockVacuumChest.java
+++ b/src/main/java/crazypants/enderio/machine/vacuum/BlockVacuumChest.java
@@ -8,18 +8,20 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
-import cpw.mods.fml.common.network.IGuiHandler;
 import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import crazypants.enderio.BlockEio;
-import crazypants.enderio.EnderIO;
 import crazypants.enderio.GuiHandler;
+import crazypants.enderio.CommonProxy;
+import crazypants.enderio.EnderIO;
+import crazypants.enderio.ISidedGuiHandler;
 import crazypants.enderio.ModObject;
 import crazypants.enderio.TileEntityEio;
 import crazypants.enderio.api.redstone.IRedstoneConnectable;
 import crazypants.enderio.gui.IResourceTooltipProvider;
 import crazypants.enderio.network.PacketHandler;
 
-public class BlockVacuumChest extends BlockEio implements IGuiHandler, IResourceTooltipProvider, IRedstoneConnectable {
+public class BlockVacuumChest extends BlockEio implements ISidedGuiHandler, IResourceTooltipProvider, IRedstoneConnectable {
 
   public static BlockVacuumChest create() {
     PacketHandler.INSTANCE.registerMessage(PacketVaccumChest.class,PacketVaccumChest.class,PacketHandler.nextID(), Side.SERVER);
@@ -51,7 +53,7 @@ public class BlockVacuumChest extends BlockEio implements IGuiHandler, IResource
   @Override
   protected void init() {
     super.init();
-    EnderIO.guiHandler.registerGuiHandler(GuiHandler.GUI_ID_VACUUM_CHEST, this);
+    CommonProxy.guiHandler.registerGuiHandler(GuiHandler.GUI_ID_VACUUM_CHEST, this);
   }
 
   @Override
@@ -106,6 +108,7 @@ public class BlockVacuumChest extends BlockEio implements IGuiHandler, IResource
   }
 
   @Override
+  @SideOnly(Side.CLIENT)
   public Object getClientGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z) {
     TileEntity te = world.getTileEntity(x, y, z);
     if(te instanceof TileVacuumChest) {

--- a/src/main/java/crazypants/enderio/machine/vacuum/GuiVacuumChest.java
+++ b/src/main/java/crazypants/enderio/machine/vacuum/GuiVacuumChest.java
@@ -1,7 +1,18 @@
 package crazypants.enderio.machine.vacuum;
 
+import java.awt.Color;
+import java.awt.Rectangle;
+
+import net.minecraft.client.gui.FontRenderer;
+import net.minecraft.client.gui.GuiButton;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.entity.player.InventoryPlayer;
+import net.minecraft.item.ItemStack;
+
 import org.lwjgl.opengl.GL11;
 
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import crazypants.enderio.conduit.item.filter.ItemFilter;
 import crazypants.enderio.gui.IconButtonEIO;
 import crazypants.enderio.gui.IconEIO;
@@ -15,14 +26,8 @@ import crazypants.render.ColorUtil;
 import crazypants.render.RenderUtil;
 import crazypants.util.BlockCoord;
 import crazypants.util.Lang;
-import java.awt.Color;
-import java.awt.Rectangle;
-import net.minecraft.client.gui.FontRenderer;
-import net.minecraft.client.gui.GuiButton;
-import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.entity.player.InventoryPlayer;
-import net.minecraft.item.ItemStack;
 
+@SideOnly(Side.CLIENT)
 public class GuiVacuumChest extends GuiContainerBase {
 
   private static final int RANGE_LEFT  = 145;
@@ -195,6 +200,7 @@ public class GuiVacuumChest extends GuiContainerBase {
     fr.drawString(str, sx + RANGE_LEFT + RANGE_WIDTH - sw - 5, sy + RANGE_TOP + 5, ColorUtil.getRGB(Color.black));
   }
 
+  @SideOnly(Side.CLIENT)
   class FilterGhostSlot extends GhostSlot {
     final int slot;
     FilterGhostSlot(int slot, int x, int y) {

--- a/src/main/java/crazypants/enderio/machine/vat/BlockVat.java
+++ b/src/main/java/crazypants/enderio/machine/vat/BlockVat.java
@@ -234,6 +234,7 @@ public class BlockVat extends AbstractMachineBlock<TileVat> {
   }
 
   @Override
+  @SideOnly(Side.CLIENT)
   public Object getClientGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z) {
     TileEntity te = world.getTileEntity(x, y, z);
     if(te instanceof TileVat) {

--- a/src/main/java/crazypants/enderio/machine/vat/GuiVat.java
+++ b/src/main/java/crazypants/enderio/machine/vat/GuiVat.java
@@ -11,6 +11,8 @@ import net.minecraftforge.fluids.Fluid;
 
 import org.lwjgl.opengl.GL11;
 
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import crazypants.enderio.fluid.Fluids;
 import crazypants.enderio.gui.IconButtonEIO;
 import crazypants.enderio.gui.IconEIO;
@@ -22,6 +24,7 @@ import crazypants.render.ColorUtil;
 import crazypants.render.RenderUtil;
 import crazypants.util.Lang;
 
+@SideOnly(Side.CLIENT)
 public class GuiVat extends GuiPoweredMachineBase<TileVat> {
 
   private static final String GUI_TEXTURE = "enderio:textures/gui/vat.png";
@@ -101,7 +104,7 @@ public class GuiVat extends GuiPoweredMachineBase<TileVat> {
     RenderUtil.bindTexture(GUI_TEXTURE);
     drawTexturedModalRect(guiLeft, guiTop, 0, 0, xSize, ySize);
     TileVat vat = getTileEntity();
-    
+
     if(shouldRenderProgress()) {
       int scaled = vat.getProgressScaled(14) + 1;
       drawTexturedModalRect(guiLeft + 81, guiTop + 77 - scaled, 176, 14 - scaled, 14, scaled);

--- a/src/main/java/crazypants/enderio/machine/weather/BlockWeatherObelisk.java
+++ b/src/main/java/crazypants/enderio/machine/weather/BlockWeatherObelisk.java
@@ -35,6 +35,7 @@ public class BlockWeatherObelisk extends AbstractMachineBlock<TileWeatherObelisk
   }
 
   @Override
+  @SideOnly(Side.CLIENT)
   public Object getClientGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z) {
     return new GuiWeatherObelisk(player.inventory, (TileWeatherObelisk) world.getTileEntity(x, y, z));
   }

--- a/src/main/java/crazypants/enderio/machine/weather/GuiWeatherObelisk.java
+++ b/src/main/java/crazypants/enderio/machine/weather/GuiWeatherObelisk.java
@@ -12,6 +12,8 @@ import net.minecraft.util.ResourceLocation;
 
 import org.lwjgl.opengl.GL11;
 
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import crazypants.enderio.gui.IconButtonEIO;
 import crazypants.enderio.gui.IconEIO;
 import crazypants.enderio.machine.gui.GuiPoweredMachineBase;
@@ -19,19 +21,20 @@ import crazypants.enderio.machine.weather.TileWeatherObelisk.WeatherTask;
 import crazypants.enderio.network.PacketHandler;
 import crazypants.util.Lang;
 
+@SideOnly(Side.CLIENT)
 public class GuiWeatherObelisk extends GuiPoweredMachineBase<TileWeatherObelisk> {
 
   private static final ResourceLocation texture = new ResourceLocation("enderio:textures/gui/weatherObelisk.png");
   private static final NumberFormat fmt = NumberFormat.getNumberInstance();
-  
+
   public GuiWeatherObelisk(InventoryPlayer inventory, TileWeatherObelisk tileEntity) {
     super(tileEntity, new ContainerWeatherObelisk(inventory, tileEntity));
-    
+
     addProgressTooltip(79, 29, 18, 31);
   }
 
   @Override
-  public void initGui() {    
+  public void initGui() {
     super.initGui();
 
     int x = (xSize / 2) - (BUTTON_SIZE / 2);
@@ -58,7 +61,7 @@ public class GuiWeatherObelisk extends GuiPoweredMachineBase<TileWeatherObelisk>
       refreshButtons();
     }
   }
-  
+
   @SuppressWarnings("unchecked")
   private void refreshButtons() {
     for (GuiButton button : (List<GuiButton>) buttonList) {
@@ -88,37 +91,37 @@ public class GuiWeatherObelisk extends GuiPoweredMachineBase<TileWeatherObelisk>
     if(shouldRenderProgress() && getTileEntity().activeTask != null) {
       int barHeight = getTileEntity().progress;
       Color color = getTileEntity().activeTask.color;
-      GL11.glColor3f((float) color.getRed() / 255f, (float) color.getGreen() / 255f, (float) color.getBlue() / 255f);
+      GL11.glColor3f(color.getRed() / 255f, color.getGreen() / 255f, color.getBlue() / 255f);
       this.drawTexturedModalRect(getGuiLeft() + 81, getGuiTop() + 58 - barHeight, getXSize(), 32 - barHeight, 12, barHeight);
     }
     super.drawGuiContainerBackgroundLayer(par1, par2, par3);
   }
-  
+
   @Override
   protected int getPowerHeight() {
     return super.getPowerHeight() + 20;
   }
-  
+
   @Override
   protected int getPowerU() {
     return super.getPowerU();
   }
-  
+
   @Override
   protected int getPowerV() {
     return 34;
   }
-  
+
   @Override
   protected int getPowerX() {
     return super.getPowerX();
   }
-  
+
   @Override
   protected int getPowerY() {
     return super.getPowerY();
   }
-  
+
   @Override
   protected void actionPerformed(GuiButton b) {
     super.actionPerformed(b);

--- a/src/main/java/crazypants/enderio/machine/xp/BlockExperienceObelisk.java
+++ b/src/main/java/crazypants/enderio/machine/xp/BlockExperienceObelisk.java
@@ -10,8 +10,8 @@ import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
-import crazypants.enderio.EnderIO;
 import crazypants.enderio.GuiHandler;
+import crazypants.enderio.EnderIO;
 import crazypants.enderio.ModObject;
 import crazypants.enderio.machine.AbstractMachineBlock;
 
@@ -124,6 +124,7 @@ public class BlockExperienceObelisk extends AbstractMachineBlock<TileExperienceO
   }
 
   @Override
+  @SideOnly(Side.CLIENT)
   public Object getClientGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z) {
     return new GuiExperianceObelisk(player.inventory, (TileExperienceOblisk)world.getTileEntity(x, y, z));
   }

--- a/src/main/java/crazypants/enderio/machine/xp/GuiExperianceObelisk.java
+++ b/src/main/java/crazypants/enderio/machine/xp/GuiExperianceObelisk.java
@@ -7,6 +7,8 @@ import net.minecraft.entity.player.InventoryPlayer;
 
 import org.lwjgl.opengl.GL11;
 
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import crazypants.enderio.gui.IconButtonEIO;
 import crazypants.enderio.gui.IconEIO;
 import crazypants.enderio.machine.gui.GuiMachineBase;
@@ -17,8 +19,9 @@ import crazypants.enderio.xp.PacketGivePlayerXP;
 import crazypants.render.RenderUtil;
 import crazypants.util.Lang;
 
+@SideOnly(Side.CLIENT)
 public class GuiExperianceObelisk extends GuiMachineBase<TileExperienceOblisk> {
-  
+
   private IconButtonEIO p;
   private IconButtonEIO pp;
   private IconButtonEIO ppp;

--- a/src/main/java/crazypants/enderio/teleport/GuiTravelAccessable.java
+++ b/src/main/java/crazypants/enderio/teleport/GuiTravelAccessable.java
@@ -12,6 +12,8 @@ import org.lwjgl.opengl.GL11;
 
 import crazypants.enderio.api.teleport.ITravelAccessable;
 import crazypants.enderio.api.teleport.ITravelAccessable.AccessMode;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import crazypants.enderio.gui.CheckBoxEIO;
 import crazypants.enderio.gui.IGuiOverlay;
 import crazypants.enderio.gui.TextFieldEIO;
@@ -24,6 +26,7 @@ import crazypants.render.RenderUtil;
 import crazypants.util.BlockCoord;
 import crazypants.util.Lang;
 
+@SideOnly(Side.CLIENT)
 public class GuiTravelAccessable extends GuiContainerBase {
 
   private static final int ID_PUBLIC = 0;

--- a/src/main/java/crazypants/enderio/teleport/GuiTravelAuth.java
+++ b/src/main/java/crazypants/enderio/teleport/GuiTravelAuth.java
@@ -11,6 +11,8 @@ import net.minecraft.world.World;
 import org.lwjgl.opengl.GL11;
 
 import crazypants.enderio.api.teleport.ITravelAccessable;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import crazypants.enderio.network.MessageTileNBT;
 import crazypants.enderio.network.PacketHandler;
 import crazypants.gui.GuiContainerBase;
@@ -18,18 +20,19 @@ import crazypants.render.ColorUtil;
 import crazypants.render.RenderUtil;
 import crazypants.util.Lang;
 
+@SideOnly(Side.CLIENT)
 public class GuiTravelAuth extends GuiContainerBase {
 
   private final String title;
   private final ITravelAccessable ta;
-  
+
   private boolean failed = false;
   private final EntityPlayer player;
 
   public GuiTravelAuth(EntityPlayer player, ITravelAccessable te, World world) {
     super(new ContainerTravelAuth(player.inventory));
     this.ta = te;
-    title = Lang.localize("gui.travelAccessable.enterCode");  
+    title = Lang.localize("gui.travelAccessable.enterCode");
     this.player = player;
   }
 

--- a/src/main/java/crazypants/enderio/teleport/anchor/BlockTravelAnchor.java
+++ b/src/main/java/crazypants/enderio/teleport/anchor/BlockTravelAnchor.java
@@ -17,12 +17,13 @@ import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 import net.minecraftforge.common.UsernameCache;
 import cpw.mods.fml.common.FMLCommonHandler;
-import cpw.mods.fml.common.network.IGuiHandler;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import crazypants.enderio.BlockEio;
-import crazypants.enderio.EnderIO;
 import crazypants.enderio.GuiHandler;
+import crazypants.enderio.CommonProxy;
+import crazypants.enderio.EnderIO;
+import crazypants.enderio.ISidedGuiHandler;
 import crazypants.enderio.ModObject;
 import crazypants.enderio.TileEntityEio;
 import crazypants.enderio.api.teleport.ITravelAccessable;
@@ -47,7 +48,7 @@ import crazypants.enderio.teleport.packet.PacketTravelEvent;
 import crazypants.util.IFacade;
 import crazypants.util.Lang;
 
-public class BlockTravelAnchor extends BlockEio implements IGuiHandler, ITileEntityProvider, IResourceTooltipProvider, IFacade {
+public class BlockTravelAnchor extends BlockEio implements ISidedGuiHandler, ITileEntityProvider, IResourceTooltipProvider, IFacade {
 
   public static int renderId = -1;
 
@@ -85,8 +86,8 @@ public class BlockTravelAnchor extends BlockEio implements IGuiHandler, ITileEnt
   @Override
   protected void init() {
     super.init();
-    EnderIO.guiHandler.registerGuiHandler(GuiHandler.GUI_ID_TRAVEL_ACCESSABLE, this);
-    EnderIO.guiHandler.registerGuiHandler(GuiHandler.GUI_ID_TRAVEL_AUTH, this);
+    CommonProxy.guiHandler.registerGuiHandler(GuiHandler.GUI_ID_TRAVEL_ACCESSABLE, this);
+    CommonProxy.guiHandler.registerGuiHandler(GuiHandler.GUI_ID_TRAVEL_AUTH, this);
     MachineRecipeRegistry.instance.registerRecipe(ModObject.blockPainter.unlocalisedName, new PainterTemplate());
   }
 
@@ -167,6 +168,7 @@ public class BlockTravelAnchor extends BlockEio implements IGuiHandler, ITileEnt
   }
 
   @Override
+  @SideOnly(Side.CLIENT)
   public Object getClientGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z) {
     TileEntity te = world.getTileEntity(x, y, z);
     if(te instanceof ITravelAccessable) {

--- a/src/main/java/crazypants/enderio/teleport/telepad/BlockTelePad.java
+++ b/src/main/java/crazypants/enderio/teleport/telepad/BlockTelePad.java
@@ -12,6 +12,7 @@ import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import crazypants.enderio.CommonProxy;
 import crazypants.enderio.EnderIO;
 import crazypants.enderio.GuiHandler;
 import crazypants.enderio.ModObject;
@@ -51,8 +52,8 @@ public class BlockTelePad extends BlockTravelAnchor {
   @Override
   protected void init() {
     super.init();
-    EnderIO.guiHandler.registerGuiHandler(GuiHandler.GUI_ID_TELEPAD, this);
-    EnderIO.guiHandler.registerGuiHandler(GuiHandler.GUI_ID_TELEPAD_TRAVEL, this);
+    CommonProxy.guiHandler.registerGuiHandler(GuiHandler.GUI_ID_TELEPAD, this);
+    CommonProxy.guiHandler.registerGuiHandler(GuiHandler.GUI_ID_TELEPAD_TRAVEL, this);
   }
 
   @Override

--- a/src/main/java/crazypants/gui/GuiContainerBase.java
+++ b/src/main/java/crazypants/gui/GuiContainerBase.java
@@ -26,6 +26,8 @@ import codechicken.nei.api.TaggedInventoryArea;
 import com.google.common.collect.Lists;
 
 import cpw.mods.fml.common.Optional;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import crazypants.enderio.gui.IGuiOverlay;
 import crazypants.enderio.gui.TextFieldEIO;
 import crazypants.gui.ToolTipManager.ToolTipRenderer;
@@ -34,6 +36,7 @@ import crazypants.render.RenderUtil;
 @Optional.InterfaceList({
     @Optional.Interface(iface = "codechicken.nei.api.INEIGuiHandler", modid = "NotEnoughItems")
 })
+@SideOnly(Side.CLIENT)
 public abstract class GuiContainerBase extends GuiContainer implements ToolTipRenderer, IGuiScreen, INEIGuiHandler {
 
   protected ToolTipManager ttMan = new ToolTipManager();
@@ -177,7 +180,7 @@ public abstract class GuiContainerBase extends GuiContainer implements ToolTipRe
     drawForegroundImpl(mouseX, mouseY);
 
     Timer t = RenderUtil.getTimer();
-    
+
     if(t != null) {
       GL11.glPushMatrix();
       GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
@@ -353,7 +356,7 @@ public abstract class GuiContainerBase extends GuiContainer implements ToolTipRe
 
       while (iterator.hasNext())
       {
-        String s = (String) iterator.next();
+        String s = iterator.next();
         int l = font.getStringWidth(s);
 
         if(l > k)
@@ -398,7 +401,7 @@ public abstract class GuiContainerBase extends GuiContainer implements ToolTipRe
 
       for (int k2 = 0; k2 < par1List.size(); ++k2)
       {
-        String s1 = (String) par1List.get(k2);
+        String s1 = par1List.get(k2);
         font.drawStringWithShadow(s1, i1, j1, -1);
 
         if(k2 == 0)

--- a/src/main/java/crazypants/gui/GuiScreenBase.java
+++ b/src/main/java/crazypants/gui/GuiScreenBase.java
@@ -12,8 +12,11 @@ import net.minecraft.client.renderer.RenderHelper;
 import org.lwjgl.opengl.GL11;
 import org.lwjgl.opengl.GL12;
 
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import crazypants.gui.ToolTipManager.ToolTipRenderer;
 
+@SideOnly(Side.CLIENT)
 public abstract class GuiScreenBase extends GuiScreen implements ToolTipRenderer, IGuiScreen {
 
   protected ToolTipManager ttMan = new ToolTipManager();
@@ -221,10 +224,10 @@ public abstract class GuiScreenBase extends GuiScreen implements ToolTipRenderer
   public void removeButton(GuiButton button) {
     buttonList.remove(button);
   }
-  
+
   @Override
   public void doActionPerformed(GuiButton guiButton) {
-    actionPerformed(guiButton); 
+    actionPerformed(guiButton);
   }
 
 }


### PR DESCRIPTION
* All getClientGuiElement() methods are now client side only
* The GuiScreens they use, too (they extend vanilla's sided GuiScreen)
* Had to introduce our own version of IGuiHandler, "ISidedGuiHandler"
because fml's one mixes sides
* Split our central GuiHandler into client and server and moved it to the proxy
* Missed a couple of getIcon()s last time

Note: I'm still playing it save---only code that would have crashed and
burned server-side is annotated.