### PR TITLE
SAG Mill support for blocks

### DIFF
--- a/resources/assets/enderio/config/SAGMillRecipes_Core.xml
+++ b/resources/assets/enderio/config/SAGMillRecipes_Core.xml
@@ -445,7 +445,7 @@
     </recipe>
   </recipeGroup>
 
-  <recipeGroup name="Common Ores/Ingots" >
+  <recipeGroup name="Common Ores/Ingots/Blocks" >
     <recipe name="CopperOre" energyCost="3600" >
       <input>
         <itemStack oreDictionary="oreCopper" />
@@ -461,7 +461,15 @@
         <itemStack oreDictionary="ingotCopper" />
       </input>
       <output>
-        <itemStack oreDictionary="dustCopper" number="1" />
+        <itemStack oreDictionary="dustCopper" />
+      </output>
+    </recipe>
+    <recipe name="CopperBlock" energyCost="3600" >
+      <input>
+        <itemStack oreDictionary="blockCopper" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustCopper" number="9" />
       </output>
     </recipe>
     <recipe name="TinOre" energyCost="3600" >
@@ -478,7 +486,15 @@
         <itemStack oreDictionary="ingotTin" />
       </input>
       <output>
-        <itemStack oreDictionary="dustTin" number="1" />
+        <itemStack oreDictionary="dustTin" />
+      </output>
+    </recipe>
+    <recipe name="TinBlock" energyCost="3600" >
+      <input>
+        <itemStack oreDictionary="blockTin" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustTin" number="9" />
       </output>
     </recipe>
     <recipe name="LeadOre" energyCost="3600" >
@@ -499,6 +515,14 @@
         <itemStack oreDictionary="dustLead" />
       </output>
     </recipe>
+    <recipe name="LeadBlock" energyCost="3600" >
+      <input>
+        <itemStack oreDictionary="blockLead" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustLead" number="9" />
+      </output>
+    </recipe>
     <recipe name="SilverOre" energyCost="3600" >
       <input>
         <itemStack oreDictionary="oreSilver" />
@@ -516,12 +540,37 @@
         <itemStack oreDictionary="dustSilver" />
       </output>
     </recipe>
+    <recipe name="SilverBlock" energyCost="3600" >
+      <input>
+        <itemStack oreDictionary="blockSilver" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustSilver" number="9" />
+      </output>
+    </recipe>
     <recipe name="BronzeIngot" energyCost="2400" >
       <input>
         <itemStack oreDictionary="ingotBronze" />
       </input>
       <output>
         <itemStack oreDictionary="dustBronze" />
+      </output>
+    </recipe>
+    <recipe name="BronzeBlock" energyCost="3600" >
+      <input>
+        <itemStack oreDictionary="blockBronze" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustBronze" number="9" />
+      </output>
+    </recipe>
+    <recipe name="NickelOre" energyCost="3600" >
+      <input>
+        <itemStack oreDictionary="oreNickel" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustNickel" number="2" />
+        <itemStack oreDictionary="dustPlatinum" chance="0.1" />
       </output>
     </recipe>
     <recipe name="NickelIngot" energyCost="2400" >
@@ -532,13 +581,12 @@
         <itemStack oreDictionary="dustNickel" />
       </output>
     </recipe>
-    <recipe name="NickelOre" energyCost="3600" >
+    <recipe name="NickelBlock" energyCost="3600" >
       <input>
-        <itemStack oreDictionary="oreNickel" />
+        <itemStack oreDictionary="blockNickel" />
       </input>
       <output>
-        <itemStack oreDictionary="dustNickel" number="2" />
-        <itemStack oreDictionary="dustPlatinum" chance="0.1" />
+        <itemStack oreDictionary="dustNickel" number="9" />
       </output>
     </recipe>
     <recipe name="AluminiumOre" energyCost="2400" >
@@ -557,6 +605,14 @@
         <itemStack oreDictionary="dustAluminium" />
       </output>
     </recipe>
+    <recipe name="AluminiumBlock" energyCost="3600" >
+      <input>
+        <itemStack oreDictionary="blockAluminium" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustAluminium" number="9" />
+      </output>
+    </recipe>
     <recipe name="AluminumOre" energyCost="2400" >
       <input>
         <itemStack oreDictionary="oreAluminum" />
@@ -573,6 +629,14 @@
         <itemStack oreDictionary="dustAluminum" />
       </output>
     </recipe>
+    <recipe name="AluminumBlock" energyCost="3600" >
+      <input>
+        <itemStack oreDictionary="blockAluminum" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustAluminum" number="9" />
+      </output>
+    </recipe>
     <recipe name="NaturalAluminumOre" energyCost="2400" >
       <input>
         <itemStack oreDictionary="oreNaturalAluminum" />
@@ -587,6 +651,14 @@
       </input>
       <output>
         <itemStack oreDictionary="dustNaturalAluminum" />
+      </output>
+    </recipe>
+    <recipe name="NaturalAluminumBlock" energyCost="3600" >
+      <input>
+        <itemStack oreDictionary="blockNaturalAluminum" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustNaturalAluminum" number="9" />
       </output>
     </recipe>
   </recipeGroup>
@@ -2020,7 +2092,7 @@
     </recipe>
   </recipeGroup>
 
-  <recipeGroup name="BigReactors" >
+  <recipeGroup name="Big Reactors" >
     <!-- Metals -->
     <recipe name="YelloriteOre" energyCost="3600" >
       <input>
@@ -2032,12 +2104,12 @@
       </output>
     </recipe>
     <!-- Alloys and Ingots -->
-    <recipe name="YelloriteIngot" energyCost="2400" >
+    <recipe name="YelloriumIngot" energyCost="2400" >
       <input>
         <itemStack oreDictionary="ingotYellorium" />
       </input>
       <output>
-        <itemStack oreDictionary="dustUranium" number="1" />
+        <itemStack oreDictionary="dustYellorium" number="1" />
       </output>
     </recipe>
     <recipe name="CyaniteIngot" energyCost="2400" >
@@ -2062,6 +2134,55 @@
       </input>
       <output>
         <itemStack oreDictionary="dustGraphite" number="1" />
+      </output>
+    </recipe>
+    <recipe name="LudicriteIngot" energyCost="2400" >
+      <input>
+        <itemStack oreDictionary="ingotLudicrite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustLudicrite" number="1" />
+      </output>
+    </recipe>
+    <!-- Blocks -->
+    <recipe name="YelloriumBlock" energyCost="3600" >
+      <input>
+        <itemStack oreDictionary="blockYellorium" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustYellorium" number="9" />
+      </output>
+    </recipe>
+    <recipe name="CyaniteBlock" energyCost="3600" >
+      <input>
+        <itemStack oreDictionary="blockCyanite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustCyanite" number="9" />
+      </output>
+    </recipe>
+    <recipe name="GraphiteBlock" energyCost="3600" >
+      <input>
+        <itemStack oreDictionary="blockGraphite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustGraphite" number="9" />
+      </output>
+    </recipe>
+    <recipe name="BlutoniumBlock" energyCost="3600" >
+      <input>
+        <itemStack oreDictionary="blockBlutonium" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustBlutonium" number="9" />
+      </output>
+    </recipe>
+    <recipe name="LudicriteBlock" energyCost="3600" >
+      <input>
+        <itemStack oreDictionary="blockLudicrite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustLudicrite" number="9" />
       </output>
     </recipe>
   </recipeGroup>
@@ -2115,6 +2236,39 @@
       </input>
       <output>
         <itemStack oreDictionary="dustAluminumBrass" number="1" />
+      </output>
+    </recipe>
+    <!-- Blocks -->
+    <recipe name="ArditeBlock" energyCost="3600" >
+      <input>
+        <itemStack oreDictionary="blockArdite" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustArdite" number="9" />
+      </output>
+    </recipe>
+    <recipe name="CobaltBlock" energyCost="3600" >
+      <input>
+        <itemStack oreDictionary="blockCobalt" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustCobalt" number="9" />
+      </output>
+    </recipe>
+    <recipe name="ManyullynBlock" energyCost="3600" >
+      <input>
+        <itemStack oreDictionary="blockManyullyn" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustManyullyn" number="9" />
+      </output>
+    </recipe>
+    <recipe name="AluminumBrassBlock" energyCost="3600" >
+      <input>
+        <itemStack oreDictionary="blockAluminumBrass" />
+      </input>
+      <output>
+        <itemStack oreDictionary="dustAluminumBrass" number="9" />
       </output>
     </recipe>
   </recipeGroup>


### PR DESCRIPTION
Reworked version of #2418 but now without touching CoFH/Tcon stuff. Only added blocks support for existing stuff.