### PR TITLE
Fix: TeleportEntityEvent fired twice

### DIFF
--- a/src/main/java/crazypants/enderio/teleport/packet/PacketTravelEvent.java
+++ b/src/main/java/crazypants/enderio/teleport/packet/PacketTravelEvent.java
@@ -68,10 +68,7 @@ public class PacketTravelEvent implements IMessage, IMessageHandler<PacketTravel
     int x = message.x, y = message.y, z = message.z;
 
     TravelSource source = TravelSource.values()[message.source];
-    TeleportEntityEvent evt = new TeleportEntityEvent(toTp, source, x, y, z);
-    if(!MinecraftForge.EVENT_BUS.post(evt)) {
-      doServerTeleport(toTp, x, y, z, message.powerUse, message.conserveMotion, source);
-    }
+    doServerTeleport(toTp, x, y, z, message.powerUse, message.conserveMotion, source);
 
     return null;
   }


### PR DESCRIPTION
doServerTeleport() does it, too.