### PR TITLE
Use seperate texture for machine bottom

### DIFF
--- a/src/main/java/crazypants/enderio/machine/AbstractMachineBlock.java
+++ b/src/main/java/crazypants/enderio/machine/AbstractMachineBlock.java
@@ -70,6 +70,7 @@ public abstract class AbstractMachineBlock<T extends AbstractMachineEntity> exte
     this(mo, teClass, new Material(MapColor.ironColor));
   }
 
+  @Override
   protected void init() {
     GameRegistry.registerBlock(this, modObject.unlocalisedName);
     GameRegistry.registerTileEntity(teClass, modObject.unlocalisedName + "TileEntity");
@@ -81,6 +82,7 @@ public abstract class AbstractMachineBlock<T extends AbstractMachineEntity> exte
     return renderId;
   }
 
+  @Override
   public boolean openGui(World world, int x, int y, int z, EntityPlayer entityPlayer, int side) {
     if(!world.isRemote) {
       entityPlayer.openGui(EnderIO.instance, getGuiId(), world, x, y, z);
@@ -100,7 +102,7 @@ public abstract class AbstractMachineBlock<T extends AbstractMachineEntity> exte
     iconBuffer = new IIcon[2][12];
     String side = getSideIconKey(false);
     // first the 6 sides in OFF state
-    iconBuffer[0][0] = iIconRegister.registerIcon(side);
+    iconBuffer[0][0] = iIconRegister.registerIcon(getBottomIconKey(false));
     iconBuffer[0][1] = iIconRegister.registerIcon(getTopIconKey(false));
     iconBuffer[0][2] = iIconRegister.registerIcon(getBackIconKey(false));
     iconBuffer[0][3] = iIconRegister.registerIcon(getMachineFrontIconKey(false));
@@ -108,7 +110,7 @@ public abstract class AbstractMachineBlock<T extends AbstractMachineEntity> exte
     iconBuffer[0][5] = iIconRegister.registerIcon(side);
 
     side = getSideIconKey(true);
-    iconBuffer[0][6] = iIconRegister.registerIcon(side);
+    iconBuffer[0][6] = iIconRegister.registerIcon(getBottomIconKey(true));
     iconBuffer[0][7] = iIconRegister.registerIcon(getTopIconKey(true));
     iconBuffer[0][8] = iIconRegister.registerIcon(getBackIconKey(true));
     iconBuffer[0][9] = iIconRegister.registerIcon(getMachineFrontIconKey(true));
@@ -273,6 +275,10 @@ public abstract class AbstractMachineBlock<T extends AbstractMachineEntity> exte
 
   protected String getTopIconKey(boolean active) {
     return "enderio:machineTop";
+  }
+
+  protected String getBottomIconKey(boolean active) {
+    return "enderio:machineTemplate";
   }
 
   protected String getModelIconKey(boolean active) {

--- a/src/main/java/crazypants/enderio/machine/obelisk/BlockObeliskAbstract.java
+++ b/src/main/java/crazypants/enderio/machine/obelisk/BlockObeliskAbstract.java
@@ -44,6 +44,11 @@ public abstract class BlockObeliskAbstract<T extends AbstractMachineEntity> exte
   }
 
   @Override
+  protected String getBottomIconKey(boolean active) {
+    return "enderio:blockSoulMachineBlank";
+  }
+
+  @Override
   public boolean renderAsNormalBlock() {
     return false;
   }

--- a/src/main/java/crazypants/enderio/machine/slicensplice/BlockSliceAndSplice.java
+++ b/src/main/java/crazypants/enderio/machine/slicensplice/BlockSliceAndSplice.java
@@ -69,6 +69,11 @@ public class BlockSliceAndSplice extends AbstractMachineBlock<TileSliceAndSplice
   }
 
   @Override
+  protected String getBottomIconKey(boolean active) {
+    return "enderio:blockSoulMachineBlank";
+  }
+
+  @Override
   protected String getBackIconKey(boolean active) {
     return "enderio:blockSoulMachineBack";
   }

--- a/src/main/java/crazypants/enderio/machine/soul/BlockSoulBinder.java
+++ b/src/main/java/crazypants/enderio/machine/soul/BlockSoulBinder.java
@@ -98,8 +98,14 @@ public class BlockSoulBinder extends AbstractMachineBlock<TileSoulBinder> {
     return "enderio:blockSoulMachineBlank";
   }
   
+  @Override
   protected String getTopIconKey(boolean active) {
     return "enderio:blockSoulMachineTop";
+  }
+
+  @Override
+  protected String getBottomIconKey(boolean active) {
+    return "enderio:blockSoulMachineBlank";
   }
 
   @Override


### PR DESCRIPTION
The side looks a bit silly on the bottom, as it has an up and a down. "machineTemplate.png"/"blockSoulMachineBlank.png" are nice and
symetrical. Should they be copied over to
"machineBottom.png"/"blockSoulMachineBottom.png"?