### PR TITLE
Fix: Combustion Generator Input Tank Handling

### DIFF
--- a/src/main/java/crazypants/enderio/machine/generator/combustion/TileCombustionGenerator.java
+++ b/src/main/java/crazypants/enderio/machine/generator/combustion/TileCombustionGenerator.java
@@ -419,11 +419,13 @@ public class TileCombustionGenerator extends AbstractGeneratorEntity implements 
 
   @Override
   public FluidTank getInputTank(FluidStack forFluidType) {
-    if (FluidFuelRegister.instance.getCoolant(forFluidType.getFluid()) != null) {
-      return coolantTank;
-    }
-    if (FluidFuelRegister.instance.getFuel(forFluidType.getFluid()) != null) {
-      return fuelTank;
+    if (forFluidType != null) {
+      if (FluidFuelRegister.instance.getCoolant(forFluidType.getFluid()) != null) {
+        return coolantTank;
+      }
+      if (FluidFuelRegister.instance.getFuel(forFluidType.getFluid()) != null) {
+        return fuelTank;
+      }
     }
     return null;
   }


### PR DESCRIPTION
* Combustion Generator Input Tank Handling wasn't implementing the
interface correctly, leading to NPEs
* re #2584