### PR TITLE
Replace Conduits

### DIFF
--- a/src/main/java/crazypants/enderio/conduit/AbstractItemConduit.java
+++ b/src/main/java/crazypants/enderio/conduit/AbstractItemConduit.java
@@ -5,6 +5,7 @@ import java.util.List;
 import net.minecraft.block.Block;
 import net.minecraft.client.renderer.texture.IIconRegister;
 import net.minecraft.creativetab.CreativeTabs;
+import net.minecraft.entity.item.EntityItem;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
@@ -103,6 +104,31 @@ public abstract class AbstractItemConduit extends Item implements IConduitItem {
             }
           }
           return true;
+        } else {
+          // There's not really any good way to compare conduits...
+          IConduit existingConduit = bundle.getConduit(getBaseConduitType());
+          ItemStack existingConduitAsItemStack = existingConduit.createItem();
+          if (!crazypants.util.ItemUtil.areStacksEqual(existingConduitAsItemStack, stack)) {
+            if (!world.isRemote) {
+              IConduit newConduit = createConduit(stack, player);
+              if (newConduit == null) {
+                System.out.println("AbstractItemConduit.onItemUse: Conduit null.");
+                return false;
+              }
+              bundle.removeConduit(existingConduit);
+              bundle.addConduit(newConduit);
+              if (!player.capabilities.isCreativeMode) {
+                stack.stackSize--;
+                for (ItemStack drop : existingConduit.getDrops()) {
+                  EntityItem entityitem = new EntityItem(world, x + hitX, y + hitY, z + hitZ, drop);
+                  entityitem.delayBeforeCanPickup = 10;
+                  world.spawnEntityInWorld(entityitem);
+                }
+              }
+            }
+            return true;
+          }
+
         }
       }
     }


### PR DESCRIPTION
* When trying to place a conduit where different one of the same type already exists, this will drop the existing conduit and place the new one. (Old: do nothing)
* re #2485 