### PR TITLE
Fix: Allow Unbreaking to work on dark steel items

### DIFF
--- a/src/main/java/crazypants/enderio/item/darksteel/ItemDarkSteelArmor.java
+++ b/src/main/java/crazypants/enderio/item/darksteel/ItemDarkSteelArmor.java
@@ -224,11 +224,7 @@ public class ItemDarkSteelArmor extends ItemArmor implements IEnergyContainerIte
       eu.extractEnergy(damage * powerPerDamagePoint, false);
 
     } else {
-      damage = stack.getItemDamage() + damage;
-      if(damage >= getMaxDamage()) {
-        stack.stackSize = 0;
-      }
-      stack.setItemDamage(damage);
+      stack.damageItem(damage, entity);
     }
     if(eu != null) {
       eu.writeToItem(stack);


### PR DESCRIPTION
* Dark Axe: Damage is routed the vanilla way (which does enchantment
damage reduction) and then intercepted at the "apply" stage.
Multi-harvesting is handled as direct energy use, as multi-harvesting
only works with power.
* Dark Pick: Damage is routed the vanilla way (which does enchantment
damage reduction) and then intercepted at the "apply" stage. Obsidian is
handled as additional direct energy use.
* Dark Armour: Damage is no longer set directly but routed through the
stack (which does enchantment damage reduction). This makes armor check
enchantments *after* power use.