### PR TITLE
optimize canInsertItem

### DIFF
--- a/src/main/java/crazypants/enderio/machine/AbstractMachineEntity.java
+++ b/src/main/java/crazypants/enderio/machine/AbstractMachineEntity.java
@@ -643,11 +643,18 @@ public abstract class AbstractMachineEntity extends TileEntityEio implements ISi
   }
 
   @Override
-  public boolean canInsertItem(int slot, ItemStack var2, int side) {
-    if(isSideDisabled(side)) {
+  public boolean canInsertItem(int slot, ItemStack itemstack, int side) {
+    if(isSideDisabled(side) || !slotDefinition.isInputSlot(slot)) {
       return false;
     }
-    return slotDefinition.isInputSlot(slot) && isMachineItemValidForSlot(slot, var2);
+    ItemStack existing = inventory[slot];
+    if(existing != null) {
+      // no point in checking the recipes if an item is already in the slot
+      // worst case we get more of the wrong item - but that doesn't change anything
+      return existing.isStackable() && existing.isItemEqual(itemstack);
+    }
+    // no need to call isItemValidForSlot as upgrade slots are not input slots
+    return isMachineItemValidForSlot(slot, itemstack);
   }
 
   @Override

--- a/src/main/java/crazypants/enderio/machine/AbstractPoweredTaskEntity.java
+++ b/src/main/java/crazypants/enderio/machine/AbstractPoweredTaskEntity.java
@@ -47,20 +47,6 @@ public abstract class AbstractPoweredTaskEntity extends AbstractPowerConsumerEnt
   }
 
   @Override
-  public boolean canInsertItem(int i, ItemStack itemstack, int j) {
-    if(!super.canInsertItem(i, itemstack, j)) {
-      return false;
-    }
-    if(!isItemValidForSlot(i, itemstack)) {
-      return false;
-    }
-    if(inventory[i] == null) {
-      return true;
-    }
-    return inventory[i].isItemEqual(itemstack);
-  }
-
-  @Override
   public boolean isActive() {
     return currentTask == null ? false : currentTask.getProgress() >= 0 && hasPower() && redstoneCheckPassed;
   }


### PR DESCRIPTION
The previous implementations calls isMachineItemValidForSlot twice which can be expensive.