### PR TITLE
Generic GUI classes handling

### DIFF
--- a/src/main/java/crazypants/enderio/machine/alloy/BlockAlloySmelter.java
+++ b/src/main/java/crazypants/enderio/machine/alloy/BlockAlloySmelter.java
@@ -29,6 +29,7 @@ public class BlockAlloySmelter extends AbstractMachineBlock<TileAlloySmelter> {
 
   private BlockAlloySmelter() {
     super(ModObject.blockAlloySmelter, TileAlloySmelter.class);
+    setGuiClasses(ContainerAlloySmelter.class, GuiAlloySmelter.class);
   }
 
   @Override
@@ -38,23 +39,6 @@ public class BlockAlloySmelter extends AbstractMachineBlock<TileAlloySmelter> {
     vanillaSmeltingOn = iIconRegister.registerIcon("enderio:furnaceSmeltingOn");
     vanillaSmeltingOff = iIconRegister.registerIcon("enderio:furnaceSmeltingOff");
     vanillaSmeltingOnly = iIconRegister.registerIcon("enderio:furnaceSmeltingOnly");
-  }
-
-  @Override
-  public Object getServerGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z) {
-    // The server needs the container as it manages the adding and removing of
-    // items, which are then sent to the client for display
-    TileEntity te = world.getTileEntity(x, y, z);
-    if(te instanceof TileAlloySmelter) {
-      return new ContainerAlloySmelter(player.inventory, (TileAlloySmelter) te);
-    }
-    return null;
-  }
-
-  @Override
-  public Object getClientGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z) {
-    TileEntity te = world.getTileEntity(x, y, z);
-    return new GuiAlloySmelter(player.inventory, (TileAlloySmelter) te);
   }
 
   @Override

--- a/src/main/java/crazypants/enderio/machine/buffer/BlockBuffer.java
+++ b/src/main/java/crazypants/enderio/machine/buffer/BlockBuffer.java
@@ -41,6 +41,7 @@ public class BlockBuffer extends AbstractMachineBlock<TileBuffer> implements IFa
 
   private BlockBuffer() {
     super(ModObject.blockBuffer, TileBuffer.class);
+    setGuiClasses(ContainerBuffer.class, GuiBuffer.class);
   }
 
   @Override
@@ -49,24 +50,6 @@ public class BlockBuffer extends AbstractMachineBlock<TileBuffer> implements IFa
     GameRegistry.registerTileEntity(teClass, modObject.unlocalisedName + "TileEntity");
     EnderIO.guiHandler.registerGuiHandler(getGuiId(), this);
     MachineRecipeRegistry.instance.registerRecipe(ModObject.blockPainter.unlocalisedName, new PainterTemplate());
-  }
-
-  @Override
-  public Object getServerGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z) {
-    TileEntity te = world.getTileEntity(x, y, z);
-    if(te instanceof TileBuffer) {
-      return new ContainerBuffer(player.inventory, (TileBuffer) te);
-    }
-    return null;
-  }
-
-  @Override
-  public Object getClientGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z) {
-    TileEntity te = world.getTileEntity(x, y, z);
-    if(te instanceof TileBuffer) {
-      return new GuiBuffer(player.inventory, (TileBuffer) te);
-    }
-    return null;
   }
 
   @Override

--- a/src/main/java/crazypants/enderio/machine/crafter/BlockCrafter.java
+++ b/src/main/java/crazypants/enderio/machine/crafter/BlockCrafter.java
@@ -20,24 +20,7 @@ public class BlockCrafter extends AbstractMachineBlock<TileCrafter> {
   
   protected BlockCrafter() {
     super(ModObject.blockCrafter, TileCrafter.class);
-  }
-
-  @Override
-  public Object getServerGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z) {
-    TileEntity te = world.getTileEntity(x, y, z);
-    if(te instanceof TileCrafter) {
-      return new ContainerCrafter(player.inventory, (TileCrafter) te);
-    }
-    return null;
-  }
-
-  @Override
-  public Object getClientGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z) {
-    TileEntity te = world.getTileEntity(x, y, z);
-    if(te instanceof TileCrafter) {
-      return new GuiCrafter(player.inventory, (TileCrafter) te);
-    }
-    return null;
+    setGuiClasses(ContainerCrafter.class, GuiCrafter.class);
   }
 
   @Override

--- a/src/main/java/crazypants/enderio/machine/crusher/BlockCrusher.java
+++ b/src/main/java/crazypants/enderio/machine/crusher/BlockCrusher.java
@@ -25,26 +25,7 @@ public class BlockCrusher extends AbstractMachineBlock {
 
   private BlockCrusher() {
     super(ModObject.blockSagMill, TileCrusher.class);
-  }
-
-  @Override
-  public Object getServerGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z) {
-    // The server needs the container as it manages the adding and removing of
-    // items, which are then sent to the client for display
-    TileEntity te = world.getTileEntity(x, y, z);
-    if(te instanceof TileCrusher) {
-      return new ContainerCrusher(player.inventory, (TileCrusher) te);
-    }
-    return null;
-  }
-
-  @Override
-  public Object getClientGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z) {
-    TileEntity te = world.getTileEntity(x, y, z);
-    if(te instanceof TileCrusher) {
-      return new GuiCrusher(player.inventory, (TileCrusher) te);
-    }
-    return null;
+    setGuiClasses(ContainerCrusher.class, GuiCrusher.class);
   }
 
   @Override

--- a/src/main/java/crazypants/enderio/machine/farm/BlockFarmStation.java
+++ b/src/main/java/crazypants/enderio/machine/farm/BlockFarmStation.java
@@ -35,24 +35,7 @@ public class BlockFarmStation extends AbstractMachineBlock<TileFarmStation> {
 
   protected BlockFarmStation() {
     super(ModObject.blockFarmStation, TileFarmStation.class);
-  }
-
-  @Override
-  public Object getServerGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z) {
-    TileEntity te = world.getTileEntity(x, y, z);
-    if(te instanceof TileFarmStation) {
-      return new FarmStationContainer(player.inventory, (TileFarmStation)te);
-    }
-    return null;
-  }
-
-  @Override
-  public Object getClientGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z) {
-    TileEntity te = world.getTileEntity(x, y, z);
-    if(te instanceof TileFarmStation) {
-      return new GuiFarmStation(player.inventory, (TileFarmStation) te);
-    }
-    return null;
+    setGuiClasses(FarmStationContainer.class, GuiFarmStation.class);
   }
 
   @Override

--- a/src/main/java/crazypants/enderio/machine/generator/combustion/BlockCombustionGenerator.java
+++ b/src/main/java/crazypants/enderio/machine/generator/combustion/BlockCombustionGenerator.java
@@ -33,29 +33,12 @@ public class BlockCombustionGenerator extends AbstractMachineBlock<TileCombustio
 
   protected BlockCombustionGenerator() {
     super(ModObject.blockCombustionGenerator, TileCombustionGenerator.class);
+    setGuiClasses(ContainerCombustionEngine.class, GuiCombustionGenerator.class);
   }
 
   @Override
   public int getLightOpacity() {
     return 0;
-  }
-
-  @Override
-  public Object getServerGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z) {
-    TileEntity te = world.getTileEntity(x, y, z);
-    if(te instanceof TileCombustionGenerator) {
-      return new ContainerCombustionEngine(player.inventory, (TileCombustionGenerator) te);
-    }
-    return null;
-  }
-
-  @Override
-  public Object getClientGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z) {
-    TileEntity te = world.getTileEntity(x, y, z);
-    if(te instanceof TileCombustionGenerator) {
-      return new GuiCombustionGenerator(player.inventory, (TileCombustionGenerator) te);
-    }
-    return null;
   }
 
   @Override

--- a/src/main/java/crazypants/enderio/machine/generator/combustion/ContainerCombustionEngine.java
+++ b/src/main/java/crazypants/enderio/machine/generator/combustion/ContainerCombustionEngine.java
@@ -6,7 +6,7 @@ import crazypants.enderio.machine.gui.AbstractMachineContainer;
 
 public class ContainerCombustionEngine extends AbstractMachineContainer {
 
-  public ContainerCombustionEngine(InventoryPlayer playerInv, AbstractMachineEntity te) {
+  public ContainerCombustionEngine(InventoryPlayer playerInv, TileCombustionGenerator te) {
     super(playerInv, te);
   }
 

--- a/src/main/java/crazypants/enderio/machine/generator/stirling/BlockStirlingGenerator.java
+++ b/src/main/java/crazypants/enderio/machine/generator/stirling/BlockStirlingGenerator.java
@@ -25,16 +25,7 @@ public class BlockStirlingGenerator extends AbstractMachineBlock<TileEntityStirl
 
   protected BlockStirlingGenerator() {
     super(ModObject.blockStirlingGenerator, TileEntityStirlingGenerator.class);
-  }
-
-  @Override
-  public Object getServerGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z) {
-    return new StirlingGeneratorContainer(player.inventory, (TileEntityStirlingGenerator) world.getTileEntity(x, y, z));
-  }
-
-  @Override
-  public Object getClientGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z) {
-    return new GuiStirlingGenerator(player.inventory, (TileEntityStirlingGenerator) world.getTileEntity(x, y, z));
+    setGuiClasses(StirlingGeneratorContainer.class, GuiStirlingGenerator.class);
   }
 
   @Override

--- a/src/main/java/crazypants/enderio/machine/generator/zombie/BlockZombieGenerator.java
+++ b/src/main/java/crazypants/enderio/machine/generator/zombie/BlockZombieGenerator.java
@@ -29,6 +29,7 @@ public class BlockZombieGenerator extends AbstractMachineBlock<TileZombieGenerat
 
   protected BlockZombieGenerator() {
     super(ModObject.blockZombieGenerator, TileZombieGenerator.class, Material.anvil);
+    setGuiClasses(ContainerZombieGenerator.class, GuiZombieGenerator.class);
   }
 
   @Override
@@ -39,16 +40,6 @@ public class BlockZombieGenerator extends AbstractMachineBlock<TileZombieGenerat
   @Override
   public boolean isReplaceable(IBlockAccess world, int x, int y, int z) {
     return false;
-  }
-
-  @Override
-  public Object getServerGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z) {
-    return new ContainerZombieGenerator(player.inventory, (TileZombieGenerator) world.getTileEntity(x, y, z));
-  }
-
-  @Override
-  public Object getClientGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z) {
-    return new GuiZombieGenerator(player.inventory, (TileZombieGenerator) world.getTileEntity(x, y, z));
   }
 
   @Override

--- a/src/main/java/crazypants/enderio/machine/generator/zombie/ContainerZombieGenerator.java
+++ b/src/main/java/crazypants/enderio/machine/generator/zombie/ContainerZombieGenerator.java
@@ -6,7 +6,7 @@ import crazypants.enderio.machine.gui.AbstractMachineContainer;
 
 public class ContainerZombieGenerator extends AbstractMachineContainer {
 
-  public ContainerZombieGenerator(InventoryPlayer playerInv, AbstractMachineEntity te) {
+  public ContainerZombieGenerator(InventoryPlayer playerInv, TileZombieGenerator te) {
     super(playerInv, te);
   }
 

--- a/src/main/java/crazypants/enderio/machine/gui/GuiClassMaker.java
+++ b/src/main/java/crazypants/enderio/machine/gui/GuiClassMaker.java
@@ -1,0 +1,177 @@
+package crazypants.enderio.machine.gui;
+
+import java.lang.reflect.Constructor;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.entity.player.InventoryPlayer;
+import net.minecraft.inventory.IInventory;
+import net.minecraft.tileentity.TileEntity;
+import crazypants.enderio.Log;
+
+/**
+ * A proxy class to create Container and GUI classes. This allows a superclass
+ * to create matching classes for its subclasses, using only the class
+ * references.
+ *
+ */
+public class GuiClassMaker {
+  private final Class<?> targetClass;
+  private final Constructor constructor;
+  private final GuiClassMaker.CallType callType;
+  private final String caseName;
+
+  /**
+   * The different patterns of parameter for the constructor that are supported:
+   * <ul>
+   * <li>{@link #NONE}: No constructor found (yet).
+   * <li>{@link #TE}: A TileEntity of the given type.
+   * <li>{@link #INV}: An InventoryPlayer or IInventory.
+   * <li>{@link #INV_TE}: An InventoryPlayer and a TileEntity.
+   * <li>{@link #PL_INV_TE}: A player, an InventoryPlayer and a TileEntity.
+   * <li>{@link #TE_CONT}: A TileEntity and a Container class.
+   * <li>{@link #DEFAULT}: The parameterless default constructor.
+   * </ul>
+   * There are way to many different constructors...
+   */
+  private static enum CallType {
+    NONE, TE, INV, INV_TE, PL_INV_TE, DEFAULT, TE_CONT;
+  }
+
+  private GuiClassMaker(Class<?> targetClass, Constructor constructor, GuiClassMaker.CallType callType, String caseName) {
+    this.targetClass = targetClass;
+    this.constructor = constructor;
+    this.callType = callType;
+    this.caseName = caseName;
+  }
+
+  /**
+   * Finds out which constructor of the given targetClass can be used to create
+   * it for the given teClass and optionally (for GUI classes) the given
+   * additional class (usually a Container class).
+   * 
+   * @param targetClass
+   *          The class that should be created. Can be null.
+   * @param teClass
+   *          The TileEntity the targetClass relates to.
+   * @param scondaryClass
+   *          A secondary class that may be an additional parameter of the
+   *          constructor.
+   * @param caseName
+   *          A name to be used in the logfile warning if no matching
+   *          constructor is found.
+   * @return A GuiClassMaker object that can be used to create an object of
+   *         class targetClass or null if either no targetClass was given or no
+   *         constructor could be be found.
+   */
+  @Nullable
+  public static GuiClassMaker getClassMaker(@Nullable Class<?> targetClass, Class<?> teClass, @Nullable Class<?> scondaryClass,
+      @Nonnull String caseName) {
+    Constructor tmpConstructor = null;
+    GuiClassMaker.CallType tmpCallType = CallType.NONE;
+    if (targetClass != null) {
+        try {
+        tmpConstructor = targetClass.getDeclaredConstructor(new Class[] { teClass });
+        tmpCallType = CallType.TE;
+      } catch (Exception e) {
+      }
+      if (tmpCallType == CallType.NONE) {
+        try {
+          tmpConstructor = targetClass.getDeclaredConstructor(new Class[] { InventoryPlayer.class });
+          tmpCallType = CallType.INV;
+        } catch (Exception e) {
+        }
+      }
+      if (tmpCallType == CallType.NONE) {
+        try {
+          tmpConstructor = targetClass.getDeclaredConstructor(new Class[] { IInventory.class });
+          tmpCallType = CallType.INV;
+        } catch (Exception e) {
+        }
+      }
+      if (tmpCallType == CallType.NONE) {
+        try {
+          tmpConstructor = targetClass.getDeclaredConstructor(new Class[] { InventoryPlayer.class, teClass });
+          tmpCallType = CallType.INV_TE;
+        } catch (Exception e) {
+        }
+      }
+      if (tmpCallType == CallType.NONE) {
+        try {
+          tmpConstructor = targetClass.getDeclaredConstructor(new Class[] { EntityPlayer.class, InventoryPlayer.class, teClass });
+          tmpCallType = CallType.PL_INV_TE;
+        } catch (Exception e) {
+        }
+      }
+      if (tmpCallType == CallType.NONE) {
+        try {
+          tmpConstructor = targetClass.getDeclaredConstructor(new Class[] {});
+          tmpCallType = CallType.DEFAULT;
+        } catch (Exception e) {
+        }
+      }
+      if (tmpCallType == CallType.NONE) {
+        try {
+          if (scondaryClass != null) {
+            tmpConstructor = targetClass.getDeclaredConstructor(new Class[] { teClass, scondaryClass });
+            tmpCallType = CallType.TE_CONT;
+          }
+        } catch (Exception e) {
+          }
+        }
+      if (tmpCallType == CallType.NONE) {
+        Log.warn("Failed to find constructor for " + caseName + " '" + targetClass.getName() + "' of TileEntity '" + teClass.getName() + "'");
+        return null;
+      } else {
+        return new GuiClassMaker(targetClass, tmpConstructor, tmpCallType, caseName);
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Creates and returns a new object of the targetClass this GuiClassMaker was
+   * configured for.
+   * 
+   * @param player
+   *          An EntityPlayer object.
+   * @param te
+   *          A TileEntity of the same class this GuiClassMaker was configured
+   *          for.
+   * @param secondary
+   *          An optional GuiClassMaker object to provide another parameter
+   *          object.
+   * @return A new object or null if no new object can be created.
+   */
+  @Nullable
+  public Object makeClass(@Nonnull EntityPlayer player, @Nonnull TileEntity te, @Nullable GuiClassMaker secondary) {
+    try {
+      switch (callType) {
+      case NONE:
+        return null;
+      case DEFAULT:
+        return constructor.newInstance(new Object[] {});
+      case TE:
+        return constructor.newInstance(new Object[] { te });
+      case INV:
+        return constructor.newInstance(new Object[] { player.inventory });
+      case INV_TE:
+        return constructor.newInstance(new Object[] { player.inventory, te });
+      case PL_INV_TE:
+        return constructor.newInstance(new Object[] { player, player.inventory, te });
+      case TE_CONT:
+        if(secondary != null) {
+          return constructor.newInstance(new Object[] { te, secondary.makeClass(player, te, null) });
+        } else {
+          throw new Exception("ContainerClass missing but required");
+        }
+      }
+    } catch (Exception e) {
+      Log.warn("Failed to call constructor for " + caseName + " '" + targetClass.getName() + "' of TileEntity '" + te.getClass().getName() + "': " + e);
+    }
+    return null;
+  }
+  
+}

--- a/src/main/java/crazypants/enderio/machine/invpanel/BlockInventoryPanel.java
+++ b/src/main/java/crazypants/enderio/machine/invpanel/BlockInventoryPanel.java
@@ -43,6 +43,7 @@ public class BlockInventoryPanel extends AbstractMachineBlock<TileInventoryPanel
 
   public BlockInventoryPanel() {
     super(ModObject.blockInventoryPanel, TileInventoryPanel.class);
+    setGuiClasses(InventoryPanelContainer.class, GuiInventoryPanel.class);
   }
 
   @Override
@@ -172,20 +173,4 @@ public class BlockInventoryPanel extends AbstractMachineBlock<TileInventoryPanel
     return iconBuffer[0][blockSide + 6];
   }
 
-  @Override
-  public Object getServerGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z) {
-    // The server needs the container as it manages the adding and removing of
-    // items, which are then sent to the client for display
-    TileEntity te = world.getTileEntity(x, y, z);
-    if(te instanceof TileInventoryPanel) {
-      return new InventoryPanelContainer(player.inventory, (TileInventoryPanel) te);
-    }
-    return null;
-  }
-
-  @Override
-  public Object getClientGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z) {
-    TileInventoryPanel te = (TileInventoryPanel) world.getTileEntity(x, y, z);
-    return new GuiInventoryPanel(te, new InventoryPanelContainer(player.inventory, te));
-  }
 }

--- a/src/main/java/crazypants/enderio/machine/invpanel/GuiInventoryPanel.java
+++ b/src/main/java/crazypants/enderio/machine/invpanel/GuiInventoryPanel.java
@@ -88,7 +88,7 @@ public class GuiInventoryPanel extends GuiMachineBase<TileInventoryPanel> {
 
   private final Rectangle btnAddStoredRecipe = new Rectangle();
 
-  public GuiInventoryPanel(TileInventoryPanel te, Container container) {
+  public GuiInventoryPanel(TileInventoryPanel te, InventoryPanelContainer container) {
     super(te, container);
     redstoneButton.visible = false;
     configB.visible = false;

--- a/src/main/java/crazypants/enderio/machine/killera/BlockKillerJoe.java
+++ b/src/main/java/crazypants/enderio/machine/killera/BlockKillerJoe.java
@@ -35,7 +35,8 @@ public class BlockKillerJoe extends AbstractMachineBlock<TileKillerJoe> {
 
   protected BlockKillerJoe() {
     super(ModObject.blockKillerJoe, TileKillerJoe.class);
-    setStepSound(Block.soundTypeGlass);    
+    setStepSound(Block.soundTypeGlass);
+    setGuiClasses(ContainerKillerJoe.class, GuiKillerJoe.class);
   }
   
   @Override
@@ -50,16 +51,6 @@ public class BlockKillerJoe extends AbstractMachineBlock<TileKillerJoe> {
     }
   }
   
-  @Override
-  public Object getServerGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z) {
-    return new ContainerKillerJoe(player.inventory, (TileKillerJoe) world.getTileEntity(x, y, z));
-  }
-
-  @Override
-  public Object getClientGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z) {
-    return new GuiKillerJoe(player.inventory, (TileKillerJoe) world.getTileEntity(x, y, z));
-  }
-
   @Override
   protected int getGuiId() {
     return GuiHandler.GUI_ID_KILLER_JOE;
@@ -85,6 +76,7 @@ public class BlockKillerJoe extends AbstractMachineBlock<TileKillerJoe> {
     return false;
   }
   
+  @Override
   protected short getFacingForHeading(int heading) {
     switch (heading) {
     case 0:

--- a/src/main/java/crazypants/enderio/machine/monitor/BlockPowerMonitor.java
+++ b/src/main/java/crazypants/enderio/machine/monitor/BlockPowerMonitor.java
@@ -29,25 +29,7 @@ public class BlockPowerMonitor extends AbstractMachineBlock<TilePowerMonitor> {
 
   protected BlockPowerMonitor() {
     super(ModObject.blockPowerMonitor, TilePowerMonitor.class);
-  }
-
-  @Override
-  public Object getServerGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z) {
-    TileEntity te = world.getTileEntity(x, y, z);
-    if (te instanceof TilePowerMonitor) {
-      return new ContainerNoInv((TilePowerMonitor) te);
-    }
-    return null;
-  }
-
-  @Override
-  public Object getClientGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z) {
-    TileEntity te = world.getTileEntity(x, y, z);
-    if(te instanceof TilePowerMonitor) {
-      return new GuiPowerMonitor(player.inventory, (TilePowerMonitor) te);
-    }
-    return null;
-
+    setGuiClasses(ContainerNoInv.class, GuiPowerMonitor.class);
   }
 
   @Override

--- a/src/main/java/crazypants/enderio/machine/obelisk/attractor/BlockAttractor.java
+++ b/src/main/java/crazypants/enderio/machine/obelisk/attractor/BlockAttractor.java
@@ -22,29 +22,12 @@ public class BlockAttractor extends BlockObeliskAbstract<TileAttractor> {
   
   protected BlockAttractor() {
     super(ModObject.blockAttractor, TileAttractor.class);
+    setGuiClasses(ContainerAttractor.class, GuiAttractor.class);
   }
 
-  @Override
-  public Object getServerGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z) {
-    TileEntity te = world.getTileEntity(x, y, z);
-    if(te instanceof TileAttractor) {
-      return new ContainerAttractor(player.inventory, (TileAttractor)te);
-    }
-    return null;
-  }
-  
   @SideOnly(Side.CLIENT)
   public IIcon getOnIcon() {
     return iconBuffer[0][6];
-  }
-
-  @Override
-  public Object getClientGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z) {
-    TileEntity te = world.getTileEntity(x, y, z);
-    if(te instanceof TileAttractor) {
-      return new GuiAttractor(player.inventory, (TileAttractor)te);
-    }
-    return null;
   }
 
   @Override

--- a/src/main/java/crazypants/enderio/machine/obelisk/aversion/BlockAversionObelisk.java
+++ b/src/main/java/crazypants/enderio/machine/obelisk/aversion/BlockAversionObelisk.java
@@ -21,24 +21,7 @@ public class BlockAversionObelisk extends BlockObeliskAbstract<TileAversionObeli
 
   protected BlockAversionObelisk() {
     super(ModObject.blockSpawnGuard, TileAversionObelisk.class);
-  }
-
-  @Override
-  public Object getServerGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z) {
-    TileEntity te = world.getTileEntity(x, y, z);
-    if(te instanceof TileAversionObelisk) {
-      return new ContainerAversionObelisk(player.inventory, (TileAversionObelisk) te);
-    }
-    return null;
-  }
-
-  @Override
-  public Object getClientGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z) {
-    TileEntity te = world.getTileEntity(x, y, z);
-    if(te instanceof TileAversionObelisk) {
-      return new GuiAversionObelisk(player.inventory, (TileAversionObelisk) te);
-    }
-    return null;
+    setGuiClasses(ContainerAversionObelisk.class, GuiAversionObelisk.class);
   }
 
   @Override

--- a/src/main/java/crazypants/enderio/machine/obelisk/inhibitor/BlockInhibitorObelisk.java
+++ b/src/main/java/crazypants/enderio/machine/obelisk/inhibitor/BlockInhibitorObelisk.java
@@ -31,22 +31,7 @@ public class BlockInhibitorObelisk extends BlockObeliskAbstract<TileInhibitorObe
   
   protected BlockInhibitorObelisk() {
     super(ModObject.blockInhibitorObelisk, TileInhibitorObelisk.class);
-  }
-
-  @Override
-  public Object getServerGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z) {
-    return ID == getGuiId() ? new ContainerInhibitorObelisk(player.inventory, (AbstractMachineEntity) world.getTileEntity(x, y, z)) : null;
-  }
-
-  @Override
-  public Object getClientGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z) {
-    if(ID == getGuiId()) {
-      TileInhibitorObelisk te = (TileInhibitorObelisk) world.getTileEntity(x, y, z);
-      if(te != null) {
-        return new GuiInhibitorObelisk(te, new ContainerInhibitorObelisk(player.inventory, te));
-      }
-    }
-    return null;
+    setGuiClasses(ContainerInhibitorObelisk.class, GuiInhibitorObelisk.class);
   }
 
   @Override

--- a/src/main/java/crazypants/enderio/machine/obelisk/inhibitor/ContainerInhibitorObelisk.java
+++ b/src/main/java/crazypants/enderio/machine/obelisk/inhibitor/ContainerInhibitorObelisk.java
@@ -6,7 +6,7 @@ import crazypants.enderio.machine.gui.AbstractMachineContainer;
 
 public class ContainerInhibitorObelisk extends AbstractMachineContainer {
 
-  public ContainerInhibitorObelisk(InventoryPlayer playerInv, AbstractMachineEntity te) {
+  public ContainerInhibitorObelisk(InventoryPlayer playerInv, TileInhibitorObelisk te) {
     super(playerInv, te);
   }
 

--- a/src/main/java/crazypants/enderio/machine/obelisk/inhibitor/GuiInhibitorObelisk.java
+++ b/src/main/java/crazypants/enderio/machine/obelisk/inhibitor/GuiInhibitorObelisk.java
@@ -14,7 +14,7 @@ import crazypants.enderio.machine.gui.GuiPoweredMachineBase;
 
 public class GuiInhibitorObelisk extends GuiPoweredMachineBase<TileInhibitorObelisk> {
 
-  public GuiInhibitorObelisk(TileInhibitorObelisk machine, Container container) {
+  public GuiInhibitorObelisk(TileInhibitorObelisk machine, ContainerInhibitorObelisk container) {
     super(machine, container);
   }
 

--- a/src/main/java/crazypants/enderio/machine/obelisk/weather/BlockWeatherObelisk.java
+++ b/src/main/java/crazypants/enderio/machine/obelisk/weather/BlockWeatherObelisk.java
@@ -24,16 +24,7 @@ public class BlockWeatherObelisk extends BlockObeliskAbstract<TileWeatherObelisk
 
   private BlockWeatherObelisk() {
     super(ModObject.blockWeatherObelisk, TileWeatherObelisk.class);
-  }
-
-  @Override
-  public Object getServerGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z) {
-    return new ContainerWeatherObelisk(player.inventory, (TileWeatherObelisk) world.getTileEntity(x, y, z));
-  }
-
-  @Override
-  public Object getClientGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z) {
-    return new GuiWeatherObelisk(player.inventory, (TileWeatherObelisk) world.getTileEntity(x, y, z));
+    setGuiClasses(ContainerWeatherObelisk.class, GuiWeatherObelisk.class);
   }
 
   @Override

--- a/src/main/java/crazypants/enderio/machine/obelisk/xp/BlockExperienceObelisk.java
+++ b/src/main/java/crazypants/enderio/machine/obelisk/xp/BlockExperienceObelisk.java
@@ -32,6 +32,7 @@ public class BlockExperienceObelisk extends BlockObeliskAbstract<TileExperienceO
 
   private BlockExperienceObelisk() {
     super(ModObject.blockExperienceObelisk, TileExperienceObelisk.class);
+    setGuiClasses(ContainerNoInv.class, GuiExperienceObelisk.class);
   }
 
   @Override
@@ -53,25 +54,6 @@ public class BlockExperienceObelisk extends BlockObeliskAbstract<TileExperienceO
   public String getUnlocalizedNameForTooltip(ItemStack itemStack) {
     return getUnlocalizedName();
   }
-
-  @Override
-  public Object getServerGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z) {
-    TileEntity te = world.getTileEntity(x, y, z);
-    if (te instanceof TileExperienceObelisk) {
-      return new ContainerNoInv((IInventory) te);
-    }
-    return null;
-  }
-
-  @Override
-  public Object getClientGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z) {
-    TileEntity te = world.getTileEntity(x, y, z);
-    if(te instanceof TileExperienceObelisk) {
-      return new GuiExperienceObelisk(player.inventory, (TileExperienceObelisk) te);
-    }
-    return null;
-  }
-
 
   @Override
   protected int getGuiId() {

--- a/src/main/java/crazypants/enderio/machine/painter/BlockPainter.java
+++ b/src/main/java/crazypants/enderio/machine/painter/BlockPainter.java
@@ -26,24 +26,7 @@ public class BlockPainter extends AbstractMachineBlock<TileEntityPainter> {
 
   private BlockPainter() {
     super(ModObject.blockPainter, TileEntityPainter.class);
-  }
-
-  @Override
-  public Object getServerGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z) {
-    // The server needs the container as it manages the adding and removing of
-    // items, which are then sent to the client for display
-    TileEntity te = world.getTileEntity(x, y, z);
-    if(te instanceof TileEntityPainter) {
-      return new PainterContainer(player.inventory, (TileEntityPainter) te);
-    }
-    return null;
-  }
-
-  @Override
-  @SideOnly(Side.CLIENT)
-  public Object getClientGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z) {
-    TileEntity te = world.getTileEntity(x, y, z);
-    return new GuiPainter(player.inventory, (TileEntityPainter) te);
+    setGuiClasses(PainterContainer.class, GuiPainter.class);
   }
 
   @Override

--- a/src/main/java/crazypants/enderio/machine/slicensplice/BlockSliceAndSplice.java
+++ b/src/main/java/crazypants/enderio/machine/slicensplice/BlockSliceAndSplice.java
@@ -25,24 +25,7 @@ public class BlockSliceAndSplice extends AbstractMachineBlock<TileSliceAndSplice
 
   protected BlockSliceAndSplice() {
     super(ModObject.blockSliceAndSplice, TileSliceAndSplice.class);
-  }
-
-  @Override
-  public Object getServerGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z) {
-    TileEntity te = world.getTileEntity(x, y, z);
-    if(te instanceof TileSliceAndSplice) {
-      return new ContainerSliceAndSplice(player.inventory, (TileSliceAndSplice) te);
-    }
-    return null;
-  }
-
-  @Override
-  public Object getClientGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z) {
-    TileEntity te = world.getTileEntity(x, y, z);
-    if(te instanceof TileSliceAndSplice) {
-      return new GuiSliceAndSplice(player.inventory, (TileSliceAndSplice) te);
-    }
-    return null;
+    setGuiClasses(ContainerSliceAndSplice.class, GuiSliceAndSplice.class);
   }
 
   @Override

--- a/src/main/java/crazypants/enderio/machine/soul/BlockSoulBinder.java
+++ b/src/main/java/crazypants/enderio/machine/soul/BlockSoulBinder.java
@@ -37,26 +37,9 @@ public class BlockSoulBinder extends AbstractMachineBlock<TileSoulBinder> {
   
   protected BlockSoulBinder() {
     super(ModObject.blockSoulBinder, TileSoulBinder.class);
+    setGuiClasses(ContainerSoulBinder.class, GuiSoulBinder.class);
   }  
   
-  @Override
-  public Object getServerGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z) {
-    TileEntity te = world.getTileEntity(x, y, z);
-    if(te instanceof TileSoulBinder) {
-      return new ContainerSoulBinder(player.inventory, (TileSoulBinder) te);
-    }
-    return null;
-  }
-
-  @Override
-  public Object getClientGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z) {
-    TileEntity te = world.getTileEntity(x, y, z);
-    if(te instanceof TileSoulBinder) {
-      return new GuiSoulBinder(player.inventory, (TileSoulBinder) te);
-    }
-    return null;
-  }
-
   @Override
   protected int getGuiId() {
     return GuiHandler.GUI_ID_SOUL_BINDER;

--- a/src/main/java/crazypants/enderio/machine/spawner/BlockPoweredSpawner.java
+++ b/src/main/java/crazypants/enderio/machine/spawner/BlockPoweredSpawner.java
@@ -101,6 +101,7 @@ public class BlockPoweredSpawner extends AbstractMachineBlock<TilePoweredSpawner
 
   protected BlockPoweredSpawner() {
     super(ModObject.blockPoweredSpawner, TilePoweredSpawner.class);
+    setGuiClasses(ContainerPoweredSpawner.class, GuiPoweredSpawner.class);
 
     String[] blackListNames = Config.brokenSpawnerToolBlacklist;
     for (String name : blackListNames) {
@@ -254,24 +255,6 @@ public class BlockPoweredSpawner extends AbstractMachineBlock<TilePoweredSpawner
   }
 
   @Override
-  public Object getServerGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z) {
-    TileEntity te = world.getTileEntity(x, y, z);
-    if(te instanceof TilePoweredSpawner) {
-      return new ContainerPoweredSpawner(player.inventory, (TilePoweredSpawner) te);
-    }
-    return null;
-  }
-
-  @Override
-  public Object getClientGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z) {
-    TileEntity te = world.getTileEntity(x, y, z);
-    if(te instanceof TilePoweredSpawner) {
-      return new GuiPoweredSpawner(player.inventory, (TilePoweredSpawner) te);
-    }
-    return null;
-  }
-
-  @Override
   protected int getGuiId() {
     return GuiHandler.GUI_ID_POWERED_SPAWNER;
   }
@@ -340,24 +323,4 @@ public class BlockPoweredSpawner extends AbstractMachineBlock<TilePoweredSpawner
     return stack;
   }
 
-  private static class DropInfo {
-
-    BlockEvent.BreakEvent evt;
-    ItemStack drop;
-
-    DropInfo(BreakEvent evt, ItemStack stack) {
-      super();
-      this.evt = evt;
-      drop = stack;
-    }
-
-    void doDrop() {
-      if(evt.isCanceled()) {
-        return;
-      }
-
-      Util.dropItems(evt.getPlayer().worldObj, drop, evt.x, evt.y, evt.z, true);
-    }
-
-  }
 }

--- a/src/main/java/crazypants/enderio/machine/tank/BlockTank.java
+++ b/src/main/java/crazypants/enderio/machine/tank/BlockTank.java
@@ -46,6 +46,7 @@ public class BlockTank extends AbstractMachineBlock<TileTank> implements IAdvanc
     super(ModObject.blockTank, TileTank.class);
     setStepSound(Block.soundTypeGlass);
     setLightOpacity(0);
+    setGuiClasses(ContainerTank.class, GuiTank.class);
   }
 
   @Override
@@ -71,24 +72,6 @@ public class BlockTank extends AbstractMachineBlock<TileTank> implements IAdvanc
   @Override
   public TileEntity createTileEntity(World world, int metadata) {
     return new TileTank(metadata);
-  }
-
-  @Override
-  public Object getServerGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z) {
-    TileEntity te = world.getTileEntity(x, y, z);
-    if(!(te instanceof TileTank)) {
-      return null;
-    }
-    return new ContainerTank(player.inventory, (TileTank) te);
-  }
-
-  @Override
-  public Object getClientGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z) {
-    TileEntity te = world.getTileEntity(x, y, z);
-    if(!(te instanceof TileTank)) {
-      return null;
-    }
-    return new GuiTank(player.inventory, (TileTank) te);
   }
 
   @Override

--- a/src/main/java/crazypants/enderio/machine/transceiver/BlockTransceiver.java
+++ b/src/main/java/crazypants/enderio/machine/transceiver/BlockTransceiver.java
@@ -52,6 +52,7 @@ public class BlockTransceiver extends AbstractMachineBlock<TileTransceiver> {
     if(!Config.transceiverEnabled) {
       setCreativeTab(null);
     }
+    setGuiClasses(ContainerTransceiver.class, GuiTransceiver.class);
   }
 
   @Override
@@ -63,21 +64,6 @@ public class BlockTransceiver extends AbstractMachineBlock<TileTransceiver> {
       }
     }
     return super.removedByPlayer(world, player, x, y, z, doHarvest);
-  }
-
-  @Override
-  public Object getServerGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z) {
-    TileEntity te = world.getTileEntity(x, y, z);
-    if(te instanceof TileTransceiver) {
-      return new ContainerTransceiver(player.inventory, (TileTransceiver) te);
-    }
-    return null;
-  }
-
-  @Override
-  public Object getClientGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z) {
-    TileEntity te = world.getTileEntity(x, y, z);
-    return new GuiTransceiver(player.inventory, (TileTransceiver) te);
   }
 
   @Override

--- a/src/main/java/crazypants/enderio/machine/vat/BlockVat.java
+++ b/src/main/java/crazypants/enderio/machine/vat/BlockVat.java
@@ -41,8 +41,10 @@ public class BlockVat extends AbstractMachineBlock<TileVat> {
 
   public BlockVat() {
     super(ModObject.blockVat, TileVat.class);
+    setGuiClasses(ContainerVat.class, GuiVat.class);
   }
 
+  @Override
   protected String getModelIconKey(boolean active) {
     return "enderio:vatModel";
   }
@@ -96,26 +98,6 @@ public class BlockVat extends AbstractMachineBlock<TileVat> {
   @Override
   public boolean isOpaqueCube() {
     return false;
-  }
-
-  @Override
-  public Object getServerGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z) {
-    // The server needs the container as it manages the adding and removing of
-    // items, which are then sent to the client for display
-    TileEntity te = world.getTileEntity(x, y, z);
-    if(te instanceof TileVat) {
-      return new ContainerVat(player.inventory, (TileVat) te);
-    }
-    return null;
-  }
-
-  @Override
-  public Object getClientGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z) {
-    TileEntity te = world.getTileEntity(x, y, z);
-    if(te instanceof TileVat) {
-      return new GuiVat(player.inventory, (TileVat) te);
-    }
-    return null;
   }
 
   @Override


### PR DESCRIPTION
This moves the creation of Container and Gui classes for all machines up into AbstractMachineBlock.

Many of the removed handler were not type-safe. This solution is. It also saves much copy&paste code. The additional overhead is very small, it consists of a switch() statement and calling the constructor indirectly. As this only happens when a player opens a GUI, that won't matter. The "no GUI" case is a single null check.

Feel free to pull this up into EnderCore. I still have no combined workspace to develop combined EC/EIO changes. Sorry.