### PR TITLE
Fix: Stack size limits on Farming Station

### DIFF
--- a/src/main/java/crazypants/enderio/machine/AbstractMachineEntity.java
+++ b/src/main/java/crazypants/enderio/machine/AbstractMachineEntity.java
@@ -367,7 +367,7 @@ public abstract class AbstractMachineEntity extends TileEntityEio implements ISi
 
     boolean hasSpace = false;
     for (int slot = slotDefinition.minInputSlot; slot <= slotDefinition.maxInputSlot && !hasSpace; slot++) {
-      hasSpace = inventory[slot] == null ? true : inventory[slot].stackSize < inventory[slot].getMaxStackSize();
+      hasSpace = inventory[slot] == null ? true : inventory[slot].stackSize < Math.min(inventory[slot].getMaxStackSize(), getInventoryStackLimit(slot));
     }
     if(!hasSpace) {
       return false;
@@ -569,6 +569,10 @@ public abstract class AbstractMachineEntity extends TileEntityEio implements ISi
     return slotDefinition.getNumSlots();
   }
 
+  public int getInventoryStackLimit(int slot) {
+    return getInventoryStackLimit();
+  }
+
   @Override
   public int getInventoryStackLimit() {
     return 64;
@@ -608,8 +612,8 @@ public abstract class AbstractMachineEntity extends TileEntityEio implements ISi
       inventory[slot] = contents.copy();
     }
 
-    if(contents != null && contents.stackSize > getInventoryStackLimit()) {
-      contents.stackSize = getInventoryStackLimit();
+    if(contents != null && contents.stackSize > getInventoryStackLimit(slot)) {
+      contents.stackSize = getInventoryStackLimit(slot);
     }
   }
 

--- a/src/main/java/crazypants/enderio/machine/farm/FarmStationContainer.java
+++ b/src/main/java/crazypants/enderio/machine/farm/FarmStationContainer.java
@@ -62,11 +62,7 @@ public class FarmStationContainer extends AbstractMachineContainer {
 
         @Override
         public int getSlotStackLimit() {             
-          if(slot > 2 && slot < 7) {
-            int tier = ((TileFarmStation)tileEntity).getCapacitorType().ordinal();
-            return (int) (16 * Math.pow(2, tier));
-          }
-          return 64;
+          return ((TileFarmStation)tileEntity).getInventoryStackLimit(slot);
         }
       });
     }


### PR DESCRIPTION
* The Farming Station's stack size limitations now actually work. Cases:
** Manual insert
** Shift-Click
** Pulling
** Pushing (e.g. item conduits)
** Harvesting
* re #2122