### PR TITLE
don't crash for unnamed inventories or when the name contains special characters

### DIFF
--- a/src/main/java/crazypants/enderio/conduit/item/ItemConduitNetwork.java
+++ b/src/main/java/crazypants/enderio/conduit/item/ItemConduitNetwork.java
@@ -14,7 +14,6 @@ import crazypants.enderio.conduit.item.NetworkedInventory.Target;
 import crazypants.enderio.conduit.item.filter.IItemFilter;
 import crazypants.enderio.machine.invpanel.server.InventoryDatabaseServer;
 import crazypants.util.BlockCoord;
-import crazypants.util.Lang;
 
 public class ItemConduitNetwork extends AbstractConduitNetwork<IItemConduit, IItemConduit> {
 
@@ -180,7 +179,7 @@ public class ItemConduitNetwork extends AbstractConduitNetwork<IItemConduit, IIt
           for (Target t : source.sendPriority) {
             IItemFilter f = t.inv.con.getOutputFilter(t.inv.conDir);
             if(input == null || f == null || f.doesItemPassFilter(t.inv, input)) {
-              String s = Lang.localize(t.inv.getInventory().getInventoryName(), false) + " " + t.inv.location.chatString() + " Distance [" + t.distance + "] ";
+              String s = t.inv.getLocalizedInventoryName() + " " + t.inv.location.chatString() + " Distance [" + t.distance + "] ";
               result.add(s);
             }
           }
@@ -197,7 +196,7 @@ public class ItemConduitNetwork extends AbstractConduitNetwork<IItemConduit, IIt
       if(inv.hasTarget(con, dir)) {
         IItemFilter f = inv.con.getInputFilter(inv.conDir);
         if(input == null || f == null || f.doesItemPassFilter(inv, input)) {
-          result.add(Lang.localize(inv.getInventory().getInventoryName(), false) + " " + inv.location.chatString());
+          result.add(inv.getLocalizedInventoryName() + " " + inv.location.chatString());
         }
       }
     }

--- a/src/main/java/crazypants/enderio/conduit/item/NetworkedInventory.java
+++ b/src/main/java/crazypants/enderio/conduit/item/NetworkedInventory.java
@@ -11,6 +11,7 @@ import net.minecraft.inventory.ISidedInventory;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.tileentity.TileEntityChest;
+import net.minecraft.util.StatCollector;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 import crazypants.enderio.conduit.ConnectionMode;
@@ -389,6 +390,17 @@ public class NetworkedInventory {
 
   public void setInventorySide(int inventorySide) {
     this.inventorySide = inventorySide;
+  }
+
+  public String getLocalizedInventoryName() {
+    String inventoryName = getInventory().getInventoryName();
+    if(inventoryName == null) {
+      return "null";
+    } else {
+      // don't use Lang.localize as that passes the localized string to
+      // String.format which might crash when it contains formatting specifiers
+      return StatCollector.translateToLocal(inventoryName);
+    }
   }
 
   static class Target implements Comparable<Target> {


### PR DESCRIPTION
While Lang.localize has a try/catch it doesn't make sense to use this class for names outside of the EnderIO resources. And sadly that try/catch did not protect against all crashes.