### PR TITLE
Duplication fix

### DIFF
--- a/src/main/java/crazypants/enderio/machine/crusher/CrusherRecipeManager.java
+++ b/src/main/java/crazypants/enderio/machine/crusher/CrusherRecipeManager.java
@@ -64,7 +64,7 @@ public class CrusherRecipeManager {
         int id = OreDictionary.getOreID(input.item);
         if(id >= 0) {
           String name = OreDictionary.getOreName(id);
-          if(name.startsWith("ingot")) {            
+          if(name.startsWith("ingot") || name.startsWith("block")) {
             addExcludedStack(input.item);
             return true;
           }


### PR DESCRIPTION
Very simple, just excludes block* (any oredict entry that starts with block) from grinding ball bonuses.