### PR TITLE
More shearing tweaks

### DIFF
--- a/src/main/java/crazypants/enderio/config/Config.java
+++ b/src/main/java/crazypants/enderio/config/Config.java
@@ -974,8 +974,9 @@ public final class Config {
         "Use this to specify items that can be hoes in the farming station. Use the registry name (eg. modid:name).").getStringList();
 
     farmSaplingReserveAmount = config.get(sectionFarm.name, "farmSaplingReserveAmount", farmSaplingReserveAmount,
-        "The amount saplings the farm has to have in reserve to switch to shearing all leaves. If there are less " +
-        "saplings in store, it will only shear half the leaves. Set this to 0 to always shear leaves.").getInt(farmSaplingReserveAmount);
+        "The amount of saplings the farm has to have in reserve to switch to shearing all leaves. If there are less " +
+        "saplings in store, it will only shear part the leaves and break the others for spalings. Set this to 0 to " +
+        "always shear all leaves.").getInt(farmSaplingReserveAmount);
     
     combustionGeneratorUseOpaqueModel = config.get(sectionAesthetic.name, "combustionGeneratorUseOpaqueModel", combustionGeneratorUseOpaqueModel,
         "If set to true: fluid will not be shown in combustion generator tanks. Improves FPS. ").getBoolean(combustionGeneratorUseOpaqueModel);

--- a/src/main/java/crazypants/enderio/machine/farm/farmers/TreeFarmer.java
+++ b/src/main/java/crazypants/enderio/machine/farm/farmers/TreeFarmer.java
@@ -118,8 +118,8 @@ public class TreeFarmer implements IFarmerJoe {
 
     // avoid calling this in a loop
     boolean hasShears = farm.hasShears();
-    boolean lowOnSaplings = farm.isLowOnSaplings(bc);
-    boolean fiftyFiftyToggle = false;
+    int noShearingPercentage = farm.isLowOnSaplings(bc);
+    int shearCount = 0;
 
     for (int i = 0; i < res.harvestedBlocks.size() && hasAxe; i++) {
       BlockCoord coord = res.harvestedBlocks.get(i);
@@ -129,11 +129,11 @@ public class TreeFarmer implements IFarmerJoe {
       boolean wasSheared = false;
       boolean wasAxed = false;
       boolean wasWood = isWood(blk);
-      fiftyFiftyToggle = !fiftyFiftyToggle;
       
-      if (blk instanceof IShearable && hasShears && (!lowOnSaplings || fiftyFiftyToggle)) {
+      if (blk instanceof IShearable && hasShears && ((shearCount / res.harvestedBlocks.size() + noShearingPercentage) < 100)) {
         drops = ((IShearable)blk).onSheared(null, farm.getWorldObj(), coord.x, coord.y, coord.z, 0);
         wasSheared = true;
+        shearCount += 100;
       } else {
         drops = blk.getDrops(farm.getWorldObj(), coord.x, coord.y, coord.z, farm.getBlockMeta(coord), farm.getAxeLootingValue());
         wasAxed = true;


### PR DESCRIPTION
* Shearing ratio is now dynamic, between 10% at empty supply slot and
100% at the configured reserve
* Harvested seeds/sappling are added to the supply slot for the quarter
they were harvested from, then the others in order
* re #2119