### PR TITLE
Nether Quartz Balance

### DIFF
--- a/resources/assets/enderio/config/SAGMillRecipes_Core.xml
+++ b/resources/assets/enderio/config/SAGMillRecipes_Core.xml
@@ -445,8 +445,8 @@ addOreDictionaryTooltips=true
         <itemStack oreDictionary="oreQuartz" />
       </input>
       <output>
-        <itemStack modID="minecraft" itemName="quartz" number="4" />
-        <itemStack oreDictionary="dustCertusQuartz" chance="0.05" />
+        <itemStack modID="minecraft" itemName="quartz" number="1" />
+        <itemStack oreDictionary="dustNetherQuartz" number="1" />
       </output>
     </recipe>
 


### PR DESCRIPTION
Mining nether quartz without luck gives 1 quartz per ore. Comparable
mods give two per grinding. Certus Quartz gives one crystal one dust in
the sag mill recipe.

This change makes Nether Quartz comparable to Certus Quartz in EIO
recipes, and comparable to other mods, while still improving compared to
vanilla yields (just not quadruple)