### PR TITLE
Cleanup of common constructs

### DIFF
--- a/src/main/java/crazypants/enderio/BlockEio.java
+++ b/src/main/java/crazypants/enderio/BlockEio.java
@@ -24,14 +24,14 @@ import crazypants.enderio.tool.ToolUtil;
 
 public abstract class BlockEio extends Block {
 
-  protected final Class<? extends TileEntity> teClass;
+  protected final Class<? extends TileEntityEio> teClass;
   protected final String name;
 
-  protected BlockEio(String name, Class<? extends TileEntity> teClass) {
+  protected BlockEio(String name, Class<? extends TileEntityEio> teClass) {
     this(name, teClass, new Material(MapColor.ironColor));
   }
 
-  protected BlockEio(String name, Class<? extends TileEntity> teClass, Material mat) {
+  protected BlockEio(String name, Class<? extends TileEntityEio> teClass, Material mat) {
     super(mat);
     this.teClass = teClass;
     this.name = name;
@@ -58,7 +58,9 @@ public abstract class BlockEio extends Block {
   public TileEntity createTileEntity(World world, int metadata) {
     if(teClass != null) {
       try {
-        return teClass.newInstance();
+        TileEntityEio te = teClass.newInstance();
+        te.init();
+        return te;
       } catch (Exception e) {
         Log.error("Could not create tile entity for block " + name + " for class " + teClass);
       }
@@ -73,7 +75,7 @@ public abstract class BlockEio extends Block {
   }
 
   /* Subclass Helpers */
-  
+
   @Override
   public boolean onBlockActivated(World world, int x, int y, int z, EntityPlayer entityPlayer, int side, float par7, float par8, float par9) {
 
@@ -94,7 +96,7 @@ public abstract class BlockEio extends Block {
     if(entityPlayer.isSneaking()) {
       return false;
     }
-    
+
     return openGui(world, x, y, z, entityPlayer, side);
   }
 
@@ -117,7 +119,7 @@ public abstract class BlockEio extends Block {
     }
     return super.removedByPlayer(world, player, x, y, z, willHarvest);
   }
-  
+
   @Override
   public void harvestBlock(World world, EntityPlayer player, int x, int y, int z, int meta) {
     super.harvestBlock(world, player, x, y, z, meta);
@@ -131,7 +133,7 @@ public abstract class BlockEio extends Block {
     }
     return Lists.newArrayList(getNBTDrop(world, x, y, z, (TileEntityEio) world.getTileEntity(x, y, z)));
   }
-  
+
   public ItemStack getNBTDrop(World world, int x, int y, int z, TileEntityEio te) {
     int meta = damageDropped(te.getBlockMetadata());
     ItemStack itemStack = new ItemStack(this, 1, meta);
@@ -141,4 +143,30 @@ public abstract class BlockEio extends Block {
 
   protected void processDrop(World world, int x, int y, int z, @Nullable TileEntityEio te, ItemStack drop) {
   }
+
+  protected TileEntityEio getTileEntityEio(World world, int x, int y, int z) {
+    TileEntity te = world.getTileEntity(x, y, z);
+    if (teClass.isInstance(te)) {
+      return (TileEntityEio)te;
+    }
+    return null;
+  }
+
+  protected boolean shouldDoWorkThisTick(World world, int x, int y, int z, int interval) {
+    TileEntityEio te = getTileEntityEio(world, x, y, z);
+    if (te == null) {
+      return world.getTotalWorldTime() % interval == 0;
+    } else {
+      return te.shouldDoWorkThisTick(interval);
+    }
+  }
+  protected boolean shouldDoWorkThisTick(World world, int x, int y, int z, int interval, int offset) {
+    TileEntityEio te = getTileEntityEio(world, x, y, z);
+    if (te == null) {
+      return (world.getTotalWorldTime() + offset) % interval == 0;
+    } else {
+      return te.shouldDoWorkThisTick(interval, offset);
+    }
+  }
+
 }

--- a/src/main/java/crazypants/enderio/TileEntityEio.java
+++ b/src/main/java/crazypants/enderio/TileEntityEio.java
@@ -1,5 +1,6 @@
 package crazypants.enderio;
 
+import crazypants.util.BlockCoord;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.network.NetworkManager;
 import net.minecraft.network.Packet;
@@ -11,6 +12,8 @@ import net.minecraft.tileentity.TileEntity;
  */
 public abstract class TileEntityEio extends TileEntity {
   
+  private final int checkOffset = (int) (Math.random() * 20);
+
   @Override
   public final void readFromNBT(NBTTagCompound root) {
     super.readFromNBT(root);
@@ -47,5 +50,28 @@ public abstract class TileEntityEio extends TileEntity {
   
   protected boolean isPoweredRedstone() {
     return worldObj.getStrongestIndirectPower(xCoord, yCoord, zCoord) > 0;
+  }
+
+  /*
+   * init() is called directly after the TE is constructed. This is the place to call
+   * non-final methods.
+   */
+  public void init() {}
+
+  public BlockCoord getLocation() {
+    return new BlockCoord(this);
+  }
+  /*
+   * Call this with an interval (in ticks) to find out if the current tick is the one you want
+   * to do some work. This is staggered so the work of different TEs is stretched out over time.
+   * 
+   * If you have different work items in your TE, use the variant with the offset parameter to
+   * stagger your work.
+   */
+  protected boolean shouldDoWorkThisTick(int interval) {
+    return (worldObj.getTotalWorldTime() + checkOffset) % interval == 0;
+  }
+  protected boolean shouldDoWorkThisTick(int interval, int offset) {
+    return (worldObj.getTotalWorldTime() + checkOffset + offset) % interval == 0;
   }
 }

--- a/src/main/java/crazypants/enderio/conduit/TileConduitBundle.java
+++ b/src/main/java/crazypants/enderio/conduit/TileConduitBundle.java
@@ -41,7 +41,6 @@ import crazypants.enderio.conduit.power.IPowerConduit;
 import crazypants.enderio.conduit.redstone.InsulatedRedstoneConduit;
 import crazypants.enderio.config.Config;
 import crazypants.render.BoundingBox;
-import crazypants.util.BlockCoord;
 
 public class TileConduitBundle extends TileEntityEio implements IConduitBundle {
 
@@ -302,11 +301,6 @@ public class TileConduitBundle extends TileEntityEio implements IConduitBundle {
     if(markForUpdate) {
       worldObj.markBlockForUpdate(xCoord, yCoord, zCoord);
     }
-  }
-
-  @Override
-  public BlockCoord getLocation() {
-    return new BlockCoord(xCoord, yCoord, zCoord);
   }
 
   @Override

--- a/src/main/java/crazypants/enderio/machine/AbstractMachineEntity.java
+++ b/src/main/java/crazypants/enderio/machine/AbstractMachineEntity.java
@@ -130,11 +130,6 @@ public abstract class AbstractMachineEntity extends TileEntityEio implements ISi
     return res;
   }
 
-  @Override
-  public BlockCoord getLocation() {
-    return new BlockCoord(this);
-  }
-
   public SlotDefinition getSlotDefinition() {
     return slotDefinition;
   }
@@ -281,7 +276,7 @@ public abstract class AbstractMachineEntity extends TileEntityEio implements ISi
       redstoneStateDirty = false;
     }
 
-    if(worldObj.getTotalWorldTime() % 5 == 0) {
+    if(shouldDoWorkThisTick(5)) {
       requiresClientSync |= doSideIo();
     }
 
@@ -330,7 +325,7 @@ public abstract class AbstractMachineEntity extends TileEntityEio implements ISi
     if(slotDefinition.getNumOutputSlots() <= 0) {
       return false;
     }
-    if(worldObj.getTotalWorldTime() % 20 != 0) {
+    if(!shouldDoWorkThisTick(20)) {
       return false;
     }
 
@@ -366,7 +361,7 @@ public abstract class AbstractMachineEntity extends TileEntityEio implements ISi
     if(slotDefinition.getNumInputSlots() <= 0) {
       return false;
     }
-    if(worldObj.getTotalWorldTime() % 20 != 0) {
+    if(!shouldDoWorkThisTick(20)) {
       return false;
     }
 

--- a/src/main/java/crazypants/enderio/machine/attractor/BlockAttractor.java
+++ b/src/main/java/crazypants/enderio/machine/attractor/BlockAttractor.java
@@ -109,7 +109,7 @@ public class BlockAttractor extends AbstractMachineBlock<TileAttractor> {
   @SideOnly(Side.CLIENT)
   @Override
   public void randomDisplayTick(World world, int x, int y, int z, Random rand) {
-    if(isActive(world, x, y, z) && world.getTotalWorldTime() % 5 == 0) {
+    if(isActive(world, x, y, z) && shouldDoWorkThisTick(world, x, y, z, 5)) {
       float startX = x + 1.0F;
       float startY = y + 0.85F;
       float startZ = z + 1.0F;

--- a/src/main/java/crazypants/enderio/machine/attractor/TileAttractor.java
+++ b/src/main/java/crazypants/enderio/machine/attractor/TileAttractor.java
@@ -56,24 +56,10 @@ public class TileAttractor extends AbstractPowerConsumerEntity implements IRange
   private int tickCounter = 0;
   private int maxMobsAttracted = 20;
 
-  private ICapacitor capacitor;
-
   private boolean showingRange;
 
   public TileAttractor() {
     super(new SlotDefinition(12, 0));
-    setUpdrade(Capacitors.BASIC_CAPACITOR);
-  }
-
-  @Override
-  public void setCapacitor(Capacitors capacitorType) {
-    setUpdrade(capacitorType);
-    super.setCapacitor(capacitorType);
-  }
-
-  @Override
-  public ICapacitor getCapacitor() {
-    return capacitor;
   }
 
   @Override
@@ -103,8 +89,9 @@ public class TileAttractor extends AbstractPowerConsumerEntity implements IRange
     return worldObj;
   }
 
-  private void setUpdrade(Capacitors capacitorType) {
-    switch (capacitorType) {
+  @Override
+  public void onCapacitorTypeChange() {
+    switch (getCapacitorType()) {
     case ACTIVATED_CAPACITOR:
       range = Config.attractorRangeLevelTwo;
       powerPerTick = Config.attractorPowerPerTickLevelTwo;
@@ -124,7 +111,7 @@ public class TileAttractor extends AbstractPowerConsumerEntity implements IRange
     BoundingBox bb = new BoundingBox(new BlockCoord(this));
     bb = bb.scale(range, range, range);
     attractorBounds = AxisAlignedBB.getBoundingBox(bb.minX, bb.minY, bb.minZ, bb.maxX, bb.maxY, bb.maxZ);
-    capacitor = new BasicCapacitor(powerPerTick * 8, capacitorType.capacitor.getMaxEnergyStored(), powerPerTick);
+    setCapacitor(new BasicCapacitor(powerPerTick * 8, getCapacitor().getMaxEnergyStored(), powerPerTick));
   }
 
   @Override

--- a/src/main/java/crazypants/enderio/machine/buffer/TileBuffer.java
+++ b/src/main/java/crazypants/enderio/machine/buffer/TileBuffer.java
@@ -131,7 +131,7 @@ public class TileBuffer extends AbstractPowerConsumerEntity implements IPaintabl
   @Override
   protected boolean doPush(ForgeDirection dir) {
 
-    if(worldObj.getTotalWorldTime() % 20 != 0) {
+    if(!shouldDoWorkThisTick(20)) {
       return false;
     }
 

--- a/src/main/java/crazypants/enderio/machine/capbank/BlockCapBank.java
+++ b/src/main/java/crazypants/enderio/machine/capbank/BlockCapBank.java
@@ -501,7 +501,7 @@ public class BlockCapBank extends BlockEio implements IGuiHandler, IAdvancedTool
     if(te instanceof TileCapBank) {
       TileCapBank cap = (TileCapBank) te;
       if(cap.getNetwork() != null) {
-        if(world.isRemote && world.getTotalWorldTime() % 20 == 0) {
+        if(world.isRemote && shouldDoWorkThisTick(world, x, y, z, 20)) {
           PacketHandler.INSTANCE.sendToServer(new PacketNetworkStateRequest(cap));
         }
         ICapBankNetwork nw = cap.getNetwork();

--- a/src/main/java/crazypants/enderio/machine/capbank/TileCapBank.java
+++ b/src/main/java/crazypants/enderio/machine/capbank/TileCapBank.java
@@ -80,11 +80,6 @@ public class TileCapBank extends TileEntityEio implements IInternalPowerHandler,
   private boolean revalidateDisplayTypes;
   private int lastComparatorState;
 
-  @Override
-  public BlockCoord getLocation() {
-    return new BlockCoord(this);
-  }
-
   public CapBankType getType() {
     if(type == null) {
       type = CapBankType.getTypeFromMeta(getBlockMetadata());

--- a/src/main/java/crazypants/enderio/machine/crafter/TileCrafter.java
+++ b/src/main/java/crazypants/enderio/machine/crafter/TileCrafter.java
@@ -26,8 +26,6 @@ public class TileCrafter extends AbstractPowerConsumerEntity implements IItemBuf
 
   private List<ItemStack> containerItems;
 
-  private ICapacitor capacitor;
-  
   private boolean bufferStacks = true;
 
   private long ticksSinceLastCraft = 0;
@@ -35,21 +33,14 @@ public class TileCrafter extends AbstractPowerConsumerEntity implements IItemBuf
   public TileCrafter() {
     super(new SlotDefinition(9, 1));
     containerItems = new ArrayList<ItemStack>();    
-    setCapacitor(Capacitors.BASIC_CAPACITOR);    
   }
 
   @Override
-  public ICapacitor getCapacitor() {
-    return capacitor;
-  }
-
-  @Override
-  public void setCapacitor(Capacitors capacitorType) {    
-    ICapacitor refCap = capacitorType.capacitor;    
-    int maxUse = getPowerUsePerTick(capacitorType);
+  public void onCapacitorTypeChange() {
+    ICapacitor refCap = getCapacitor();
+    int maxUse = getPowerUsePerTick(getCapacitorType());
     int io = Math.max(maxUse, refCap.getMaxEnergyExtracted());
-    capacitor = new BasicCapacitor(io * 4, refCap.getMaxEnergyStored(), io);
-    super.setCapacitor(capacitorType);             
+    setCapacitor(new BasicCapacitor(io * 4, refCap.getMaxEnergyStored(), io));
   }
 
   @Override

--- a/src/main/java/crazypants/enderio/machine/farm/FarmStationContainer.java
+++ b/src/main/java/crazypants/enderio/machine/farm/FarmStationContainer.java
@@ -45,7 +45,7 @@ public class FarmStationContainer extends AbstractMachineContainer {
         @Override
         public int getSlotStackLimit() {             
           if(slot > 2 && slot < 7) {
-            int tier = ((TileFarmStation)tileEntity).tier;
+            int tier = ((TileFarmStation)tileEntity).getCapacitorType().ordinal();
             return (int) (16 * Math.pow(2, tier));
           }
           return 64;

--- a/src/main/java/crazypants/enderio/machine/farm/TileFarmStation.java
+++ b/src/main/java/crazypants/enderio/machine/farm/TileFarmStation.java
@@ -97,10 +97,6 @@ public class TileFarmStation extends AbstractPoweredTaskEntity {
 
   private final int upgradeBonusSize = 2;
 
-  private ICapacitor cap = new BasicCapacitor(200, 25000);
-
-  public int tier = 1;
-
   public String notification = "";
   public boolean sendNotification = false;
   
@@ -108,7 +104,6 @@ public class TileFarmStation extends AbstractPoweredTaskEntity {
 
   public TileFarmStation() {
     super(new SlotDefinition(7, 4, 1));
-    setCapacitor(Capacitors.BASIC_CAPACITOR);
   }
 
   public int getFarmSize() {
@@ -347,7 +342,7 @@ public class TileFarmStation extends AbstractPoweredTaskEntity {
   }
 
   protected boolean canTick(boolean redstoneChecksPassed) {
-    if(worldObj.getTotalWorldTime() % 2 != 0) {
+    if(!shouldDoWorkThisTick(2)) {
       return false;
     }
     if(getEnergyStored() < getPowerUsePerTick()) {
@@ -367,7 +362,7 @@ public class TileFarmStation extends AbstractPoweredTaskEntity {
 
   protected void doTick() {
 
-    if (sendNotification && worldObj.getTotalWorldTime() % 20 == 0) {
+    if (sendNotification && shouldDoWorkThisTick(20)) {
       sendNotification = false;
       sendNotification();
     }
@@ -611,31 +606,21 @@ public class TileFarmStation extends AbstractPoweredTaskEntity {
   }
 
   @Override
-  public void setCapacitor(Capacitors capacitorType) {
-    super.setCapacitor(capacitorType);
-    tier = capacitorType.ordinal();
+  public void onCapacitorTypeChange() {
     currentTask = createTask();
 
     int ppt = getPowerUsePerTick();
-    switch (capacitorType.ordinal()) {
-    case 1:
-      cap = new BasicCapacitor(ppt * 40, 500000);
+    switch (getCapacitorType()) {
+    case BASIC_CAPACITOR:
+      setCapacitor(new BasicCapacitor(ppt * 40, 500000));
       break;
-    case 2:
-      cap = new BasicCapacitor(ppt * 40, 1000000);
+    case ACTIVATED_CAPACITOR:
+      setCapacitor(new BasicCapacitor(ppt * 40, 1000000));
       break;
-    default:
-      cap = new BasicCapacitor(ppt * 40, 250000);
+    case ENDER_CAPACITOR:
+      setCapacitor(new BasicCapacitor(ppt * 40, 250000));
       break;
     }
-    if(getEnergyStored() > getMaxEnergyStored()) {
-      setEnergyStored(getMaxEnergyStored());
-    }
-  }
-
-  @Override
-  public ICapacitor getCapacitor() {
-    return cap;
   }
 
   @Override

--- a/src/main/java/crazypants/enderio/machine/generator/combustion/TileCombustionGenerator.java
+++ b/src/main/java/crazypants/enderio/machine/generator/combustion/TileCombustionGenerator.java
@@ -170,19 +170,19 @@ public class TileCombustionGenerator extends AbstractGeneratorEntity implements 
         generatedDirty = true;
       }
 
-      if(getEnergyStored() >= getCapacitor().getMaxEnergyStored()) {
+      if(getEnergyStored() >= getMaxEnergyStored()) {
         inPause = true;        
       }       
 
       transmitEnergy();
     }
 
-    if(tanksDirty && worldObj.getTotalWorldTime() % 10 == 0) {
+    if(tanksDirty && shouldDoWorkThisTick(10)) {
       PacketHandler.sendToAllAround(new PacketCombustionTank(this), this);
       tanksDirty = false;
     }
     
-    if(generatedDirty && worldObj.getTotalWorldTime() % 10 == 0) {
+    if(generatedDirty && shouldDoWorkThisTick(10)) {
       generatedDirty = false;
       res = true;
     }

--- a/src/main/java/crazypants/enderio/machine/generator/stirling/TileEntityStirlingGenerator.java
+++ b/src/main/java/crazypants/enderio/machine/generator/stirling/TileEntityStirlingGenerator.java
@@ -122,7 +122,7 @@ public class TileEntityStirlingGenerator extends AbstractGeneratorEntity impleme
         setEnergyStored(getEnergyStored() + getPowerUsePerTick());        
       }
       burnTime--;
-      sendBurnTimePacket = worldObj.getTotalWorldTime() % 20 == 1 || burnTime == 0;    
+      sendBurnTimePacket = shouldDoWorkThisTick(20,-1) || burnTime == 0;    
     }
 
     transmitEnergy();
@@ -158,7 +158,7 @@ public class TileEntityStirlingGenerator extends AbstractGeneratorEntity impleme
       return false;
     }
 
-    if(worldObj.getTotalWorldTime() % 20 != 0) {
+    if(!shouldDoWorkThisTick(20)) {
       return false;
     }
 

--- a/src/main/java/crazypants/enderio/machine/generator/zombie/TileZombieGenerator.java
+++ b/src/main/java/crazypants/enderio/machine/generator/zombie/TileZombieGenerator.java
@@ -129,7 +129,7 @@ public class TileZombieGenerator extends AbstractGeneratorEntity implements IFlu
         res = true;
       }
 
-      if(getEnergyStored() >= getCapacitor().getMaxEnergyStored()) {
+      if(getEnergyStored() >= getMaxEnergyStored()) {
         inPause = true;
       }
 

--- a/src/main/java/crazypants/enderio/machine/gui/GuiPoweredMachineBase.java
+++ b/src/main/java/crazypants/enderio/machine/gui/GuiPoweredMachineBase.java
@@ -48,7 +48,7 @@ public abstract class GuiPoweredMachineBase<T extends AbstractPoweredMachineEnti
   protected void updatePowerBarTooltip(List<String> text) {
     text.add(getPowerOutputLabel() + " " + PowerDisplayUtil.formatPower(getPowerOutputValue()) + " " + PowerDisplayUtil.abrevation()
         + PowerDisplayUtil.perTickStr());
-    text.add(PowerDisplayUtil.formatStoredPower(getTileEntity().getEnergyStored(), getTileEntity().getCapacitor().getMaxEnergyStored()));
+    text.add(PowerDisplayUtil.formatStoredPower(getTileEntity().getEnergyStored(), getTileEntity().getMaxEnergyStored()));
   }
 
   public void renderPowerBar(int k, int l) {

--- a/src/main/java/crazypants/enderio/machine/hypercube/TileHyperCube.java
+++ b/src/main/java/crazypants/enderio/machine/hypercube/TileHyperCube.java
@@ -135,11 +135,6 @@ public class TileHyperCube extends TileEntityEio implements IInternalPowerHandle
   }
 
   @Override
-  public BlockCoord getLocation() {
-    return new BlockCoord(this);
-  }
-
-  @Override
   public RedstoneControlMode getRedstoneControlMode() {
     return redstoneControlMode;
   }
@@ -308,7 +303,7 @@ public class TileHyperCube extends TileEntityEio implements IInternalPowerHandle
 
     requiresClientSync |= prevRedCheck != redstoneCheckPassed;
 
-    boolean powerChanged = lastSyncPowerStored != storedEnergyRF && worldObj.getTotalWorldTime() % 21 == 0;
+    boolean powerChanged = lastSyncPowerStored != storedEnergyRF && shouldDoWorkThisTick(21);
     if(powerChanged) {
       lastSyncPowerStored = storedEnergyRF;
       EnderIO.packetPipeline.sendToAllAround(new PacketStoredPower(this), this);

--- a/src/main/java/crazypants/enderio/machine/killera/TileKillerJoe.java
+++ b/src/main/java/crazypants/enderio/machine/killera/TileKillerJoe.java
@@ -144,7 +144,7 @@ public class TileKillerJoe extends AbstractMachineEntity implements IFluidHandle
   @Override
   protected boolean processTasks(boolean redstoneCheckPassed) {
 
-    if(worldObj.getTotalWorldTime() % 10 != 0) {
+    if(!shouldDoWorkThisTick(10)) {
       return false;
     }
 

--- a/src/main/java/crazypants/enderio/machine/light/TileElectricLight.java
+++ b/src/main/java/crazypants/enderio/machine/light/TileElectricLight.java
@@ -56,11 +56,6 @@ public class TileElectricLight extends TileEntityEio implements IInternalPowerRe
     energyStoredRF = 0;
   }
 
-  @Override
-  public BlockCoord getLocation() {
-    return new BlockCoord(this);
-  }
-
   public void onNeighborBlockChange(Block blockID) {
     init = true;
   }

--- a/src/main/java/crazypants/enderio/machine/light/TileLightNode.java
+++ b/src/main/java/crazypants/enderio/machine/light/TileLightNode.java
@@ -26,7 +26,7 @@ public class TileLightNode extends TileEntityEio {
     if(worldObj.isRemote) {
       return;
     }
-    if(worldObj.getWorldTime() % 42 == 0) {
+    if(shouldDoWorkThisTick(42)) {
       if(worldObj.getBlock(parentX, parentY, parentZ) != EnderIO.blockElectricLight) {
         worldObj.setBlockToAir(xCoord, yCoord, zCoord);
       }

--- a/src/main/java/crazypants/enderio/machine/power/TileCapacitorBank.java
+++ b/src/main/java/crazypants/enderio/machine/power/TileCapacitorBank.java
@@ -185,11 +185,6 @@ public class TileCapacitorBank extends TileEntityEio implements IInternalPowerHa
     return res;
   }
 
-  @Override
-  public BlockCoord getLocation() {
-    return new BlockCoord(this);
-  }
-
   private IPowerInterface getReceptorForFace(ForgeDirection faceHit) {
     BlockCoord checkLoc = new BlockCoord(this).getLocation(faceHit);
     TileEntity te = worldObj.getTileEntity(checkLoc.x, checkLoc.y, checkLoc.z);
@@ -264,7 +259,7 @@ public class TileCapacitorBank extends TileEntityEio implements IInternalPowerHa
       setEnergyStored(getMaxEnergyStored() / 2);
     }
 
-    if(lastSyncPowerStored != getEnergyStored() && worldObj.getTotalWorldTime() % 10 == 0) {
+    if(lastSyncPowerStored != getEnergyStored() && shouldDoWorkThisTick(10)) {
       lastSyncPowerStored = getEnergyStored();
       PacketHandler.sendToAllAround(new PacketPowerStorage(this), this, 64);
     }

--- a/src/main/java/crazypants/enderio/machine/reservoir/TileReservoir.java
+++ b/src/main/java/crazypants/enderio/machine/reservoir/TileReservoir.java
@@ -118,7 +118,7 @@ public class TileReservoir extends TileEntityEio implements IFluidHandler {
         }
       }
     }
-    if(tankDirty && worldObj.getTotalWorldTime() % 2 == 0) {
+    if(tankDirty && shouldDoWorkThisTick(2)) {
       worldObj.markBlockForUpdate(xCoord, yCoord, zCoord);
       tankDirty = false;
     }

--- a/src/main/java/crazypants/enderio/machine/slicensplice/TileSliceAndSplice.java
+++ b/src/main/java/crazypants/enderio/machine/slicensplice/TileSliceAndSplice.java
@@ -41,11 +41,8 @@ public class TileSliceAndSplice extends AbstractPoweredTaskEntity {
   private final int shearsIndex = 7;
   private EntityLivingBase fakePlayer;
 
-  private ICapacitor capacitor;
-
   public TileSliceAndSplice() {
     super(new SlotDefinition(8, 1));
-    capacitor = CAP_ONE;
   }
 
   @Override
@@ -58,37 +55,19 @@ public class TileSliceAndSplice extends AbstractPoweredTaskEntity {
     return 1;
   }
 
-  public void setCapacitor(Capacitors capacitorType) {
-    switch (capacitorType) {
+  @Override
+  public void onCapacitorTypeChange() {
+    switch (getCapacitorType()) {
     case BASIC_CAPACITOR:
-      capacitor = CAP_ONE;
+      setCapacitor(CAP_ONE);
       break;
     case ACTIVATED_CAPACITOR:
-      capacitor = CAP_TWO;
+      setCapacitor(CAP_TWO);
       break;
     case ENDER_CAPACITOR:
-      capacitor = CAP_THREE;
-      break;
-    default:
-      capacitor = CAP_ONE;
+      setCapacitor(CAP_THREE);
       break;
     }
-    super.setCapacitor(capacitorType);
-  }
-
-  @Override
-  public ICapacitor getCapacitor() {
-    return capacitor;
-  }
-
-  @Override
-  public int getPowerUsePerTick() {
-    if(getCapacitorType().ordinal() == 0) {
-      return POWER_PER_TICK_ONE;
-    } else if(getCapacitorType().ordinal() == 1) {
-      return POWER_PER_TICK_TWO;
-    }
-    return POWER_PER_TICK_THREE;
   }
 
   @Override

--- a/src/main/java/crazypants/enderio/machine/solar/TileEntitySolarPanel.java
+++ b/src/main/java/crazypants/enderio/machine/solar/TileEntitySolarPanel.java
@@ -30,25 +30,17 @@ public class TileEntitySolarPanel extends TileEntityEio implements IInternalPowe
 
   private int lastCollectionValue = -1;
   
-  private int checkOffset;
   private static final int CHECK_INTERVAL = 100;
   
   EnergyStorage destroyedNetworkBuffer = null;
   
   protected SolarPanelNetwork network = new SolarPanelNetwork();
 
-  public TileEntitySolarPanel() {
-    checkOffset = (int) (Math.random() * 20);
-  }
-  
   public void onNeighborBlockChange() {
     receptorsDirty = true;
   }
 
-  @Override
-  public BlockCoord getLocation() {
-    return new BlockCoord(this);
-  }
+  
 
   // RF Power
 
@@ -108,7 +100,7 @@ public class TileEntitySolarPanel extends TileEntityEio implements IInternalPowe
       network.onUpdate(this);
     }
     
-    if (!network.isValid() || (worldObj.getTotalWorldTime() % 20 == 0 && network.addToNetwork(this))) {
+    if (!network.isValid() || (shouldDoWorkThisTick(20, 1) && network.addToNetwork(this))) {
       findNetwork();
     }
   }
@@ -141,7 +133,7 @@ public class TileEntitySolarPanel extends TileEntityEio implements IInternalPowe
 
   private void collectEnergy() {
     if(canSeeSun()) {
-      if(lastCollectionValue == -1 || (worldObj.getWorldTime() + checkOffset) % CHECK_INTERVAL == 0) {
+      if(lastCollectionValue == -1 || shouldDoWorkThisTick(CHECK_INTERVAL)) {
         float fromSun = calculateLightRatio();
         lastCollectionValue = Math.round(getEnergyPerTick() * fromSun);
       }

--- a/src/main/java/crazypants/enderio/machine/soul/TileSoulBinder.java
+++ b/src/main/java/crazypants/enderio/machine/soul/TileSoulBinder.java
@@ -40,13 +40,10 @@ public class TileSoulBinder extends AbstractPoweredTaskEntity implements IHaveEx
   private static final BasicCapacitor CAP_THREE = new BasicCapacitor(POWER_PER_TICK_THREE * 2,
       Capacitors.ENDER_CAPACITOR.capacitor.getMaxEnergyStored(), POWER_PER_TICK_THREE);
   
-  private ICapacitor capacitor;
-  
   private final ExperienceContainer xpCont = new ExperienceContainer(XpUtil.getExperienceForLevel(Config.soulBinderMaxXpLevel));
   
   public TileSoulBinder() {
     super(new SlotDefinition(2, 2, 1));
-    capacitor = CAP_ONE;
   }
 
   @Override
@@ -138,37 +135,19 @@ public class TileSoulBinder extends AbstractPoweredTaskEntity implements IHaveEx
     return false;
   }
 
-  public void setCapacitor(Capacitors capacitorType) {    
-    switch (capacitorType) {
+  @Override
+  public void onCapacitorTypeChange() {
+    switch (getCapacitorType()) {
     case BASIC_CAPACITOR:
-      capacitor = CAP_ONE;
+      setCapacitor(CAP_ONE);
       break;
     case ACTIVATED_CAPACITOR:
-      capacitor = CAP_TWO;
+      setCapacitor(CAP_TWO);
       break;
     case ENDER_CAPACITOR:
-      capacitor = CAP_THREE;
-      break;
-    default:
-      capacitor = CAP_ONE;
+      setCapacitor(CAP_THREE);
       break;
     }
-    super.setCapacitor(capacitorType);
-  }
-  
-  @Override
-  public ICapacitor getCapacitor() {
-    return capacitor;
-  }
-
-  @Override
-  public int getPowerUsePerTick() {
-    if(getCapacitorType().ordinal() == 0) {
-      return POWER_PER_TICK_ONE;
-    } else if(getCapacitorType().ordinal() == 1) {
-      return POWER_PER_TICK_TWO;
-    }
-    return POWER_PER_TICK_THREE;
   }
 
   @Override

--- a/src/main/java/crazypants/enderio/machine/spawner/TilePoweredSpawner.java
+++ b/src/main/java/crazypants/enderio/machine/spawner/TilePoweredSpawner.java
@@ -43,14 +43,11 @@ public class TilePoweredSpawner extends AbstractPoweredTaskEntity {
 
   private static final String NULL_ENTITY_NAME = "None";
 
-  private ICapacitor capacitor;
-
   private boolean isSpawnMode = true;
 
   public TilePoweredSpawner() {
     super(new SlotDefinition(1, 1, 1));
     logic.setEntityName(NULL_ENTITY_NAME);
-    capacitor = CAP_ONE;
   }
 
   public boolean isSpawnMode() {
@@ -84,10 +81,9 @@ public class TilePoweredSpawner extends AbstractPoweredTaskEntity {
   }
 
   @Override
-  public void setCapacitor(Capacitors capacitorType) {
-    super.setCapacitor(capacitorType);
-    ICapacitor refCap;
-    switch (capacitorType) {
+  public void onCapacitorTypeChange() {
+    ICapacitor refCap = null;
+    switch (getCapacitorType()) {
     case BASIC_CAPACITOR:
       refCap = CAP_ONE;
       break;
@@ -97,19 +93,10 @@ public class TilePoweredSpawner extends AbstractPoweredTaskEntity {
     case ENDER_CAPACITOR:
       refCap = CAP_THREE;
       break;
-    default:
-      refCap = CAP_ONE;
-      break;
     }
     double multuplier = PoweredSpawnerConfig.getInstance().getCostMultiplierFor(logic.getEntityNameToSpawn());
-    capacitor = new BasicCapacitor((int) (refCap.getMaxEnergyExtracted() * multuplier), refCap.getMaxEnergyStored());
+    setCapacitor(new BasicCapacitor((int) (refCap.getMaxEnergyExtracted() * multuplier), refCap.getMaxEnergyStored()));
     forceClientUpdate = true;
-    setEnergyStored(getEnergyStored());
-  }
-
-  @Override
-  public ICapacitor getCapacitor() {
-    return capacitor;
   }
 
   @Override

--- a/src/main/java/crazypants/enderio/machine/spawnguard/BlockSpawnGuard.java
+++ b/src/main/java/crazypants/enderio/machine/spawnguard/BlockSpawnGuard.java
@@ -108,7 +108,7 @@ public class BlockSpawnGuard extends AbstractMachineBlock<TileSpawnGuard> {
   @SideOnly(Side.CLIENT)
   @Override
   public void randomDisplayTick(World world, int x, int y, int z, Random rand) {
-    if(isActive(world, x, y, z) && world.getTotalWorldTime() % 5 == 0) {
+    if(isActive(world, x, y, z) && shouldDoWorkThisTick(world, x, y, z, 5)) {
       float startX = x + 1.0F;
       float startY = y + 0.85F;
       float startZ = z + 1.0F;

--- a/src/main/java/crazypants/enderio/machine/spawnguard/TileSpawnGuard.java
+++ b/src/main/java/crazypants/enderio/machine/spawnguard/TileSpawnGuard.java
@@ -23,7 +23,6 @@ import crazypants.render.BoundingBox;
 
 public class TileSpawnGuard extends AbstractPowerConsumerEntity implements IRanged {
 
-  private ICapacitor capacitor;
   private int powerPerTick;
   private int range;
   private int rangeSqu;
@@ -34,7 +33,6 @@ public class TileSpawnGuard extends AbstractPowerConsumerEntity implements IRang
   
   public TileSpawnGuard() {
     super(new SlotDefinition(12, 0));
-    setUpdrade(Capacitors.BASIC_CAPACITOR);    
   }
   
   @Override
@@ -72,18 +70,12 @@ public class TileSpawnGuard extends AbstractPowerConsumerEntity implements IRang
   }
 
   @Override
-  public void setCapacitor(Capacitors capacitorType) {
-    setUpdrade(capacitorType);
-    super.setCapacitor(capacitorType);
-  }
-
-  @Override
-  public ICapacitor getCapacitor() {
-    return capacitor;
-  }
-
-  private void setUpdrade(Capacitors capacitorType) {    
-    switch (capacitorType) {
+  public void onCapacitorTypeChange() {
+    switch (getCapacitorType()) {
+    case BASIC_CAPACITOR:
+    	range = Config.spawnGuardRangeLevelOne;
+    	powerPerTick = Config.spawnGuardPowerPerTickLevelOne;
+    	break;
     case ACTIVATED_CAPACITOR:
       range = Config.spawnGuardRangeLevelTwo;
       powerPerTick = Config.spawnGuardPowerPerTickLevelTwo;
@@ -92,14 +84,9 @@ public class TileSpawnGuard extends AbstractPowerConsumerEntity implements IRang
       range = Config.spawnGuardRangeLevelThree;
       powerPerTick = Config.spawnGuardPowerPerTickLevelThree;
       break;
-    case BASIC_CAPACITOR:
-    default:
-      range = Config.spawnGuardRangeLevelOne;
-      powerPerTick = Config.spawnGuardPowerPerTickLevelOne;
-      break;
     }
     rangeSqu = range * range;    
-    capacitor = new BasicCapacitor(powerPerTick * 8, capacitorType.capacitor.getMaxEnergyStored(), powerPerTick);
+    setCapacitor(new BasicCapacitor(powerPerTick * 8, getCapacitor().getMaxEnergyStored(), powerPerTick));
     
     BoundingBox bb = new BoundingBox(getLocation());
     bb = bb.scale(range + 0.5f, range + 0.5f, range + 0.5f).translate(0.5f, 0.5f, 0.5f);    

--- a/src/main/java/crazypants/enderio/machine/tank/TileTank.java
+++ b/src/main/java/crazypants/enderio/machine/tank/TileTank.java
@@ -243,7 +243,7 @@ public class TileTank extends AbstractMachineEntity implements IFluidHandler {
       tankDirty = false;
       return true;
     }
-    if(tankDirty && worldObj.getTotalWorldTime() % 10 == 0) {
+    if(tankDirty && shouldDoWorkThisTick(10)) {
       PacketHandler.sendToAllAround(new PacketTank(this), this);
       worldObj.func_147453_f(xCoord, yCoord, zCoord, getBlockType());
       tankDirty = false;
@@ -260,7 +260,7 @@ public class TileTank extends AbstractMachineEntity implements IFluidHandler {
     if(!redstoneCheckPassed) {
       return false;
     }
-    if(worldObj.getTotalWorldTime() % 20 != 0) {
+    if(!shouldDoWorkThisTick(20)) {
       return false;
     }
     return drainFullContainer() || fillEmptyContainer();

--- a/src/main/java/crazypants/enderio/machine/vacuum/TileVacuumChest.java
+++ b/src/main/java/crazypants/enderio/machine/vacuum/TileVacuumChest.java
@@ -22,7 +22,6 @@ import crazypants.enderio.config.Config;
 import crazypants.enderio.machine.IRedstoneModeControlable;
 import crazypants.enderio.machine.RedstoneControlMode;
 import crazypants.render.BoundingBox;
-import crazypants.util.BlockCoord;
 import crazypants.util.ItemUtil;
 import net.minecraft.block.Block;
 
@@ -132,10 +131,6 @@ public class TileVacuumChest extends TileEntityEio implements IEntitySelector, I
       }
     }
     return true;
-  }
-
-  private BlockCoord getLocation() {
-    return new BlockCoord(this);
   }
 
   @Override

--- a/src/main/java/crazypants/enderio/machine/vat/TileVat.java
+++ b/src/main/java/crazypants/enderio/machine/vat/TileVat.java
@@ -183,7 +183,7 @@ public class TileVat extends AbstractPoweredTaskEntity implements IFluidHandler 
   @Override
   protected boolean processTasks(boolean redstoneChecksPassed) {
     boolean res = super.processTasks(redstoneChecksPassed);
-    if(tanksDirty && worldObj.getTotalWorldTime() % 10 == 0) {
+    if(tanksDirty && shouldDoWorkThisTick(10)) {
       PacketHandler.sendToAllAround(new PacketTanks(this), this);
       tanksDirty = false;
     }

--- a/src/main/java/crazypants/enderio/machine/weather/TileWeatherObelisk.java
+++ b/src/main/java/crazypants/enderio/machine/weather/TileWeatherObelisk.java
@@ -94,9 +94,13 @@ public class TileWeatherObelisk extends AbstractPowerConsumerEntity {
   
   public TileWeatherObelisk() {
     super(new SlotDefinition(1, 0, 0));
-    setCapacitor(Capacitors.ACTIVATED_CAPACITOR);
   }
 
+  @Override
+  public void init() {
+	  setCapacitor(Capacitors.ACTIVATED_CAPACITOR);
+  }
+  
   public void updateEntity() {
     super.updateEntity();
     if(worldObj.isRemote) {

--- a/src/main/java/crazypants/enderio/machine/wireless/TileWirelessCharger.java
+++ b/src/main/java/crazypants/enderio/machine/wireless/TileWirelessCharger.java
@@ -9,7 +9,6 @@ import crazypants.enderio.TileEntityEio;
 import crazypants.enderio.network.PacketHandler;
 import crazypants.enderio.power.IInternalPowerReceiver;
 import crazypants.enderio.power.PowerHandlerUtil;
-import crazypants.util.BlockCoord;
 
 public class TileWirelessCharger extends TileEntityEio implements IInternalPowerReceiver, IWirelessCharger {
 
@@ -48,7 +47,7 @@ public class TileWirelessCharger extends TileEntityEio implements IInternalPower
     if( (lastPowerUpdate == -1) || 
         (lastPowerUpdate == 0 && storedEnergyRF > 0) ||
         (lastPowerUpdate > 0 && storedEnergyRF == 0) ||
-        (lastPowerUpdate != storedEnergyRF && worldObj.getTotalWorldTime() % 20 == 0)
+        (lastPowerUpdate != storedEnergyRF && shouldDoWorkThisTick(20))
         ) {
       lastPowerUpdate = storedEnergyRF;
       PacketHandler.sendToAllAround(new PacketStoredEnergy(this), this);
@@ -146,11 +145,6 @@ public class TileWirelessCharger extends TileEntityEio implements IInternalPower
   @Override
   public boolean canConnectEnergy(ForgeDirection from) {
     return true;
-  }
-
-  @Override
-  public BlockCoord getLocation() {
-    return new BlockCoord(this);
   }
 
   @Override

--- a/src/main/java/crazypants/enderio/teleport/anchor/TileTravelAnchor.java
+++ b/src/main/java/crazypants/enderio/teleport/anchor/TileTravelAnchor.java
@@ -17,7 +17,6 @@ import crazypants.enderio.TileEntityEio;
 import crazypants.enderio.api.teleport.ITravelAccessable;
 import crazypants.enderio.api.teleport.TravelSource;
 import crazypants.enderio.machine.painter.IPaintableTileEntity;
-import crazypants.util.BlockCoord;
 import crazypants.util.PlayerUtil;
 
 public class TileTravelAnchor extends TileEntityEio implements ITravelAccessable, IPaintableTileEntity {
@@ -57,11 +56,6 @@ public class TileTravelAnchor extends TileEntityEio implements ITravelAccessable
   @Override
   public void clearAuthorisedUsers() {
     authorisedUsers.clear();
-  }
-
-  @Override
-  public BlockCoord getLocation() {
-    return new BlockCoord(this);
   }
 
   private boolean checkPassword(ItemStack[] pwd) {

--- a/src/main/java/crazypants/enderio/teleport/telepad/TileTelePad.java
+++ b/src/main/java/crazypants/enderio/teleport/telepad/TileTelePad.java
@@ -121,12 +121,12 @@ public class TileTelePad extends TileTravelAnchor implements IInternalPowerRecei
         } else {
           powerUsed += energy.extractEnergy(getUsage(), false);
         }
-        if(worldObj.getTotalWorldTime() % 5 == 0) {
+        if(shouldDoWorkThisTick(5)) {
           updateQueuedEntities();
         }
       }
 
-      boolean powerChanged = (lastSyncPowerStored != getEnergyStored() && worldObj.getTotalWorldTime() % 5 == 0);
+      boolean powerChanged = (lastSyncPowerStored != getEnergyStored() && shouldDoWorkThisTick(5));
       if(powerChanged) {
         lastSyncPowerStored = getEnergyStored();
         PacketHandler.sendToAllAround(new PacketPowerStorage(this), this);


### PR DESCRIPTION
* Capacitors in Powered Machines are now handled consistently
* Powered Machine TileEntities have a callback when the capacitor type is changed to compute the details of the internally used capacitor
* TileEntityEIOs have an init() method and no longer need to call non-final methods in their contructor
* They (and BlockEIOs) now have methods to determine on which tick to work. These will stagger the work over time.
* The getLocation() method now is in TileEntityEIO and no longer duplicated over 20 classes.
* BlockEIOs have a getTileEntityEIO() method