### PR TITLE
New: Config value to disable upticking

### DIFF
--- a/src/main/java/crazypants/enderio/TileEntityEio.java
+++ b/src/main/java/crazypants/enderio/TileEntityEio.java
@@ -5,6 +5,7 @@ import net.minecraft.network.NetworkManager;
 import net.minecraft.network.Packet;
 import net.minecraft.network.play.server.S35PacketUpdateTileEntity;
 import net.minecraft.tileentity.TileEntity;
+import crazypants.enderio.config.Config;
 import crazypants.enderio.machine.PacketProgress;
 import crazypants.enderio.network.PacketHandler;
 import crazypants.util.BlockCoord;
@@ -32,14 +33,19 @@ public abstract class TileEntityEio extends TileEntity {
     return true;
   }
 
+  private long lastUpdate = 0;
+
   @Override
   public final void updateEntity() {
-    doUpdate();
-    if(isProgressTile && !worldObj.isRemote) {
-      int curScaled = getProgressScaled(16);
-      if(++ticksSinceLastProgressUpdate >= getProgressUpdateFreq() || curScaled != lastProgressScaled) {
-        sendTaskProgressPacket();
-        lastProgressScaled = curScaled;
+    if (Config.allowExternalTickSpeedup || worldObj.getTotalWorldTime() != lastUpdate) {
+      lastUpdate = worldObj.getTotalWorldTime();
+      doUpdate();
+      if (isProgressTile && !worldObj.isRemote) {
+        int curScaled = getProgressScaled(16);
+        if (++ticksSinceLastProgressUpdate >= getProgressUpdateFreq() || curScaled != lastProgressScaled) {
+          sendTaskProgressPacket();
+          lastProgressScaled = curScaled;
+        }
       }
     }
   }

--- a/src/main/java/crazypants/enderio/config/Config.java
+++ b/src/main/java/crazypants/enderio/config/Config.java
@@ -99,6 +99,7 @@ public final class Config {
   public static File configDirectory;
 
   public static boolean useHardRecipes = false;
+  public static boolean allowExternalTickSpeedup = true;
 
   public static boolean useSteelInChassi = false;
 
@@ -566,6 +567,11 @@ public final class Config {
         "The number of conduits crafted per recipe.").getInt(numConduitsPerRecipe);
     transceiverUseEasyRecipe= config.get(sectionRecipe.name, "transceiverUseEasyRecipe", transceiverUseEasyRecipe, "When enabled the dim trans. will use a cheaper recipe")
         .getBoolean(useHardRecipes);
+
+    allowExternalTickSpeedup = config.get(sectionMisc.name, "allowExternalTickSpeedup", allowExternalTickSpeedup,
+        "Allows machines to run faster if another mod speeds up the tickrate. Running at higher tickrates is "
+            + "unsupported. Disable this if you run into any kind of problem.")
+        .getBoolean(allowExternalTickSpeedup);
 
     enchanterBaseLevelCost = config.get(sectionRecipe.name, "enchanterBaseLevelCost", enchanterBaseLevelCost,
         "Base level cost added to all recipes in the enchanter.").getInt(enchanterBaseLevelCost);


### PR DESCRIPTION
* Config value to have machines reject an update rate that is higher
than the global tick rate.
* Default is unchanged (allow).