### PR TITLE
small enhancements(?) related to TinkersConstruct and Mekanism

### DIFF
--- a/src/main/java/crazypants/enderio/machine/farm/TileFarmStation.java
+++ b/src/main/java/crazypants/enderio/machine/farm/TileFarmStation.java
@@ -294,6 +294,23 @@ public class TileFarmStation extends AbstractPoweredTaskEntity {
         EnchantmentHelper.getEnchantmentLevel(Enchantment.fortune.effectId, stack));
   }
 
+  @Override
+  public boolean canExtractItem(int slot, ItemStack itemstack, int side) {
+    if(super.canExtractItem(slot, itemstack, side)) {
+      return true;
+    }
+    //allow almost completely broken tools from Tinkers Construct to be extracted to get them repaired/recharged
+    if(slot >= minToolSlot && slot <= maxToolSlot && itemstack.getItemDamage() >= 95) {
+      Class<?> c = itemstack.getItem().getClass();
+      do {
+        if(c.getName().equals("tconstruct.library.tools.HarvestTool"))
+          return true;
+        c = c.getSuperclass();
+      } while(c != null);
+    }
+    return false;
+  }
+
   public EntityPlayerMP getFakePlayer() {
     return farmerJoe;
   }

--- a/src/main/java/crazypants/enderio/machine/killera/TileKillerJoe.java
+++ b/src/main/java/crazypants/enderio/machine/killera/TileKillerJoe.java
@@ -118,7 +118,16 @@ public class TileKillerJoe extends AbstractMachineEntity implements IFluidHandle
     if(itemstack == null) {
       return false;
     }
-    return itemstack.getItem() instanceof ItemSword;
+    if(itemstack.getItem() instanceof ItemSword)
+      return true;
+    
+    Class<?> c = itemstack.getItem().getClass();
+    do {
+      if(c.getName().equals("tconstruct.library.tools.Weapon"))
+        return true;
+      c = c.getSuperclass();
+    } while(c != null);
+    return false;
   }
 
   @Override

--- a/src/main/java/crazypants/enderio/machine/solar/TileEntitySolarPanel.java
+++ b/src/main/java/crazypants/enderio/machine/solar/TileEntitySolarPanel.java
@@ -4,12 +4,15 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.ListIterator;
 
+import cpw.mods.fml.common.Optional;
+import mekanism.api.ISalinationSolar;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.network.NetworkManager;
 import net.minecraft.network.Packet;
 import net.minecraft.network.play.server.S35PacketUpdateTileEntity;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.MathHelper;
+import net.minecraft.world.biome.BiomeGenDesert;
 import net.minecraft.world.EnumSkyBlock;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
@@ -24,7 +27,8 @@ import crazypants.enderio.power.IPowerInterface;
 import crazypants.enderio.power.PowerHandlerUtil;
 import crazypants.enderio.waila.IWailaNBTProvider;
 
-public class TileEntitySolarPanel extends TileEntityEio implements IInternalPowerProvider, IWailaNBTProvider {
+@Optional.Interface(iface = "mekanism.api.ISalinationSolar", modid = "MekanismAPI|core")
+public class TileEntitySolarPanel extends TileEntityEio implements IInternalPowerProvider, IWailaNBTProvider, ISalinationSolar {
   
   private final List<Receptor> receptors = new ArrayList<Receptor>();
   private ListIterator<Receptor> receptorIterator = receptors.listIterator();
@@ -288,5 +292,15 @@ public class TileEntitySolarPanel extends TileEntityEio implements IInternalPowe
     if (network.isValid()) {
       network.getMaster().writeToNBT(tag);
     }
+  }
+  
+  @Override
+  @Optional.Method(modid = "MekanismAPI|core")
+  public boolean seesSun() {
+    return worldObj.isDaytime()
+      && ((!worldObj.isRaining() && !worldObj.isThundering())
+        || (worldObj.provider.getBiomeGenForCoords(xCoord >> 4, zCoord >> 4) instanceof BiomeGenDesert))
+      && !worldObj.provider.hasNoSky
+      && worldObj.canBlockSeeTheSky(xCoord, yCoord, zCoord);
   }
 }


### PR DESCRIPTION
TileFarmStation: Allow almost completely broken Tools from Tinkers Construct to be extracted from the Farming Station.
With this modification I'm able to automate the use of TinkersConstruct Tools in the Farming Station so it is easy to automatically recharge a Tool with the flux modifier. 

TileKillerJoe: The Killer Joe now also accepts Tinkers Construct Weapons (those don't extend ItemSword)
The effects (modifiers) of the Weapon do apply, so the attack works as expected, but the weapon does not render. The Killer Joe looks like it has no weapon equipped.
Maybe allowing the Weapon to be extracted like I did it with the Farming Station would be useful, too. I haven't used the Killer Joe much, and I've not yet tried to automate it.

TileEntitySolarPanel: The Mekanism Solar Evaporation Plant (aka Salination Plant) can now be "powered" by EnderIO Photovoltaic Cells. (seesSun() uses the same constraints Mekanism uses with their Solar Panel.)
I like to play with Mekanism but I only use the base package which does not include the Generators. I looked for another way to run a Solar Evaporation Plant so I decided to implement the required Interface on the Photovoltaic Cell form EnderIO. I did not restrict it to the Advanced Photovoltaic Cell, the (basic / orange) Photovoltaic Cell does also work.

Both of the TinkersConstruct related modifications work without any additional API requirements.
Since the mekanism API is already used, the Photovoltaic Cell modification doesn't need an additional API either.
I have used this modifications for quite some time on my singleplayer worlds and I think it's time to at least share the idea and the code I wrote. Feel free to cherry pick whatever you like if you think it would be useful.