### PR TITLE
Shear less when low on saplings

### DIFF
--- a/src/main/java/crazypants/enderio/config/Config.java
+++ b/src/main/java/crazypants/enderio/config/Config.java
@@ -289,6 +289,7 @@ public final class Config {
       "ThermalExpansion:tool.hoeInvar"
   };
   public static List<ItemStack> farmHoes = new ArrayList<ItemStack>();
+  public static int farmSaplingReserveAmount = 8;
 
   public static int magnetPowerUsePerSecondRF = 1;
   public static int magnetPowerCapacityRF = 100000;
@@ -972,6 +973,10 @@ public final class Config {
     hoeStrings = config.get(sectionFarm.name, "farmHoes", hoeStrings,
         "Use this to specify items that can be hoes in the farming station. Use the registry name (eg. modid:name).").getStringList();
 
+    farmSaplingReserveAmount = config.get(sectionFarm.name, "farmSaplingReserveAmount", farmSaplingReserveAmount,
+        "The amount saplings the farm has to have in reserve to switch to shearing all leaves. If there are less " +
+        "saplings in store, it will only shear half the leaves. Set this to 0 to always shear leaves.").getInt(farmSaplingReserveAmount);
+    
     combustionGeneratorUseOpaqueModel = config.get(sectionAesthetic.name, "combustionGeneratorUseOpaqueModel", combustionGeneratorUseOpaqueModel,
         "If set to true: fluid will not be shown in combustion generator tanks. Improves FPS. ").getBoolean(combustionGeneratorUseOpaqueModel);
 

--- a/src/main/java/crazypants/enderio/machine/farm/TileFarmStation.java
+++ b/src/main/java/crazypants/enderio/machine/farm/TileFarmStation.java
@@ -443,10 +443,10 @@ public class TileFarmStation extends AbstractPoweredTaskEntity {
     return inv != null && (inv.stackSize > 1 || !isSlotLocked(slot)) && inv.isItemEqual(seeds);
   }
 
-  public boolean needSeeds(BlockCoord bc) {
+  public boolean isLowOnSaplings(BlockCoord bc) {
     int slot = getSupplySlotForCoord(bc);
     ItemStack inv = inventory[slot];
-    return (inv == null || (inv.stackSize == 1 && isSlotLocked(slot)));
+    return Config.farmSaplingReserveAmount > 0 && (inv == null || (inv.stackSize < Config.farmSaplingReserveAmount));
   }
 
   public ItemStack takeSeedFromSupplies(ItemStack stack, BlockCoord forBlock) {

--- a/src/main/java/crazypants/enderio/machine/farm/farmers/TreeFarmer.java
+++ b/src/main/java/crazypants/enderio/machine/farm/farmers/TreeFarmer.java
@@ -118,6 +118,8 @@ public class TreeFarmer implements IFarmerJoe {
 
     // avoid calling this in a loop
     boolean hasShears = farm.hasShears();
+    boolean lowOnSaplings = farm.isLowOnSaplings(bc);
+    boolean fiftyFiftyToggle = false;
 
     for (int i = 0; i < res.harvestedBlocks.size() && hasAxe; i++) {
       BlockCoord coord = res.harvestedBlocks.get(i);
@@ -127,8 +129,9 @@ public class TreeFarmer implements IFarmerJoe {
       boolean wasSheared = false;
       boolean wasAxed = false;
       boolean wasWood = isWood(blk);
+      fiftyFiftyToggle = !fiftyFiftyToggle;
       
-      if (blk instanceof IShearable && hasShears) {
+      if (blk instanceof IShearable && hasShears && (!lowOnSaplings || fiftyFiftyToggle)) {
         drops = ((IShearable)blk).onSheared(null, farm.getWorldObj(), coord.x, coord.y, coord.z, 0);
         wasSheared = true;
       } else {


### PR DESCRIPTION
* New config setting for sapling reserve amount.
* When there are less than reserve amount saplings, only half the
leaves will be sheard, the other half will be harvested for saplings.
* Default is 8 (half the stacksize of the basic farming station)