### PR TITLE
Fix for #2751 - SAG mill producing sand with invalid metadata

### DIFF
--- a/resources/assets/enderio/config/OreDictionaryPreferences_Core.xml
+++ b/resources/assets/enderio/config/OreDictionaryPreferences_Core.xml
@@ -25,6 +25,11 @@
 
 <OreDictionaryPreferences>
 
+  <!-- Vanilla -->
+  <preference oreDictionary="sand" >
+    <itemStack modID="minecraft" itemName="sand" itemMeta="0" />
+  </preference>
+
   <!-- Dusts -->
   <preference oreDictionary="dustCoal" >
     <itemStack modID="ThermalFoundation" itemName="material" itemMeta="2" />

--- a/resources/assets/enderio/config/SAGMillRecipes_Core.xml
+++ b/resources/assets/enderio/config/SAGMillRecipes_Core.xml
@@ -300,8 +300,8 @@
         <itemStack oreDictionary="gravel" />
       </input>
       <output>
-        <itemStack oreDictionary="flint" />
-        <itemStack oreDictionary="flint" chance="0.1" />
+        <itemStack oreDictionary="itemFlint" />
+        <itemStack oreDictionary="itemFlint" chance="0.1" />
         <itemStack oreDictionary="sand" chance="0.1" />
       </output>
     </recipe>


### PR DESCRIPTION
These also renames ore dict references from `flint` to `itemFlint` as that's what `enderio.core.common.OreDict` is registering flint as.

I'm not sure if this fully solves #2776 though: I wasn't able to reproduce the "invalid OreDictionary tag" thing.