### PR TITLE
Typo in XML: "RegistEry"

### DIFF
--- a/resources/assets/enderio/config/SAGMillRecipes_Core.xml
+++ b/resources/assets/enderio/config/SAGMillRecipes_Core.xml
@@ -123,13 +123,17 @@
 
  Item Information and data dumps:
 
-  To write all registered items to config/modObjectsRegistery.txt include:
+  To write all registered items to config/enderio/modObjectsRegistery.txt include:
 
   <dumpRegistry modObjects="true" />
 
-  To write the contents of the ore dictionary to config/oreDictionaryRegistery.txt include:
+  To write the contents of the ore dictionary to config/enderio/oreDictionaryRegistery.txt include:
 
-  <dumpRegistery oreDictionary="true" />
+  <dumpRegistry oreDictionary="true" />
+
+  To dump both, write:
+
+  <dumpRegistry modObjects="true" oreDictionary="true" />
 
   To show ore dictionary and/or registered names, in the EnderIO config set:
 

--- a/src/main/java/crazypants/enderio/machine/recipe/RecipeConfigParser.java
+++ b/src/main/java/crazypants/enderio/machine/recipe/RecipeConfigParser.java
@@ -43,7 +43,8 @@ public class RecipeConfigParser extends DefaultHandler {
   public static final String ELEMENT_OUTPUT = "output";
   public static final String ELEMENT_ITEM_STACK = "itemStack";
   public static final String ELEMENT_FLUID_STACK = "fluidStack";
-  public static final String ELEMENT_DUMP_REGISTERY = "dumpRegistery";
+  public static final String ELEMENT_DUMP_REGISTERY = "dumpRegistery"; // compat
+  public static final String ELEMENT_DUMP_REGISTRY = "dumpRegistry";
 
   public static final String AT_NAME = "name";
   public static final String AT_ENABLED = "enabled";
@@ -219,7 +220,7 @@ public class RecipeConfigParser extends DefaultHandler {
       root = new RecipeConfig();
     }
 
-    if(ELEMENT_DUMP_REGISTERY.equals(localName)) {
+    if (ELEMENT_DUMP_REGISTERY.equals(localName) || ELEMENT_DUMP_REGISTRY.equals(localName)) {
       root.setDumpOreDictionary(getBooleanValue(AT_ORE_DICT, attributes, false));
       root.setDumpItemRegistery(getBooleanValue(AT_DUMP_ITEMS, attributes, false));
       return;


### PR DESCRIPTION
* Fixed SAGMillRecipes_Core.xml; added info on how to set both values
and better path info for clarity
* Fixed parser; left old spelling for compatibility
* re #2798 