### PR TITLE
Use type-safe getTileEntity() in blocks

### DIFF
--- a/src/main/java/crazypants/enderio/BlockEio.java
+++ b/src/main/java/crazypants/enderio/BlockEio.java
@@ -30,15 +30,12 @@ public abstract class BlockEio extends BlockEnder {
     if(shouldWrench(world, x, y, z, entityPlayer, side) && ToolUtil.breakBlockWithTool(this, world, x, y, z, entityPlayer)) {
       return true;
     }
-    TileEntity te = world.getTileEntity(x, y, z);
 
-    ITool tool = ToolUtil.getEquippedTool(entityPlayer);
-    if(tool != null && !entityPlayer.isSneaking()) {
-      if(te instanceof AbstractMachineEntity) {
-        ((AbstractMachineEntity) te).toggleIoModeForFace(ForgeDirection.getOrientation(side));
-        world.markBlockForUpdate(x, y, z);
-        return true;
-      }
+    TileEntity te = getTileEntityEio(world, x, y, z);
+    if (te != null && !entityPlayer.isSneaking() && ToolUtil.getEquippedTool(entityPlayer) != null) {
+      ((AbstractMachineEntity) te).toggleIoModeForFace(ForgeDirection.getOrientation(side));
+      world.markBlockForUpdate(x, y, z);
+      return true;
     }
     
     return super.onBlockActivated(world, x, y, z, entityPlayer, side, par7, par8, par9);

--- a/src/main/java/crazypants/enderio/block/BlockDarkSteelPressurePlate.java
+++ b/src/main/java/crazypants/enderio/block/BlockDarkSteelPressurePlate.java
@@ -102,12 +102,16 @@ public class BlockDarkSteelPressurePlate extends BlockPressurePlate implements I
 
   @Override
   public final ArrayList<ItemStack> getDrops(World world, int x, int y, int z, int metadata, int fortune) {
-    TileEntityDarkSteelPressurePlate tepb = (TileEntityDarkSteelPressurePlate) world.getTileEntity(x, y, z);
-    ItemStack stack = new ItemStack(this, 1, tepb.isSilent() ? 1 : 0);
-    if(tepb.getSourceBlock() != null) {
-      PainterUtil.setSourceBlock(stack, tepb.getSourceBlock(), tepb.getSourceBlockMetadata());
+    TileEntity te = world.getTileEntity(x, y, z);
+    if (te instanceof TileEntityDarkSteelPressurePlate) {
+      TileEntityDarkSteelPressurePlate tepb = (TileEntityDarkSteelPressurePlate) te;
+      ItemStack stack = new ItemStack(this, 1, tepb.isSilent() ? 1 : 0);
+      if (tepb.getSourceBlock() != null) {
+        PainterUtil.setSourceBlock(stack, tepb.getSourceBlock(), tepb.getSourceBlockMetadata());
+      }
+      return Lists.newArrayList(stack);
     }
-    return Lists.newArrayList(stack);
+    return super.getDrops(world, x, y, z, metadata, fortune);
   }
 
   @Override

--- a/src/main/java/crazypants/enderio/conduit/BlockConduitBundle.java
+++ b/src/main/java/crazypants/enderio/conduit/BlockConduitBundle.java
@@ -144,7 +144,10 @@ public class BlockConduitBundle extends BlockEio implements IGuiHandler, IFacade
     
     IIcon tex = null;
 
-    TileConduitBundle cb = (TileConduitBundle) world.getTileEntity(target.blockX, target.blockY, target.blockZ);
+    TileConduitBundle cb = (TileConduitBundle) getTileEntityEio(world, target.blockX, target.blockY, target.blockZ);
+    if (cb == null) {
+      return false;
+    }
     if(ConduitUtil.isSolidFacadeRendered(cb, Minecraft.getMinecraft().thePlayer)) {
       if(cb.getFacadeId() != null) {
         tex = cb.getFacadeId().getIcon(target.sideHit, cb.getFacadeMetadata());
@@ -271,14 +274,16 @@ public class BlockConduitBundle extends BlockEio implements IGuiHandler, IFacade
     }
     if(ret == null && target != null && target.hitInfo instanceof CollidableComponent) {
       CollidableComponent cc = (CollidableComponent) target.hitInfo;
-      TileConduitBundle bundle = (TileConduitBundle) world.getTileEntity(x, y, z);
-      IConduit conduit = bundle.getConduit(cc.conduitType);
-      if(conduit != null) {
-        ret = conduit.createItem();
-      } else if(cc.conduitType == null && bundle.getFacadeId() != null) {
-        // use the facde
-        ret = new ItemStack(EnderIO.itemConduitFacade, 1, 0);
-        PainterUtil.setSourceBlock(ret, bundle.getFacadeId(), bundle.getFacadeMetadata());
+      TileConduitBundle bundle = (TileConduitBundle) getTileEntityEio(world, x, y, z);
+      if (bundle != null) {
+        IConduit conduit = bundle.getConduit(cc.conduitType);
+        if (conduit != null) {
+          ret = conduit.createItem();
+        } else if (cc.conduitType == null && bundle.getFacadeId() != null) {
+          // use the facde
+          ret = new ItemStack(EnderIO.itemConduitFacade, 1, 0);
+          PainterUtil.setSourceBlock(ret, bundle.getFacadeId(), bundle.getFacadeMetadata());
+        }
       }
     }
     return ret;
@@ -286,8 +291,8 @@ public class BlockConduitBundle extends BlockEio implements IGuiHandler, IFacade
 
   @Override
   public int getDamageValue(World world, int x, int y, int z) {
-    TileEntity te = world.getTileEntity(x, y, z);
-    if(!(te instanceof IConduitBundle)) {
+    TileEntity te = getTileEntityEio(world, x, y, z);
+    if (te == null) {
       return 0;
     }
     IConduitBundle bun = (IConduitBundle) te;
@@ -375,14 +380,14 @@ public class BlockConduitBundle extends BlockEio implements IGuiHandler, IFacade
 
   @Override
   public float getBlockHardness(World world, int x, int y, int z) {
-    IConduitBundle te = (IConduitBundle) world.getTileEntity(x, y, z);
+    IConduitBundle te = (IConduitBundle) getTileEntityEio(world, x, y, z);
     return te != null && te.getFacadeType() == FacadeType.HARDENED ? blockHardness * 10 : blockHardness;
   }
 
   @Override
   public float getExplosionResistance(Entity par1Entity, World world, int x, int y, int z, double explosionX, double explosionY, double explosionZ) {
     float resist = getExplosionResistance(par1Entity);
-    IConduitBundle te = (IConduitBundle) world.getTileEntity(x, y, z);
+    IConduitBundle te = (IConduitBundle) getTileEntityEio(world, x, y, z);
     return te != null && te.getFacadeType() == FacadeType.HARDENED ? resist * 10 : resist;
   }
 
@@ -393,7 +398,7 @@ public class BlockConduitBundle extends BlockEio implements IGuiHandler, IFacade
       if(held == null || held.getItem().getHarvestLevel(held, "pickaxe") == -1) {
         event.newSpeed += 2;
       }
-      IConduitBundle te = (IConduitBundle) event.entity.worldObj.getTileEntity(event.x, event.y, event.z);
+      IConduitBundle te = (IConduitBundle) getTileEntityEio(event.entity.worldObj, event.x, event.y, event.z);
       if(te != null && te.getFacadeType() == FacadeType.HARDENED) {
         if(!ConduitUtil.isSolidFacadeRendered(te, event.entityPlayer)) {
           event.newSpeed *= 6;
@@ -442,7 +447,7 @@ public class BlockConduitBundle extends BlockEio implements IGuiHandler, IFacade
 
   @Override
   public boolean removedByPlayer(World world, EntityPlayer player, int x, int y, int z, boolean willHarvest) {
-    IConduitBundle te = (IConduitBundle) world.getTileEntity(x, y, z);
+    IConduitBundle te = (IConduitBundle) getTileEntityEio(world, x, y, z);
     if(te == null) {
       return true;
     }
@@ -541,8 +546,8 @@ public class BlockConduitBundle extends BlockEio implements IGuiHandler, IFacade
   @Override
   public void breakBlock(World world, int x, int y, int z, Block par5, int par6) {
 
-    TileEntity tile = world.getTileEntity(x, y, z);
-    if(!(tile instanceof IConduitBundle)) {
+    TileEntity tile = getTileEntityEio(world, x, y, z);
+    if (tile == null) {
       return;
     }
     IConduitBundle te = (IConduitBundle) tile;
@@ -562,7 +567,7 @@ public class BlockConduitBundle extends BlockEio implements IGuiHandler, IFacade
   @Override
   public boolean onBlockActivated(World world, int x, int y, int z, EntityPlayer player, int side, float par7, float par8, float par9) {
 
-    IConduitBundle bundle = (IConduitBundle) world.getTileEntity(x, y, z);
+    IConduitBundle bundle = (IConduitBundle) getTileEntityEio(world, x, y, z);
     if(bundle == null) {
       return false;
     }
@@ -745,7 +750,7 @@ public class BlockConduitBundle extends BlockEio implements IGuiHandler, IFacade
 
   @Override
   public boolean tryRotateFacade(World world, int x, int y, int z, ForgeDirection axis) {
-    IConduitBundle bundle = (IConduitBundle) world.getTileEntity(x, y, z);
+    IConduitBundle bundle = (IConduitBundle) getTileEntityEio(world, x, y, z);
     if(bundle == null) {
       return false;
     }
@@ -769,8 +774,8 @@ public class BlockConduitBundle extends BlockEio implements IGuiHandler, IFacade
     }
     // The server needs the container as it manages the adding and removing of
     // items, which are then sent to the client for display
-    TileEntity te = world.getTileEntity(x, y, z);
-    if(te instanceof IConduitBundle) {
+    TileEntity te = getTileEntityEio(world, x, y, z);
+    if (te != null) {
       return new ExternalConnectionContainer(player.inventory, (IConduitBundle) te, ForgeDirection.values()[id - GuiHandler.GUI_ID_EXTERNAL_CONNECTION_BASE]);
     }
     return null;
@@ -778,8 +783,8 @@ public class BlockConduitBundle extends BlockEio implements IGuiHandler, IFacade
 
   @Override
   public Object getClientGuiElement(int id, EntityPlayer player, World world, int x, int y, int z) {
-    TileEntity te = world.getTileEntity(x, y, z);
-    if(te instanceof IConduitBundle) {
+    TileEntity te = getTileEntityEio(world, x, y, z);
+    if (te != null) {
       if(id == GuiHandler.GUI_ID_EXTERNAL_CONNECTION_SELECTOR) {
         return new GuiExternalConnectionSelector((IConduitBundle) te);
       }
@@ -799,8 +804,8 @@ public class BlockConduitBundle extends BlockEio implements IGuiHandler, IFacade
 
   @Override
   public void onNeighborBlockChange(World world, int x, int y, int z, Block blockId) {
-    TileEntity tile = world.getTileEntity(x, y, z);
-    if((tile instanceof IConduitBundle)) {
+    TileEntity tile = getTileEntityEio(world, x, y, z);
+    if (tile != null) {
       ((IConduitBundle) tile).onNeighborBlockChange(blockId);
     }
   }
@@ -821,8 +826,8 @@ public class BlockConduitBundle extends BlockEio implements IGuiHandler, IFacade
       IM__addCollisionBoxesToList(world, x, y, z, axisalignedbb, arraylist, par7Entity);
     }
 
-    TileEntity te = world.getTileEntity(x, y, z);
-    if(!(te instanceof IConduitBundle)) {
+    TileEntity te = getTileEntityEio(world, x, y, z);
+    if (te == null) {
       return;
     }
     IConduitBundle con = (IConduitBundle) te;
@@ -851,12 +856,12 @@ public class BlockConduitBundle extends BlockEio implements IGuiHandler, IFacade
   @SideOnly(Side.CLIENT)
   public AxisAlignedBB getSelectedBoundingBoxFromPool(World world, int x, int y, int z) {
 
-    TileEntity te = world.getTileEntity(x, y, z);
-    EntityPlayer player = Minecraft.getMinecraft().thePlayer;
-    if(!(te instanceof IConduitBundle)) {
+    TileEntity te = getTileEntityEio(world, x, y, z);
+    if (te == null) {
       return null;
     }
     IConduitBundle con = (IConduitBundle) te;
+    EntityPlayer player = Minecraft.getMinecraft().thePlayer;
 
     BoundingBox minBB = new BoundingBox(1, 1, 1, 0, 0, 0);
 
@@ -959,8 +964,8 @@ public class BlockConduitBundle extends BlockEio implements IGuiHandler, IFacade
 
   protected List<RaytraceResult> doRayTraceAll(World world, int x, int y, int z, Vec3 origin, Vec3 direction, EntityPlayer player) {
 
-    TileEntity te = world.getTileEntity(x, y, z);
-    if(!(te instanceof IConduitBundle)) {
+    TileEntity te = getTileEntityEio(world, x, y, z);
+    if (te == null) {
       return null;
     }
     IConduitBundle bundle = (IConduitBundle) te;

--- a/src/main/java/crazypants/enderio/enderface/BlockEnderIO.java
+++ b/src/main/java/crazypants/enderio/enderface/BlockEnderIO.java
@@ -54,8 +54,8 @@ public class BlockEnderIO extends BlockEio implements IResourceTooltipProvider {
 
   @Override
   public void onBlockPlacedBy(World world, int x, int y, int z, EntityLivingBase player, ItemStack item) {
-    TileEntity te = world.getTileEntity(x, y, z);
-    if(te instanceof TileEnderIO) {
+    TileEntity te = getTileEntityEio(world, x, y, z);
+    if (te != null) {
       TileEnderIO eio = (TileEnderIO) te;
       eio.initUiPitch = -player.rotationPitch;
       eio.initUiYaw = -player.rotationYaw + 180;
@@ -70,7 +70,7 @@ public class BlockEnderIO extends BlockEio implements IResourceTooltipProvider {
 
   @Override
   public boolean openGui(World world, int x, int y, int z, EntityPlayer entityPlayer, int side) {
-    TileEntity te = world.getTileEntity(x, y, z);
+    TileEntity te = getTileEntityEio(world, x, y, z);
     if(te instanceof ITravelAccessable) {
       ITravelAccessable ta = (ITravelAccessable) te;
       if(ta.canUiBeAccessed(entityPlayer)) {

--- a/src/main/java/crazypants/enderio/item/skull/BlockEndermanSkull.java
+++ b/src/main/java/crazypants/enderio/item/skull/BlockEndermanSkull.java
@@ -113,13 +113,15 @@ public class BlockEndermanSkull extends BlockEio implements IInfusionStabiliser 
 
     int inc = MathHelper.floor_double(player.rotationYaw * 16.0F / 360.0F + 0.5D) & 15;
     float facingYaw = -22.5f * inc;
-    TileEndermanSkull te = (TileEndermanSkull) world.getTileEntity(x, y, z);
-    te.setYaw(facingYaw);
-    if(world.isRemote) {
-      return;
+    TileEndermanSkull te = (TileEndermanSkull) getTileEntityEio(world, x, y, z);
+    if (te != null) {
+      te.setYaw(facingYaw);
+      if (world.isRemote) {
+        return;
+      }
+      world.setBlockMetadataWithNotify(x, y, z, stack.getItemDamage(), 2);
+      world.markBlockForUpdate(x, y, z);
     }
-    world.setBlockMetadataWithNotify(x, y, z, stack.getItemDamage(), 2);
-    world.markBlockForUpdate(x, y, z);
   }
 
   @Override

--- a/src/main/java/crazypants/enderio/machine/AbstractMachineBlock.java
+++ b/src/main/java/crazypants/enderio/machine/AbstractMachineBlock.java
@@ -179,7 +179,8 @@ public abstract class AbstractMachineBlock<T extends AbstractMachineEntity> exte
   }
 
   public IIcon getModelIcon(IBlockAccess world, int x, int y, int z) {
-    return getModelIcon(((AbstractMachineEntity) world.getTileEntity(x, y, z)).isActive());
+    AbstractMachineEntity te = (AbstractMachineEntity) getTileEntityEio(world, x, y, z);
+    return getModelIcon(te != null ? te.isActive() : false);
   }
 
   public IIcon getModelIcon() {
@@ -206,7 +207,10 @@ public abstract class AbstractMachineBlock<T extends AbstractMachineEntity> exte
   public void onBlockPlacedBy(World world, int x, int y, int z, EntityLivingBase player, ItemStack stack) {
     super.onBlockPlacedBy(world, x, y, z, player, stack);
     int heading = MathHelper.floor_double(player.rotationYaw * 4.0F / 360.0F + 0.5D) & 3;
-    AbstractMachineEntity te = (AbstractMachineEntity) world.getTileEntity(x, y, z);
+    AbstractMachineEntity te = (AbstractMachineEntity) getTileEntityEio(world, x, y, z);
+    if (te == null) {
+      return;
+    }
     te.setFacing(getFacingForHeading(heading));
     te.readFromItemStack(stack);
     if(world.isRemote) {
@@ -237,8 +241,8 @@ public abstract class AbstractMachineBlock<T extends AbstractMachineEntity> exte
 
   @Override
   public void onNeighborBlockChange(World world, int x, int y, int z, Block blockId) {
-    TileEntity ent = world.getTileEntity(x, y, z);
-    if(ent instanceof AbstractMachineEntity) {
+    TileEntity ent = getTileEntityEio(world, x, y, z);
+    if (ent != null) {
       AbstractMachineEntity te = (AbstractMachineEntity) ent;
       te.onNeighborBlockChange(blockId);
     }

--- a/src/main/java/crazypants/enderio/machine/alloy/BlockAlloySmelter.java
+++ b/src/main/java/crazypants/enderio/machine/alloy/BlockAlloySmelter.java
@@ -54,7 +54,10 @@ public class BlockAlloySmelter extends AbstractMachineBlock<TileAlloySmelter> {
   @Override
   public Object getClientGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z) {
     TileEntity te = world.getTileEntity(x, y, z);
-    return new GuiAlloySmelter(player.inventory, (TileAlloySmelter) te);
+    if (te instanceof TileAlloySmelter) {
+      return new GuiAlloySmelter(player.inventory, (TileAlloySmelter) te);
+    }
+    return null;
   }
 
   @Override

--- a/src/main/java/crazypants/enderio/machine/buffer/BlockBuffer.java
+++ b/src/main/java/crazypants/enderio/machine/buffer/BlockBuffer.java
@@ -114,8 +114,8 @@ public class BlockBuffer extends AbstractMachineBlock<TileBuffer> implements IFa
   @Override
   public void onBlockPlacedBy(World world, int x, int y, int z, EntityLivingBase entity, ItemStack stack) {
     if(entity instanceof EntityPlayer) {
-      TileEntity te = world.getTileEntity(x, y, z);
-      if(te instanceof TileBuffer) {
+      TileEntity te = getTileEntityEio(world, x, y, z);
+      if (te != null) {
         TileBuffer ta = (TileBuffer) te;
         if(stack.stackTagCompound != null) {
           ta.readCommon(stack.stackTagCompound);
@@ -133,7 +133,12 @@ public class BlockBuffer extends AbstractMachineBlock<TileBuffer> implements IFa
   // TODO refactor machines so all have this functionality
   @Override
   public ItemStack getPickBlock(MovingObjectPosition target, World world, int x, int y, int z) {
-    return createDrop((TileBuffer) world.getTileEntity(x, y, z));
+    TileBuffer te = (TileBuffer) getTileEntityEio(world, x, y, z);
+    if (te != null) {
+      return createDrop(te);
+    } else {
+      return null;
+    }
   }
 
   private ItemStack createDrop(TileBuffer te) {

--- a/src/main/java/crazypants/enderio/machine/capbank/BlockCapBank.java
+++ b/src/main/java/crazypants/enderio/machine/capbank/BlockCapBank.java
@@ -154,8 +154,8 @@ public class BlockCapBank extends BlockEio implements IGuiHandler, IAdvancedTool
   @Override
   public boolean onBlockActivated(World world, int x, int y, int z, EntityPlayer entityPlayer, int side, float par7, float par8, float par9) {
 
-    TileEntity te = world.getTileEntity(x, y, z);
-    if(!(te instanceof TileCapBank)) {
+    TileEntity te = getTileEntityEio(world, x, y, z);
+    if (te == null) {
       return false;
     }
 
@@ -218,8 +218,8 @@ public class BlockCapBank extends BlockEio implements IGuiHandler, IAdvancedTool
 
   @Override
   public Object getServerGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z) {
-    TileEntity te = world.getTileEntity(x, y, z);
-    if(te instanceof TileCapBank) {
+    TileEntity te = getTileEntityEio(world, x, y, z);
+    if (te != null) {
       return new ContainerCapBank(player.inventory, (TileCapBank) te);
     }
     return null;
@@ -227,8 +227,8 @@ public class BlockCapBank extends BlockEio implements IGuiHandler, IAdvancedTool
 
   @Override
   public Object getClientGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z) {
-    TileEntity te = world.getTileEntity(x, y, z);
-    if(te instanceof TileCapBank) {
+    TileEntity te = getTileEntityEio(world, x, y, z);
+    if (te != null) {
       return new GuiCapBank(player, player.inventory, (TileCapBank) te);
     }
     return null;
@@ -350,8 +350,8 @@ public class BlockCapBank extends BlockEio implements IGuiHandler, IAdvancedTool
     if(world.isRemote) {
       return;
     }
-    TileEntity tile = world.getTileEntity(x, y, z);
-    if(tile instanceof TileCapBank) {
+    TileEntity tile = getTileEntityEio(world, x, y, z);
+    if (tile != null) {
       TileCapBank te = (TileCapBank) tile;
       te.onNeighborBlockChange(blockId);
     }
@@ -366,7 +366,7 @@ public class BlockCapBank extends BlockEio implements IGuiHandler, IAdvancedTool
   public void onBlockPlacedBy(World world, int x, int y, int z, EntityLivingBase player, ItemStack stack) {
     super.onBlockPlacedBy(world, x, y, z, player, stack);
 
-    TileCapBank cb = getTileEntity(world, x, y, z);
+    TileCapBank cb = (TileCapBank) getTileEntityEio(world, x, y, z);
     if(cb == null) {
       return;
     }
@@ -381,8 +381,8 @@ public class BlockCapBank extends BlockEio implements IGuiHandler, IAdvancedTool
       cb.setDisplayType(dir, InfoDisplayType.LEVEL_BAR);
     } else {
       boolean modifiedDisplayType;
-      modifiedDisplayType = setDisplayToVerticalFillBar(cb, getTileEntity(world, x, y - 1, z));
-      modifiedDisplayType |= setDisplayToVerticalFillBar(cb, getTileEntity(world, x, y + 1, z));
+      modifiedDisplayType = setDisplayToVerticalFillBar(cb, (TileCapBank) getTileEntityEio(world, x, y - 1, z));
+      modifiedDisplayType |= setDisplayToVerticalFillBar(cb, (TileCapBank) getTileEntityEio(world, x, y + 1, z));
       if(modifiedDisplayType) {
         cb.validateDisplayTypes();
       }
@@ -407,14 +407,6 @@ public class BlockCapBank extends BlockEio implements IGuiHandler, IAdvancedTool
     return modifiedDisplayType;
   }
 
-  private TileCapBank getTileEntity(World world, int x, int y, int z) {
-    TileEntity te = world.getTileEntity(x, y, z);
-    if(te instanceof TileCapBank) {
-      return (TileCapBank) te;
-    }
-    return null;
-  }
-
   protected ForgeDirection getDirForHeading(int heading) {
     switch (heading) {
     case 0:
@@ -432,8 +424,8 @@ public class BlockCapBank extends BlockEio implements IGuiHandler, IAdvancedTool
   @Override
   public boolean removedByPlayer(World world, EntityPlayer player, int x, int y, int z, boolean doHarvest) {
     if(!world.isRemote && (!player.capabilities.isCreativeMode)) {
-      TileEntity te = world.getTileEntity(x, y, z);
-      if(te instanceof TileCapBank) {
+      TileEntity te = getTileEntityEio(world, x, y, z);
+      if (te != null) {
         TileCapBank cb = (TileCapBank) te;
         cb.moveInventoryToNetwork();
       }
@@ -452,12 +444,11 @@ public class BlockCapBank extends BlockEio implements IGuiHandler, IAdvancedTool
   @Override
   public void breakBlock(World world, int x, int y, int z, Block par5, int par6) {
     if(!world.isRemote) {
-      TileEntity te = world.getTileEntity(x, y, z);
-      if(!(te instanceof TileCapBank)) {
-        return;
+      TileEntity te = getTileEntityEio(world, x, y, z);
+      if (te != null) {
+        TileCapBank cb = (TileCapBank) te;
+        cb.onBreakBlock();
       }
-      TileCapBank cb = (TileCapBank) te;
-      cb.onBreakBlock();
     }
     super.breakBlock(world, x, y, z, par5, par6);
   }
@@ -465,8 +456,8 @@ public class BlockCapBank extends BlockEio implements IGuiHandler, IAdvancedTool
   @Override
   @SideOnly(Side.CLIENT)
   public AxisAlignedBB getSelectedBoundingBoxFromPool(World world, int x, int y, int z) {
-    TileEntity te = world.getTileEntity(x, y, z);
-    if(!(te instanceof TileCapBank)) {
+    TileEntity te = getTileEntityEio(world, x, y, z);
+    if (te == null) {
       return super.getSelectedBoundingBoxFromPool(world, x, y, z);
     }
     TileCapBank tr = (TileCapBank) te;
@@ -496,8 +487,8 @@ public class BlockCapBank extends BlockEio implements IGuiHandler, IAdvancedTool
 
   @Override
   public int getComparatorInputOverride(World w, int x, int y, int z, int side) {
-    TileEntity te = w.getTileEntity(x, y, z);
-    if(te instanceof TileCapBank) {
+    TileEntity te = getTileEntityEio(w, x, y, z);
+    if (te != null) {
       return ((TileCapBank) te).getComparatorOutput();
     }
     return 0;
@@ -505,8 +496,8 @@ public class BlockCapBank extends BlockEio implements IGuiHandler, IAdvancedTool
 
   @Override
   public void getWailaInfo(List<String> tooltip, EntityPlayer player, World world, int x, int y, int z) {
-    TileEntity te = world.getTileEntity(x, y, z);
-    if(te instanceof TileCapBank) {
+    TileEntity te = getTileEntityEio(world, x, y, z);
+    if (te != null) {
       TileCapBank cap = (TileCapBank) te;
       if(cap.getNetwork() != null) {
         if(world.isRemote && shouldDoWorkThisTick(world, x, y, z, 20)) {

--- a/src/main/java/crazypants/enderio/machine/crusher/BlockCrusher.java
+++ b/src/main/java/crazypants/enderio/machine/crusher/BlockCrusher.java
@@ -63,7 +63,7 @@ public class BlockCrusher extends AbstractMachineBlock {
   @Override
   @SideOnly(Side.CLIENT)
   public void randomDisplayTick(World world, int x, int y, int z, Random rand) {
-    TileCrusher te = (TileCrusher) world.getTileEntity(x, y, z);
+    TileCrusher te = (TileCrusher) getTileEntityEio(world, x, y, z);
     if(te != null && te.isActive()) {
       ForgeDirection front = ForgeDirection.values()[te.facing];
 

--- a/src/main/java/crazypants/enderio/machine/enchanter/BlockEnchanter.java
+++ b/src/main/java/crazypants/enderio/machine/enchanter/BlockEnchanter.java
@@ -45,7 +45,10 @@ public class BlockEnchanter extends BlockEio implements IGuiHandler, IResourceTo
   public void onBlockPlacedBy(World world, int x, int y, int z, EntityLivingBase player, ItemStack stack) {
     super.onBlockPlacedBy(world, x, y, z, player, stack);
     int heading = MathHelper.floor_double(player.rotationYaw * 4.0F / 360.0F + 0.5D) & 3;
-    TileEnchanter te = (TileEnchanter) world.getTileEntity(x, y, z);
+    TileEnchanter te = (TileEnchanter) getTileEntityEio(world, x, y, z);
+    if (te == null) {
+      return;
+    }
     switch (heading) {
     case 0:
       te.setFacing((short) 2);
@@ -78,8 +81,8 @@ public class BlockEnchanter extends BlockEio implements IGuiHandler, IResourceTo
 
   @Override
   public void breakBlock(World world, int x, int y, int z, Block block, int meta) {
-    TileEntity te = world.getTileEntity(x, y, z);
-    if(te instanceof TileEnchanter) {
+    TileEntity te = getTileEntityEio(world, x, y, z);
+    if (te != null) {
       dropItems(world, x, y, z, (TileEnchanter) te);
     }
     super.breakBlock(world, x, y, z, block, meta);
@@ -120,8 +123,8 @@ public class BlockEnchanter extends BlockEio implements IGuiHandler, IResourceTo
 
   @Override
   public Object getServerGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z) {
-    TileEntity te = world.getTileEntity(x, y, z);
-    if(te instanceof TileEnchanter) {
+    TileEntity te = getTileEntityEio(world, x, y, z);
+    if (te != null) {
       return new ContainerEnchanter(player, player.inventory, (TileEnchanter) te);
     }
     return null;
@@ -129,8 +132,8 @@ public class BlockEnchanter extends BlockEio implements IGuiHandler, IResourceTo
 
   @Override
   public Object getClientGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z) {
-    TileEntity te = world.getTileEntity(x, y, z);
-    if(te instanceof TileEnchanter) {
+    TileEntity te = getTileEntityEio(world, x, y, z);
+    if (te != null) {
       return new GuiEnchanter(player, player.inventory, (TileEnchanter) te);
     }
     return null;

--- a/src/main/java/crazypants/enderio/machine/generator/combustion/BlockCombustionGenerator.java
+++ b/src/main/java/crazypants/enderio/machine/generator/combustion/BlockCombustionGenerator.java
@@ -111,9 +111,9 @@ public class BlockCombustionGenerator extends AbstractMachineBlock<TileCombustio
     // If active, randomly throw some smoke around
     if(isActive(world, x, y, z)) {
 
-      TileEntity te = world.getTileEntity(x, y, z);
+      TileEntity te = getTileEntityEio(world, x, y, z);
       int facing = 3;
-      if(te instanceof AbstractMachineEntity) {
+      if (te != null) {
         AbstractMachineEntity me = (AbstractMachineEntity) te;
         facing = me.facing;
       }

--- a/src/main/java/crazypants/enderio/machine/generator/stirling/BlockStirlingGenerator.java
+++ b/src/main/java/crazypants/enderio/machine/generator/stirling/BlockStirlingGenerator.java
@@ -3,6 +3,7 @@ package crazypants.enderio.machine.generator.stirling;
 import java.util.Random;
 
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.tileentity.TileEntity;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 import cpw.mods.fml.relauncher.Side;
@@ -29,12 +30,20 @@ public class BlockStirlingGenerator extends AbstractMachineBlock<TileEntityStirl
 
   @Override
   public Object getServerGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z) {
-    return new StirlingGeneratorContainer(player.inventory, (TileEntityStirlingGenerator) world.getTileEntity(x, y, z));
+    TileEntity te = world.getTileEntity(x, y, z);
+    if (te instanceof TileEntityStirlingGenerator) {
+      return new StirlingGeneratorContainer(player.inventory, (TileEntityStirlingGenerator) te);
+    }
+    return null;
   }
 
   @Override
   public Object getClientGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z) {
-    return new GuiStirlingGenerator(player.inventory, (TileEntityStirlingGenerator) world.getTileEntity(x, y, z));
+    TileEntity te = world.getTileEntity(x, y, z);
+    if (te instanceof TileEntityStirlingGenerator) {
+      return new GuiStirlingGenerator(player.inventory, (TileEntityStirlingGenerator) te);
+    }
+    return null;
   }
 
   @Override
@@ -53,7 +62,7 @@ public class BlockStirlingGenerator extends AbstractMachineBlock<TileEntityStirl
   @Override
   @SideOnly(Side.CLIENT)
   public void randomDisplayTick(World world, int x, int y, int z, Random rand) {
-    TileEntityStirlingGenerator te = (TileEntityStirlingGenerator) world.getTileEntity(x, y, z);
+    TileEntityStirlingGenerator te = (TileEntityStirlingGenerator) getTileEntityEio(world, x, y, z);
     if(te != null && te.isActive()) {
       ForgeDirection front = ForgeDirection.values()[te.facing];
 

--- a/src/main/java/crazypants/enderio/machine/generator/zombie/BlockZombieGenerator.java
+++ b/src/main/java/crazypants/enderio/machine/generator/zombie/BlockZombieGenerator.java
@@ -43,14 +43,21 @@ public class BlockZombieGenerator extends AbstractMachineBlock<TileZombieGenerat
 
   @Override
   public Object getServerGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z) {
-    return new ContainerZombieGenerator(player.inventory, (TileZombieGenerator) world.getTileEntity(x, y, z));
+    TileEntity te = world.getTileEntity(x, y, z);
+    if (te instanceof TileZombieGenerator) {
+      return new ContainerZombieGenerator(player.inventory, (TileZombieGenerator) te);
+    }
+    return null;
   }
 
   @Override
   public Object getClientGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z) {
-    return new GuiZombieGenerator(player.inventory, (TileZombieGenerator) world.getTileEntity(x, y, z));
+    TileEntity te = world.getTileEntity(x, y, z);
+    if (te instanceof TileZombieGenerator) {
+      return new GuiZombieGenerator(player.inventory, (TileZombieGenerator) te);
+    }
+    return null;
   }
-
   @Override
   protected int getGuiId() {
     return GuiHandler.GUI_ID_ZOMBIE_GEN;
@@ -89,8 +96,8 @@ public class BlockZombieGenerator extends AbstractMachineBlock<TileZombieGenerat
   public void randomDisplayTick(World world, int x, int y, int z, Random rand) {
 
     if(rand.nextInt(3) == 0) {
-      TileEntity te = world.getTileEntity(x, y, z);
-      if(te instanceof TileZombieGenerator && ((TileZombieGenerator) te).isActive()) {
+      TileEntity te = getTileEntityEio(world, x, y, z);
+      if (te != null && ((TileZombieGenerator) te).isActive()) {
         for (int i = 0; i < 2; i++) {
           float xOffset = 0.5f + (world.rand.nextFloat() * 2.0F - 1.0F) * 0.3f;
           float yOffset = 0.1f;
@@ -111,8 +118,8 @@ public class BlockZombieGenerator extends AbstractMachineBlock<TileZombieGenerat
 
   @Override
   public void getWailaInfo(List<String> tooltip, EntityPlayer player, World world, int x, int y, int z) {
-    TileEntity te = world.getTileEntity(x, y, z);
-    if(te != null && te instanceof TileZombieGenerator) {
+    TileEntity te = getTileEntityEio(world, x, y, z);
+    if (te != null) {
       tooltip.add(((TileZombieGenerator) te).getFluidStored(ForgeDirection.UNKNOWN) + " " + EnderIO.lang.localize("fluid.millibucket.abr"));
     }
   }

--- a/src/main/java/crazypants/enderio/machine/hypercube/BlockHyperCube.java
+++ b/src/main/java/crazypants/enderio/machine/hypercube/BlockHyperCube.java
@@ -110,8 +110,10 @@ public class BlockHyperCube extends BlockEio implements IGuiHandler, IResourceTo
     if(world.isRemote) {
       return;
     }
-    TileHyperCube tr = (TileHyperCube) world.getTileEntity(x, y, z);
-    tr.onBlockAdded();
+    TileHyperCube tr = (TileHyperCube) getTileEntityEio(world, x, y, z);
+    if (tr != null) {
+      tr.onBlockAdded();
+    }
   }
 
   @Override
@@ -119,9 +121,10 @@ public class BlockHyperCube extends BlockEio implements IGuiHandler, IResourceTo
     if(world.isRemote) {
       return;
     }
-    TileHyperCube te = (TileHyperCube) world.getTileEntity(x, y, z);
-    te.onNeighborBlockChange();
-
+    TileHyperCube te = (TileHyperCube) getTileEntityEio(world, x, y, z);
+    if (te != null) {
+      te.onNeighborBlockChange();
+    }
   }
 
   private void setChannelOnItem(TileHyperCube hc, ItemStack itemStack) {
@@ -185,8 +188,8 @@ public class BlockHyperCube extends BlockEio implements IGuiHandler, IResourceTo
   @Override
   public boolean removedByPlayer(World world, EntityPlayer player, int x, int y, int z) {
     if(!world.isRemote) {
-      TileEntity te = world.getTileEntity(x, y, z);
-      if(te instanceof TileHyperCube) {
+      TileEntity te = getTileEntityEio(world, x, y, z);
+      if (te != null) {
         TileHyperCube hc = (TileHyperCube) te;
         hc.onBreakBlock();
         ItemStack itemStack = new ItemStack(this);
@@ -214,8 +217,8 @@ public class BlockHyperCube extends BlockEio implements IGuiHandler, IResourceTo
     if(world.isRemote) {
       return;
     }
-    TileEntity te = world.getTileEntity(x, y, z);
-    if(te instanceof TileHyperCube) {
+    TileEntity te = getTileEntityEio(world, x, y, z);
+    if (te != null) {
       TileHyperCube cb = (TileHyperCube) te;
       cb.setEnergyStored(PowerHandlerUtil.getStoredEnergyForItem(stack));
       if(player instanceof EntityPlayerMP) {
@@ -247,8 +250,8 @@ public class BlockHyperCube extends BlockEio implements IGuiHandler, IResourceTo
 
   @Override
   public Object getClientGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z) {
-    TileEntity te = world.getTileEntity(x, y, z);
-    if(te instanceof TileHyperCube) {
+    TileEntity te = getTileEntityEio(world, x, y, z);
+    if (te != null) {
       TileHyperCube hc = (TileHyperCube) te;
       return new GuiHyperCube(hc);
     }

--- a/src/main/java/crazypants/enderio/machine/invpanel/BlockInventoryPanel.java
+++ b/src/main/java/crazypants/enderio/machine/invpanel/BlockInventoryPanel.java
@@ -185,7 +185,10 @@ public class BlockInventoryPanel extends AbstractMachineBlock<TileInventoryPanel
 
   @Override
   public Object getClientGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z) {
-    TileInventoryPanel te = (TileInventoryPanel) world.getTileEntity(x, y, z);
-    return new GuiInventoryPanel(te, new InventoryPanelContainer(player.inventory, te));
+    TileEntity te = world.getTileEntity(x, y, z);
+    if (te instanceof TileInventoryPanel) {
+      return new GuiInventoryPanel((TileInventoryPanel) te, new InventoryPanelContainer(player.inventory, (TileInventoryPanel) te));
+    }
+    return null;
   }
 }

--- a/src/main/java/crazypants/enderio/machine/killera/BlockKillerJoe.java
+++ b/src/main/java/crazypants/enderio/machine/killera/BlockKillerJoe.java
@@ -3,6 +3,7 @@ package crazypants.enderio.machine.killera;
 import net.minecraft.block.Block;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.tileentity.TileEntity;
 import net.minecraft.world.World;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.entity.player.PlayerEvent;
@@ -52,12 +53,20 @@ public class BlockKillerJoe extends AbstractMachineBlock<TileKillerJoe> {
   
   @Override
   public Object getServerGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z) {
-    return new ContainerKillerJoe(player.inventory, (TileKillerJoe) world.getTileEntity(x, y, z));
+    TileEntity te = world.getTileEntity(x, y, z);
+    if (te instanceof TileKillerJoe) {
+      return new ContainerKillerJoe(player.inventory, (TileKillerJoe) te);
+    }
+    return null;
   }
 
   @Override
   public Object getClientGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z) {
-    return new GuiKillerJoe(player.inventory, (TileKillerJoe) world.getTileEntity(x, y, z));
+    TileEntity te = world.getTileEntity(x, y, z);
+    if (te instanceof TileKillerJoe) {
+      return new GuiKillerJoe(player.inventory, (TileKillerJoe) te);
+    }
+    return null;
   }
 
   @Override

--- a/src/main/java/crazypants/enderio/machine/light/BlockElectricLight.java
+++ b/src/main/java/crazypants/enderio/machine/light/BlockElectricLight.java
@@ -167,16 +167,16 @@ public class BlockElectricLight extends BlockEio implements IRedstoneConnectable
 
   @Override
   public void onNeighborBlockChange(World world, int x, int y, int z, Block blockID) {
-    TileEntity te = world.getTileEntity(x, y, z);
-    if(te instanceof TileElectricLight) {
+    TileEntity te = getTileEntityEio(world, x, y, z);
+    if (te != null) {
       ((TileElectricLight) te).onNeighborBlockChange(blockID);
     }
   }
 
   @Override
   public void breakBlock(World world, int x, int y, int z, Block par5, int par6) {
-    TileEntity te = world.getTileEntity(x, y, z);
-    if(te instanceof TileElectricLight) {
+    TileEntity te = getTileEntityEio(world, x, y, z);
+    if (te != null) {
       ((TileElectricLight) te).onBlockRemoved();
     }
   }
@@ -203,9 +203,9 @@ public class BlockElectricLight extends BlockEio implements IRedstoneConnectable
 
   @Override
   public ItemStack getPickBlock(MovingObjectPosition target, World world, int x, int y, int z) {
-    TileEntity te = world.getTileEntity(x, y, z);
+    TileEntity te = getTileEntityEio(world, x, y, z);
     ItemStack stack = new ItemStack(this);
-    if(te instanceof TileElectricLight) {
+    if (te != null) {
       processDrop(world, x, y, z, (TileEntityEio) te, stack);
     }
     return stack;

--- a/src/main/java/crazypants/enderio/machine/light/BlockLightNode.java
+++ b/src/main/java/crazypants/enderio/machine/light/BlockLightNode.java
@@ -55,7 +55,7 @@ public class BlockLightNode extends BlockEio {
 
   @Override
   public void breakBlock(World world, int x, int y, int z, Block par5, int par6) {
-    TileLightNode te = (TileLightNode) world.getTileEntity(x, y, z);
+    TileLightNode te = (TileLightNode) getTileEntityEio(world, x, y, z);
     if(te != null) {
       te.onBlockRemoved();
     }
@@ -68,7 +68,7 @@ public class BlockLightNode extends BlockEio {
 
   @Override
   public void onNeighborBlockChange(World world, int x, int y, int z, Block par5) {
-    TileLightNode te = (TileLightNode) world.getTileEntity(x, y, z);
+    TileLightNode te = (TileLightNode) getTileEntityEio(world, x, y, z);
     if(te != null) {
       te.onNeighbourChanged();
     }
@@ -76,7 +76,7 @@ public class BlockLightNode extends BlockEio {
 
   @Override
   public void updateTick(World world, int x, int y, int z, Random r) {
-    TileLightNode te = (TileLightNode) world.getTileEntity(x, y, z);
+    TileLightNode te = (TileLightNode) getTileEntityEio(world, x, y, z);
     if(te != null) {
       te.checkParent();
     }

--- a/src/main/java/crazypants/enderio/machine/light/TileElectricLight.java
+++ b/src/main/java/crazypants/enderio/machine/light/TileElectricLight.java
@@ -303,8 +303,12 @@ public class TileElectricLight extends TileEntityEio implements IInternalPowerRe
     int z = zCoord + (int) offset.z;
 
     if(isLightNode(offset)) {
-      TileLightNode te = (TileLightNode) worldObj.getTileEntity(x, y, z);
-      if(te.parentX != xCoord || te.parentY != yCoord || te.parentZ != zCoord) {
+      TileEntity te = worldObj.getTileEntity(x, y, z);
+      if (!(te instanceof TileLightNode)) {
+        return;
+      }
+      TileLightNode tl = (TileLightNode) te;
+      if (tl.parentX != xCoord || tl.parentY != yCoord || tl.parentZ != zCoord) {
         // its somebody else's so leave it alone
         return;
       }

--- a/src/main/java/crazypants/enderio/machine/obelisk/inhibitor/BlockInhibitorObelisk.java
+++ b/src/main/java/crazypants/enderio/machine/obelisk/inhibitor/BlockInhibitorObelisk.java
@@ -35,13 +35,19 @@ public class BlockInhibitorObelisk extends BlockObeliskAbstract<TileInhibitorObe
 
   @Override
   public Object getServerGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z) {
-    return ID == getGuiId() ? new ContainerInhibitorObelisk(player.inventory, (AbstractMachineEntity) world.getTileEntity(x, y, z)) : null;
+    if (ID == getGuiId()) {
+      TileInhibitorObelisk te = (TileInhibitorObelisk) getTileEntityEio(world, x, y, z);
+      if (te != null) {
+        return new ContainerInhibitorObelisk(player.inventory, te);
+      }
+    }
+    return null;
   }
 
   @Override
   public Object getClientGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z) {
     if(ID == getGuiId()) {
-      TileInhibitorObelisk te = (TileInhibitorObelisk) world.getTileEntity(x, y, z);
+      TileInhibitorObelisk te = (TileInhibitorObelisk) getTileEntityEio(world, x, y, z);
       if(te != null) {
         return new GuiInhibitorObelisk(te, new ContainerInhibitorObelisk(player.inventory, te));
       }

--- a/src/main/java/crazypants/enderio/machine/obelisk/weather/BlockWeatherObelisk.java
+++ b/src/main/java/crazypants/enderio/machine/obelisk/weather/BlockWeatherObelisk.java
@@ -3,6 +3,7 @@ package crazypants.enderio.machine.obelisk.weather;
 import java.util.Random;
 
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.tileentity.TileEntity;
 import net.minecraft.world.World;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
@@ -28,12 +29,20 @@ public class BlockWeatherObelisk extends BlockObeliskAbstract<TileWeatherObelisk
 
   @Override
   public Object getServerGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z) {
-    return new ContainerWeatherObelisk(player.inventory, (TileWeatherObelisk) world.getTileEntity(x, y, z));
+    TileEntity te = world.getTileEntity(x, y, z);
+    if (te instanceof TileWeatherObelisk) {
+      return new ContainerWeatherObelisk(player.inventory, (TileWeatherObelisk) te);
+    }
+    return null;
   }
 
   @Override
   public Object getClientGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z) {
-    return new GuiWeatherObelisk(player.inventory, (TileWeatherObelisk) world.getTileEntity(x, y, z));
+    TileEntity te = world.getTileEntity(x, y, z);
+    if (te instanceof TileWeatherObelisk) {
+      return new GuiWeatherObelisk(player.inventory, (TileWeatherObelisk) te);
+    }
+    return null;
   }
 
   @Override

--- a/src/main/java/crazypants/enderio/machine/painter/BlockPaintedCarpet.java
+++ b/src/main/java/crazypants/enderio/machine/painter/BlockPaintedCarpet.java
@@ -89,11 +89,13 @@ public class BlockPaintedCarpet extends BlockCarpet implements ITileEntityProvid
       EffectRenderer effectRenderer) {
     IIcon tex = null;
 
-    TileEntityPaintedBlock cb = (TileEntityPaintedBlock)
-        world.getTileEntity(target.blockX, target.blockY, target.blockZ);
-    Block b = cb.getSourceBlock();
-    if(b != null) {
-      tex = b.getIcon(ForgeDirection.NORTH.ordinal(), cb.getSourceBlockMetadata());
+    TileEntity te = world.getTileEntity(target.blockX, target.blockY, target.blockZ);
+    if (te instanceof TileEntityPaintedBlock) {
+      TileEntityPaintedBlock cb = (TileEntityPaintedBlock) te;
+      Block b = cb.getSourceBlock();
+      if (b != null) {
+        tex = b.getIcon(ForgeDirection.NORTH.ordinal(), cb.getSourceBlockMetadata());
+      }
     }
     if(tex == null) {
       tex = blockIcon;

--- a/src/main/java/crazypants/enderio/machine/painter/BlockPaintedFence.java
+++ b/src/main/java/crazypants/enderio/machine/painter/BlockPaintedFence.java
@@ -76,11 +76,13 @@ public class BlockPaintedFence extends BlockFence implements ITileEntityProvider
       EffectRenderer effectRenderer) {
     IIcon tex = null;
 
-    TileEntityPaintedBlock cb = (TileEntityPaintedBlock)
-        world.getTileEntity(target.blockX, target.blockY, target.blockZ);
-    Block b = cb.getSourceBlock();
-    if(b != null) {
-      tex = b.getIcon(ForgeDirection.NORTH.ordinal(), cb.getSourceBlockMetadata());
+    TileEntity te = world.getTileEntity(target.blockX, target.blockY, target.blockZ);
+    if (te instanceof TileEntityPaintedBlock) {
+      TileEntityPaintedBlock cb = (TileEntityPaintedBlock) te;
+      Block b = cb.getSourceBlock();
+      if (b != null) {
+        tex = b.getIcon(ForgeDirection.NORTH.ordinal(), cb.getSourceBlockMetadata());
+      }
     }
     if(tex == null) {
       tex = blockIcon;

--- a/src/main/java/crazypants/enderio/machine/painter/BlockPaintedFenceGate.java
+++ b/src/main/java/crazypants/enderio/machine/painter/BlockPaintedFenceGate.java
@@ -70,11 +70,13 @@ public class BlockPaintedFenceGate extends BlockFenceGate implements ITileEntity
       EffectRenderer effectRenderer) {
     IIcon tex = null;
 
-    TileEntityPaintedBlock cb = (TileEntityPaintedBlock)
-        world.getTileEntity(target.blockX, target.blockY, target.blockZ);
-    Block b = cb.getSourceBlock();
-    if(b != null) {
-      tex = b.getIcon(ForgeDirection.NORTH.ordinal(), cb.getSourceBlockMetadata());
+    TileEntity te = world.getTileEntity(target.blockX, target.blockY, target.blockZ);
+    if (te instanceof TileEntityPaintedBlock) {
+      TileEntityPaintedBlock cb = (TileEntityPaintedBlock) te;
+      Block b = cb.getSourceBlock();
+      if (b != null) {
+        tex = b.getIcon(ForgeDirection.NORTH.ordinal(), cb.getSourceBlockMetadata());
+      }
     }
     if(tex == null) {
       tex = blockIcon;

--- a/src/main/java/crazypants/enderio/machine/painter/BlockPaintedGlowstone.java
+++ b/src/main/java/crazypants/enderio/machine/painter/BlockPaintedGlowstone.java
@@ -99,11 +99,13 @@ public class BlockPaintedGlowstone extends BlockEio implements ITileEntityProvid
       EffectRenderer effectRenderer) {
     IIcon tex = null;
 
-    TileEntityPaintedBlock cb = (TileEntityPaintedBlock)
-        world.getTileEntity(target.blockX, target.blockY, target.blockZ);
-    Block b = cb.getSourceBlock();
-    if(b != null) {
-      tex = b.getIcon(ForgeDirection.NORTH.ordinal(), cb.getSourceBlockMetadata());
+    TileEntity te = world.getTileEntity(target.blockX, target.blockY, target.blockZ);
+    if (te instanceof TileEntityPaintedBlock) {
+      TileEntityPaintedBlock cb = (TileEntityPaintedBlock) te;
+      Block b = cb.getSourceBlock();
+      if (b != null) {
+        tex = b.getIcon(ForgeDirection.NORTH.ordinal(), cb.getSourceBlockMetadata());
+      }
     }
     if(tex == null) {
       tex = blockIcon;

--- a/src/main/java/crazypants/enderio/machine/painter/BlockPaintedSlab.java
+++ b/src/main/java/crazypants/enderio/machine/painter/BlockPaintedSlab.java
@@ -101,11 +101,13 @@ public class BlockPaintedSlab extends BlockSlab implements ITileEntityProvider, 
       EffectRenderer effectRenderer) {
     IIcon tex = null;
 
-    TileEntityPaintedBlock cb = (TileEntityPaintedBlock)
-        world.getTileEntity(target.blockX, target.blockY, target.blockZ);
-    Block b = cb.getSourceBlock();
-    if(b != null) {
-      tex = b.getIcon(ForgeDirection.NORTH.ordinal(), cb.getSourceBlockMetadata());
+    TileEntity te = world.getTileEntity(target.blockX, target.blockY, target.blockZ);
+    if (te instanceof TileEntityPaintedBlock) {
+      TileEntityPaintedBlock cb = (TileEntityPaintedBlock) te;
+      Block b = cb.getSourceBlock();
+      if (b != null) {
+        tex = b.getIcon(ForgeDirection.NORTH.ordinal(), cb.getSourceBlockMetadata());
+      }
     }
     if(tex == null) {
       tex = blockIcon;

--- a/src/main/java/crazypants/enderio/machine/painter/BlockPaintedStair.java
+++ b/src/main/java/crazypants/enderio/machine/painter/BlockPaintedStair.java
@@ -73,11 +73,13 @@ public class BlockPaintedStair extends BlockStairs implements ITileEntityProvide
       EffectRenderer effectRenderer) {
     IIcon tex = null;
 
-    TileEntityPaintedBlock cb = (TileEntityPaintedBlock)
-        world.getTileEntity(target.blockX, target.blockY, target.blockZ);
-    Block b = cb.getSourceBlock();
-    if(b != null) {
-      tex = b.getIcon(ForgeDirection.NORTH.ordinal(), cb.getSourceBlockMetadata());
+    TileEntity te = world.getTileEntity(target.blockX, target.blockY, target.blockZ);
+    if (te instanceof TileEntityPaintedBlock) {
+      TileEntityPaintedBlock cb = (TileEntityPaintedBlock) te;
+      Block b = cb.getSourceBlock();
+      if (b != null) {
+        tex = b.getIcon(ForgeDirection.NORTH.ordinal(), cb.getSourceBlockMetadata());
+      }
     }
     if(tex == null) {
       tex = blockIcon;

--- a/src/main/java/crazypants/enderio/machine/painter/BlockPaintedWall.java
+++ b/src/main/java/crazypants/enderio/machine/painter/BlockPaintedWall.java
@@ -71,11 +71,13 @@ public class BlockPaintedWall extends BlockWall implements ITileEntityProvider, 
       EffectRenderer effectRenderer) {
     IIcon tex = null;
 
-    TileEntityPaintedBlock cb = (TileEntityPaintedBlock)
-        world.getTileEntity(target.blockX, target.blockY, target.blockZ);
-    Block b = cb.getSourceBlock();
-    if(b != null) {
-      tex = b.getIcon(ForgeDirection.NORTH.ordinal(), cb.getSourceBlockMetadata());
+    TileEntity te = world.getTileEntity(target.blockX, target.blockY, target.blockZ);
+    if (te instanceof TileEntityPaintedBlock) {
+      TileEntityPaintedBlock cb = (TileEntityPaintedBlock) te;
+      Block b = cb.getSourceBlock();
+      if (b != null) {
+        tex = b.getIcon(ForgeDirection.NORTH.ordinal(), cb.getSourceBlockMetadata());
+      }
     }
     if(tex == null) {
       tex = blockIcon;

--- a/src/main/java/crazypants/enderio/machine/painter/BlockPainter.java
+++ b/src/main/java/crazypants/enderio/machine/painter/BlockPainter.java
@@ -43,7 +43,10 @@ public class BlockPainter extends AbstractMachineBlock<TileEntityPainter> {
   @SideOnly(Side.CLIENT)
   public Object getClientGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z) {
     TileEntity te = world.getTileEntity(x, y, z);
-    return new GuiPainter(player.inventory, (TileEntityPainter) te);
+    if (te instanceof TileEntityPainter) {
+      return new GuiPainter(player.inventory, (TileEntityPainter) te);
+    }
+    return null;
   }
 
   @Override

--- a/src/main/java/crazypants/enderio/machine/power/BlockCapacitorBank.java
+++ b/src/main/java/crazypants/enderio/machine/power/BlockCapacitorBank.java
@@ -110,8 +110,8 @@ public class BlockCapacitorBank extends BlockEio implements IGuiHandler, IAdvanc
   @Override
   public boolean onBlockActivated(World world, int x, int y, int z, EntityPlayer entityPlayer, int side, float par7, float par8, float par9) {
 
-    TileEntity te = world.getTileEntity(x, y, z);
-    if(!(te instanceof TileCapacitorBank)) {
+    TileEntity te = getTileEntityEio(world, x, y, z);
+    if (te == null) {
       return false;
     }
 
@@ -143,8 +143,8 @@ public class BlockCapacitorBank extends BlockEio implements IGuiHandler, IAdvanc
 
   @Override
   public Object getServerGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z) {
-    TileEntity te = world.getTileEntity(x, y, z);
-    if(te instanceof TileCapacitorBank) {
+    TileEntity te = getTileEntityEio(world, x, y, z);
+    if (te != null) {
       return new ContainerCapacitorBank(player, player.inventory, ((TileCapacitorBank) te).getController());
     }
     return null;
@@ -152,8 +152,8 @@ public class BlockCapacitorBank extends BlockEio implements IGuiHandler, IAdvanc
 
   @Override
   public Object getClientGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z) {
-    TileEntity te = world.getTileEntity(x, y, z);
-    if(te instanceof TileCapacitorBank) {
+    TileEntity te = getTileEntityEio(world, x, y, z);
+    if (te != null) {
       return new GuiCapacitorBank(player, player.inventory, ((TileCapacitorBank) te).getController());
     }
     return null;
@@ -223,8 +223,8 @@ public class BlockCapacitorBank extends BlockEio implements IGuiHandler, IAdvanc
     if(world.isRemote) {
       return;
     }
-    TileEntity te = world.getTileEntity(x, y, z);
-    if(te instanceof TileCapacitorBank) {
+    TileEntity te = getTileEntityEio(world, x, y, z);
+    if (te != null) {
       TileCapacitorBank tr = (TileCapacitorBank) te;
       int meta = world.getBlockMetadata(x, y, z);
       if(meta == 1) {
@@ -239,8 +239,8 @@ public class BlockCapacitorBank extends BlockEio implements IGuiHandler, IAdvanc
     if(world.isRemote) {
       return;
     }
-    TileEntity tile = world.getTileEntity(x, y, z);
-    if(tile instanceof TileCapacitorBank) {
+    TileEntity tile = getTileEntityEio(world, x, y, z);
+    if (tile != null) {
       TileCapacitorBank te = (TileCapacitorBank) tile;
       te.onNeighborBlockChange(blockId);
     }
@@ -249,8 +249,8 @@ public class BlockCapacitorBank extends BlockEio implements IGuiHandler, IAdvanc
   @Override
   public boolean removedByPlayer(World world, EntityPlayer player, int x, int y, int z) {
     if(!world.isRemote) {
-      TileEntity te = world.getTileEntity(x, y, z);
-      if(te instanceof TileCapacitorBank) {
+      TileEntity te = getTileEntityEio(world, x, y, z);
+      if (te != null) {
         TileCapacitorBank cb = (TileCapacitorBank) te;
         cb.onBreakBlock();
 
@@ -281,8 +281,8 @@ public class BlockCapacitorBank extends BlockEio implements IGuiHandler, IAdvanc
     if(world.isRemote) {
       return;
     }
-    TileEntity te = world.getTileEntity(x, y, z);
-    if(te instanceof TileCapacitorBank) {
+    TileEntity te = getTileEntityEio(world, x, y, z);
+    if (te != null) {
       TileCapacitorBank cb = (TileCapacitorBank) te;
       cb.addEnergy(PowerHandlerUtil.getStoredEnergyForItem(stack));
       if(player instanceof EntityPlayerMP) {
@@ -311,8 +311,8 @@ public class BlockCapacitorBank extends BlockEio implements IGuiHandler, IAdvanc
   @Override
   public void breakBlock(World world, int x, int y, int z, Block par5, int par6) {
     if(!world.isRemote && world.getGameRules().getGameRuleBooleanValue("doTileDrops")) {
-      TileEntity te = world.getTileEntity(x, y, z);
-      if(!(te instanceof TileCapacitorBank)) {
+      TileEntity te = getTileEntityEio(world, x, y, z);
+      if (te == null) {
         super.breakBlock(world, x, y, z, par5, par6);
         return;
       }
@@ -324,8 +324,8 @@ public class BlockCapacitorBank extends BlockEio implements IGuiHandler, IAdvanc
   @Override
   @SideOnly(Side.CLIENT)
   public AxisAlignedBB getSelectedBoundingBoxFromPool(World world, int x, int y, int z) {
-    TileEntity te = world.getTileEntity(x, y, z);
-    if(!(te instanceof TileCapacitorBank)) {
+    TileEntity te = getTileEntityEio(world, x, y, z);
+    if (te == null) {
       return super.getSelectedBoundingBoxFromPool(world, x, y, z);
     }
     TileCapacitorBank tr = (TileCapacitorBank) te;
@@ -353,8 +353,8 @@ public class BlockCapacitorBank extends BlockEio implements IGuiHandler, IAdvanc
 
   @Override
   public int getComparatorInputOverride(World w, int x, int y, int z, int side) {
-    TileEntity te = w.getTileEntity(x, y, z);
-    if (te instanceof TileCapacitorBank) {
+    TileEntity te = getTileEntityEio(w, x, y, z);
+    if (te != null) {
       return ((TileCapacitorBank) te).getComparatorOutput();
     }
     return 0;
@@ -362,8 +362,8 @@ public class BlockCapacitorBank extends BlockEio implements IGuiHandler, IAdvanc
 
   @Override
   public void getWailaInfo(List<String> tooltip, EntityPlayer player, World world, int x, int y, int z) {
-    TileEntity te = world.getTileEntity(x, y, z);
-    if (te instanceof TileCapacitorBank) {
+    TileEntity te = getTileEntityEio(world, x, y, z);
+    if (te != null) {
       TileCapacitorBank cap = (TileCapacitorBank) te;
       String format = Util.TAB + Util.ALIGNRIGHT + EnumChatFormatting.WHITE;
 

--- a/src/main/java/crazypants/enderio/machine/reservoir/BlockReservoir.java
+++ b/src/main/java/crazypants/enderio/machine/reservoir/BlockReservoir.java
@@ -63,7 +63,7 @@ public class BlockReservoir extends BlockEio implements IResourceTooltipProvider
     TileEntity te;
 
     if (!entityPlayer.isSneaking() && entityPlayer.inventory.getCurrentItem() != null
-        && (te = world.getTileEntity(x, y, z)) instanceof TileReservoir) {
+        && (te = getTileEntityEio(world, x, y, z)) != null) {
       TileReservoir tank = ((TileReservoir) te).getController();
       if (ToolUtil.isToolEquipped(entityPlayer) && tank.isMultiblock()) {
         tank.setAutoEject(!tank.isAutoEject());
@@ -87,8 +87,8 @@ public class BlockReservoir extends BlockEio implements IResourceTooltipProvider
   @Override
   @SideOnly(Side.CLIENT)
   public AxisAlignedBB getSelectedBoundingBoxFromPool(World world, int x, int y, int z) {
-    TileEntity te = world.getTileEntity(x, y, z);
-    if(!(te instanceof TileReservoir)) {
+    TileEntity te = getTileEntityEio(world, x, y, z);
+    if (te == null) {
       return super.getSelectedBoundingBoxFromPool(world, x, y, z);
     }
     TileReservoir tr = (TileReservoir) te;
@@ -126,22 +126,12 @@ public class BlockReservoir extends BlockEio implements IResourceTooltipProvider
   }
 
   @Override
-  public void onBlockAdded(World world, int x, int y, int z) {
-    if(world.isRemote) {
-      return;
-    }
-    TileReservoir tr = (TileReservoir) world.getTileEntity(x, y, z);
-    boolean res = tr.onBlockAdded();
-
-  }
-
-  @Override
   public void onNeighborBlockChange(World world, int x, int y, int z, Block block) {
     if(world.isRemote) {
       return;
     }
-    TileEntity te = world.getTileEntity(x, y, z);
-    if(te instanceof TileReservoir) {
+    TileEntity te = getTileEntityEio(world, x, y, z);
+    if (te != null) {
       ((TileReservoir) te).onNeighborBlockChange(block);
     }
   }

--- a/src/main/java/crazypants/enderio/machine/slicensplice/BlockSliceAndSplice.java
+++ b/src/main/java/crazypants/enderio/machine/slicensplice/BlockSliceAndSplice.java
@@ -81,8 +81,8 @@ public class BlockSliceAndSplice extends AbstractMachineBlock<TileSliceAndSplice
   @SideOnly(Side.CLIENT)
   @Override
   public void randomDisplayTick(World world, int x, int y, int z, Random rand) {
-    TileSliceAndSplice te = (TileSliceAndSplice) world.getTileEntity(x, y, z);
-    if(isActive(world, x, y, z) && te != null) {
+    TileSliceAndSplice te = (TileSliceAndSplice) getTileEntityEio(world, x, y, z);
+    if (te != null && isActive(world, x, y, z)) {
       
       ForgeDirection front = ForgeDirection.values()[te.facing];
 

--- a/src/main/java/crazypants/enderio/machine/solar/BlockSolarPanel.java
+++ b/src/main/java/crazypants/enderio/machine/solar/BlockSolarPanel.java
@@ -96,8 +96,8 @@ public class BlockSolarPanel extends BlockEio implements IResourceTooltipProvide
 
   @Override
   public void onNeighborBlockChange(World world, int x, int y, int z, Block par5) {
-    TileEntity te = world.getTileEntity(x, y, z);
-    if(te instanceof TileEntitySolarPanel) {
+    TileEntity te = getTileEntityEio(world, x, y, z);
+    if (te != null) {
       ((TileEntitySolarPanel) te).onNeighborBlockChange();
     }
   }
@@ -137,8 +137,8 @@ public class BlockSolarPanel extends BlockEio implements IResourceTooltipProvide
 
   @Override
   public void getWailaInfo(List<String> tooltip, EntityPlayer player, World world, int x, int y, int z) {
-    TileEntity te = world.getTileEntity(x, y, z);
-    if(te instanceof TileEntitySolarPanel) {
+    TileEntity te = getTileEntityEio(world, x, y, z);
+    if (te != null) {
       TileEntitySolarPanel solar = (TileEntitySolarPanel) te;
       float efficiency = solar.calculateLightRatio();
       if(!solar.canSeeSun()) {

--- a/src/main/java/crazypants/enderio/machine/spawner/BlockPoweredSpawner.java
+++ b/src/main/java/crazypants/enderio/machine/spawner/BlockPoweredSpawner.java
@@ -315,8 +315,10 @@ public class BlockPoweredSpawner extends AbstractMachineBlock<TilePoweredSpawner
 
   @Override
   public void getWailaInfo(List<String> tooltip, EntityPlayer player, World world, int x, int y, int z) {
-    TilePoweredSpawner te = (TilePoweredSpawner) world.getTileEntity(x, y, z);
-    tooltip.add(te.getEntityName());
+    TilePoweredSpawner te = (TilePoweredSpawner) getTileEntityEio(world, x, y, z);
+    if (te != null) {
+      tooltip.add(te.getEntityName());
+    }
   }
 
   @Override

--- a/src/main/java/crazypants/enderio/machine/tank/BlockTank.java
+++ b/src/main/java/crazypants/enderio/machine/tank/BlockTank.java
@@ -187,8 +187,8 @@ public class BlockTank extends AbstractMachineBlock<TileTank> implements IAdvanc
 
   @Override
   public int getComparatorInputOverride(World w, int x, int y, int z, int side) {
-    TileEntity te = w.getTileEntity(x, y, z);
-    if (te instanceof TileTank) {
+    TileEntity te = getTileEntityEio(w, x, y, z);
+    if (te != null) {
       return ((TileTank) te).getComparatorOutput();
     }
     return 0;
@@ -223,8 +223,8 @@ public class BlockTank extends AbstractMachineBlock<TileTank> implements IAdvanc
 
   @Override
   public void getWailaInfo(List<String> tooltip, EntityPlayer player, World world, int x, int y, int z) {
-    TileEntity te = world.getTileEntity(x, y, z);
-    if (te instanceof TileTank) {
+    TileEntity te = getTileEntityEio(world, x, y, z);
+    if (te != null) {
       TileTank tank = (TileTank) te;
       FluidStack stored = tank.tank.getFluid();
       String fluid = stored == null ? EnderIO.lang.localize("tooltip.none") : stored.getFluid().getLocalizedName(stored);

--- a/src/main/java/crazypants/enderio/machine/transceiver/BlockTransceiver.java
+++ b/src/main/java/crazypants/enderio/machine/transceiver/BlockTransceiver.java
@@ -57,8 +57,8 @@ public class BlockTransceiver extends AbstractMachineBlock<TileTransceiver> {
   @Override
   public boolean removedByPlayer(World world, EntityPlayer player, int x, int y, int z, boolean doHarvest) {
     if(!world.isRemote) {
-      TileEntity te = world.getTileEntity(x, y, z);
-      if(te instanceof TileTransceiver) {
+      TileEntity te = getTileEntityEio(world, x, y, z);
+      if (te != null) {
         ((TileTransceiver)te).getRailController().dropNonSpawnedCarts();
       }
     }
@@ -77,7 +77,10 @@ public class BlockTransceiver extends AbstractMachineBlock<TileTransceiver> {
   @Override
   public Object getClientGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z) {
     TileEntity te = world.getTileEntity(x, y, z);
-    return new GuiTransceiver(player.inventory, (TileTransceiver) te);
+    if (te instanceof TileTransceiver) {
+      return new GuiTransceiver(player.inventory, (TileTransceiver) te);
+    }
+    return null;
   }
 
   @Override
@@ -126,29 +129,31 @@ public class BlockTransceiver extends AbstractMachineBlock<TileTransceiver> {
 
   @Override
   public void getWailaInfo(List<String> tooltip, EntityPlayer player, World world, int x, int y, int z) {
-    TileEntity te = world.getTileEntity(x, y, z);
-    if (te instanceof TileTransceiver && player.isSneaking()) {
-      TileTransceiver trans = (TileTransceiver) te;
-      for (ChannelType type : ChannelType.VALUES) {
+    if (player.isSneaking()) {
+      TileEntity te = getTileEntityEio(world, x, y, z);
+      if (te != null) {
+        TileTransceiver trans = (TileTransceiver) te;
+        for (ChannelType type : ChannelType.VALUES) {
 
-        Set<Channel> recieving = trans.getRecieveChannels(type);
-        Set<Channel> sending = trans.getSendChannels(type);
-        String recieve = "[" + buildString(recieving) + "]";
-        String send = "[" + buildString(sending) + "]";
+          Set<Channel> recieving = trans.getRecieveChannels(type);
+          Set<Channel> sending = trans.getSendChannels(type);
+          String recieve = "[" + buildString(recieving) + "]";
+          String send = "[" + buildString(sending) + "]";
 
-        if(isEmpty(recieve) && isEmpty(send)) {
-          continue;
-        }
+          if (isEmpty(recieve) && isEmpty(send)) {
+            continue;
+          }
 
-        tooltip.add(EnumChatFormatting.WHITE + EnderIO.lang.localize("trans." + type.name().toLowerCase(Locale.US)));
+          tooltip.add(EnumChatFormatting.WHITE + EnderIO.lang.localize("trans." + type.name().toLowerCase(Locale.US)));
 
-        if(!isEmpty(recieve)) {
-          tooltip.add(String.format("%s%s " + Util.TAB + ": %s%s", Util.TAB, EnderIO.lang.localize("trans.receiving"), Util.TAB + Util.ALIGNRIGHT
-              + EnumChatFormatting.WHITE, recieve));
-        }
-        if(!isEmpty(send)) {
-          tooltip.add(String.format("%s%s " + Util.TAB + ": %s%s", Util.TAB, EnderIO.lang.localize("trans.sending"), Util.TAB + Util.ALIGNRIGHT
-              + EnumChatFormatting.WHITE, send));
+          if (!isEmpty(recieve)) {
+            tooltip.add(String.format("%s%s " + Util.TAB + ": %s%s", Util.TAB, EnderIO.lang.localize("trans.receiving"), Util.TAB
+                + Util.ALIGNRIGHT + EnumChatFormatting.WHITE, recieve));
+          }
+          if (!isEmpty(send)) {
+            tooltip.add(String.format("%s%s " + Util.TAB + ": %s%s", Util.TAB, EnderIO.lang.localize("trans.sending"), Util.TAB
+                + Util.ALIGNRIGHT + EnumChatFormatting.WHITE, send));
+          }
         }
       }
     }

--- a/src/main/java/crazypants/enderio/machine/vacuum/BlockVacuumChest.java
+++ b/src/main/java/crazypants/enderio/machine/vacuum/BlockVacuumChest.java
@@ -44,9 +44,9 @@ public class BlockVacuumChest extends BlockEio implements IGuiHandler, IResource
 
   @Override
   public void onNeighborBlockChange(World world, int x, int y, int z, Block blockId) {
-    TileEntity ent = world.getTileEntity(x, y, z);
-    if(ent instanceof TileVacuumChest) {
-      ((TileVacuumChest) ent).onNeighborBlockChange(blockId);
+    TileEntity te = getTileEntityEio(world, x, y, z);
+    if (te != null) {
+      ((TileVacuumChest) te).onNeighborBlockChange(blockId);
     }
   }
 
@@ -80,8 +80,8 @@ public class BlockVacuumChest extends BlockEio implements IGuiHandler, IResource
   @Override
   public void onBlockPlacedBy(World world, int x, int y, int z, EntityLivingBase placedBy, ItemStack stack) {
     if(!world.isRemote) {
-      TileEntity te = world.getTileEntity(x, y, z);
-      if(stack != null && stack.stackTagCompound != null && te instanceof TileVacuumChest) {
+      TileEntity te = getTileEntityEio(world, x, y, z);
+      if (stack != null && stack.stackTagCompound != null && te != null) {
         ((TileVacuumChest) te).readContentsFromNBT(stack.stackTagCompound);
         world.markBlockForUpdate(x, y, z);
       }
@@ -100,8 +100,8 @@ public class BlockVacuumChest extends BlockEio implements IGuiHandler, IResource
 
   @Override
   public Object getServerGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z) {
-    TileEntity te = world.getTileEntity(x, y, z);
-    if(te instanceof TileVacuumChest) {
+    TileEntity te = getTileEntityEio(world, x, y, z);
+    if (te != null) {
       return new ContainerVacuumChest(player, player.inventory, (TileVacuumChest) te);
     }
     return null;
@@ -109,8 +109,8 @@ public class BlockVacuumChest extends BlockEio implements IGuiHandler, IResource
 
   @Override
   public Object getClientGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z) {
-    TileEntity te = world.getTileEntity(x, y, z);
-    if(te instanceof TileVacuumChest) {
+    TileEntity te = getTileEntityEio(world, x, y, z);
+    if (te != null) {
       return new GuiVacuumChest(player, player.inventory, (TileVacuumChest) te);
     }
     return null;

--- a/src/main/java/crazypants/enderio/machine/vat/BlockVat.java
+++ b/src/main/java/crazypants/enderio/machine/vat/BlockVat.java
@@ -139,25 +139,27 @@ public class BlockVat extends AbstractMachineBlock<TileVat> {
   public void randomDisplayTick(World world, int x, int y, int z, Random rand) {
     // Spit some "steam" out the spout
     if (isActive(world, x, y, z)) {
-      TileVat te = (TileVat) world.getTileEntity(x, y, z);
-      float pX = x + 0.5f;
-      float pY = y + 0.7f;
-      float pZ = z + 0.5f;
+      TileVat te = (TileVat) getTileEntityEio(world, x, y, z);
+      if (te != null) {
+        float pX = x + 0.5f;
+        float pY = y + 0.7f;
+        float pZ = z + 0.5f;
 
-      ForgeDirection dir = te.getFacingDir();
-      pX += 0.6f * dir.offsetX;
-      pZ += 0.6f * dir.offsetZ;
+        ForgeDirection dir = te.getFacingDir();
+        pX += 0.6f * dir.offsetX;
+        pZ += 0.6f * dir.offsetZ;
 
-      double velX = ((rand.nextDouble() * 0.075) + 0.025) * dir.offsetX;
-      double velZ = ((rand.nextDouble() * 0.075) + 0.025) * dir.offsetZ;
+        double velX = ((rand.nextDouble() * 0.075) + 0.025) * dir.offsetX;
+        double velZ = ((rand.nextDouble() * 0.075) + 0.025) * dir.offsetZ;
 
-      int num = rand.nextInt(4) + 2;
-      for (int k = 0; k < num; k++) {
-        EffectRenderer er = Minecraft.getMinecraft().effectRenderer;
-        EntitySmokeFX fx = new EntitySmokeFX(world, pX, pY, pZ, 1, 1, 1);
-        fx.setRBGColorF(1 - (rand.nextFloat() * 0.2f), 1 - (rand.nextFloat() * 0.1f), 1 - (rand.nextFloat() * 0.2f));
-        fx.setVelocity(velX, -0.06, velZ);
-        er.addEffect(fx);
+        int num = rand.nextInt(4) + 2;
+        for (int k = 0; k < num; k++) {
+          EffectRenderer er = Minecraft.getMinecraft().effectRenderer;
+          EntitySmokeFX fx = new EntitySmokeFX(world, pX, pY, pZ, 1, 1, 1);
+          fx.setRBGColorF(1 - (rand.nextFloat() * 0.2f), 1 - (rand.nextFloat() * 0.1f), 1 - (rand.nextFloat() * 0.2f));
+          fx.setVelocity(velX, -0.06, velZ);
+          er.addEffect(fx);
+        }
       }
     }
   }

--- a/src/main/java/crazypants/enderio/machine/wireless/BlockWirelessCharger.java
+++ b/src/main/java/crazypants/enderio/machine/wireless/BlockWirelessCharger.java
@@ -116,8 +116,8 @@ public class BlockWirelessCharger extends BlockEio implements IResourceTooltipPr
     super.onBlockPlacedBy(world, x, y, z, player, stack);
 
     if(stack.stackTagCompound != null) {
-      TileEntity te = world.getTileEntity(x, y, z);
-      if(te instanceof TileWirelessCharger) {
+      TileEntity te = getTileEntityEio(world, x, y, z);
+      if (te != null) {
         ((TileWirelessCharger) te).readCustomNBT(stack.stackTagCompound);
       }
     }

--- a/src/main/java/crazypants/enderio/teleport/anchor/BlockTravelAnchor.java
+++ b/src/main/java/crazypants/enderio/teleport/anchor/BlockTravelAnchor.java
@@ -115,8 +115,8 @@ public class BlockTravelAnchor extends BlockEio implements IGuiHandler, ITileEnt
   @Override
   public void onBlockPlacedBy(World world, int x, int y, int z, EntityLivingBase entity, ItemStack par6ItemStack) {
     if (entity instanceof EntityPlayer) {
-      TileEntity te = world.getTileEntity(x, y, z);
-      if (te instanceof TileTravelAnchor) {
+      TileEntity te = getTileEntityEio(world, x, y, z);
+      if (te != null) {
         TileTravelAnchor ta = (TileTravelAnchor) te;
         ta.setPlacedBy((EntityPlayer) entity);
         Block b = PainterUtil.getSourceBlock(par6ItemStack);
@@ -129,7 +129,7 @@ public class BlockTravelAnchor extends BlockEio implements IGuiHandler, ITileEnt
 
   @Override
   public boolean openGui(World world, int x, int y, int z, EntityPlayer entityPlayer, int side) {
-    TileEntity te = world.getTileEntity(x, y, z);
+    TileEntity te = getTileEntityEio(world, x, y, z);
     if (!world.isRemote && te instanceof ITravelAccessable) {
       ITravelAccessable ta = (ITravelAccessable) te;
       if (ta.canUiBeAccessed(entityPlayer)) {
@@ -151,7 +151,7 @@ public class BlockTravelAnchor extends BlockEio implements IGuiHandler, ITileEnt
 
   @Override
   public Object getServerGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z) {
-    TileEntity te = world.getTileEntity(x, y, z);
+    TileEntity te = getTileEntityEio(world, x, y, z);
     if (te instanceof ITravelAccessable) {
       if (ID == GuiHandler.GUI_ID_TRAVEL_ACCESSABLE) {
         return new ContainerTravelAccessable(player.inventory, (ITravelAccessable) te, world);
@@ -164,7 +164,7 @@ public class BlockTravelAnchor extends BlockEio implements IGuiHandler, ITileEnt
 
   @Override
   public Object getClientGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z) {
-    TileEntity te = world.getTileEntity(x, y, z);
+    TileEntity te = getTileEntityEio(world, x, y, z);
     if (te instanceof ITravelAccessable) {
       if (ID == GuiHandler.GUI_ID_TRAVEL_ACCESSABLE) {
         return new GuiTravelAccessable(player.inventory, (ITravelAccessable) te, world);

--- a/src/main/java/crazypants/enderio/teleport/telepad/BlockTelePad.java
+++ b/src/main/java/crazypants/enderio/teleport/telepad/BlockTelePad.java
@@ -66,7 +66,7 @@ public class BlockTelePad extends BlockTravelAnchor {
 
   @Override
   public IIcon getIcon(IBlockAccess world, int x, int y, int z, int blockSide) {
-    TileTelePad te = (TileTelePad) world.getTileEntity(x, y, z);
+    TileTelePad te = (TileTelePad) getTileEntityEio(world, x, y, z);
     if(te != null && te.inNetwork()) {
       return model;
     }
@@ -86,8 +86,8 @@ public class BlockTelePad extends BlockTravelAnchor {
   @Override
   public AxisAlignedBB getSelectedBoundingBoxFromPool(World world, int x, int y, int z) {
     AxisAlignedBB bb = super.getSelectedBoundingBoxFromPool(world, x, y, z);
-    TileTelePad te = (TileTelePad) world.getTileEntity(x, y, z);
-    if(!te.inNetwork()) {
+    TileTelePad te = (TileTelePad) getTileEntityEio(world, x, y, z);
+    if (te == null || !te.inNetwork()) {
       return bb;
     }
     return te.getBoundingBox();
@@ -96,19 +96,25 @@ public class BlockTelePad extends BlockTravelAnchor {
   @Override
   public void onNeighborBlockChange(World world, int x, int y, int z, Block changedTo) {
     super.onNeighborBlockChange(world, x, y, z, changedTo);
-    ((TileTelePad) world.getTileEntity(x, y, z)).updateRedstoneState();
+    TileTelePad te = (TileTelePad) getTileEntityEio(world, x, y, z);
+    if (te != null) {
+      te.updateRedstoneState();
+    }
   }
 
   @Override
   public void onNeighborChange(IBlockAccess world, int x, int y, int z, int tileX, int tileY, int tileZ) {
     super.onNeighborChange(world, x, y, z, tileX, tileY, tileZ);
-    ((TileTelePad) world.getTileEntity(x, y, z)).updateConnectedState(true);
+    TileTelePad te = (TileTelePad) getTileEntityEio(world, x, y, z);
+    if (te != null) {
+      te.updateConnectedState(true);
+    }
   }
 
   @Override
   public boolean openGui(World world, int x, int y, int z, EntityPlayer entityPlayer, int side) {
-    TileEntity te = world.getTileEntity(x, y, z);
-    if(te instanceof TileTelePad) {
+    TileEntity te = getTileEntityEio(world, x, y, z);
+    if (te != null) {
       TileTelePad tp = (TileTelePad) te;
       if(tp.inNetwork()) {
         if(!tp.isMaster()) {
@@ -132,13 +138,16 @@ public class BlockTelePad extends BlockTravelAnchor {
   @Override
   public void onBlockPlacedBy(World world, int x, int y, int z, EntityLivingBase entity, ItemStack par6ItemStack) {
     super.onBlockPlacedBy(world, x, y, z, entity, par6ItemStack);
-    ((TileTelePad) world.getTileEntity(x, y, z)).updateConnectedState(true);
+    TileTelePad te = (TileTelePad) getTileEntityEio(world, x, y, z);
+    if (te != null) {
+      te.updateConnectedState(true);
+    }
   }
 
   @Override
   public Object getServerGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z) {
-    TileEntity te = world.getTileEntity(x, y, z);
-    if(te instanceof TileTelePad) {
+    TileEntity te = getTileEntityEio(world, x, y, z);
+    if (te != null) {
       switch (ID) {
       case GuiHandler.GUI_ID_TELEPAD:
         return new ContainerTelePad(player.inventory);
@@ -153,8 +162,8 @@ public class BlockTelePad extends BlockTravelAnchor {
 
   @Override
   public Object getClientGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z) {
-    TileEntity te = world.getTileEntity(x, y, z);
-    if(te instanceof TileTelePad) {
+    TileEntity te = getTileEntityEio(world, x, y, z);
+    if (te != null) {
       switch (ID) {
       case GuiHandler.GUI_ID_TELEPAD:
         return new GuiTelePad(player.inventory, (TileTelePad) te, world);

--- a/src/main/java/crazypants/util/ClientUtil.java
+++ b/src/main/java/crazypants/util/ClientUtil.java
@@ -56,11 +56,12 @@ public class ClientUtil {
   }
 
   public static void setTankNBT(PacketCombustionTank message, int x, int y, int z) {
-    TileCombustionGenerator tile = (TileCombustionGenerator) Minecraft.getMinecraft().theWorld.getTileEntity(x, y, z);
-    if(tile == null) {
+    TileEntity te = Minecraft.getMinecraft().theWorld.getTileEntity(x, y, z);
+    if (!(te instanceof TileCombustionGenerator)) {
       //no loaded on client when receiving message, can happen when loading the chunks 
       return;
     }
+    TileCombustionGenerator tile = (TileCombustionGenerator) te;
 
     if(message.nbtRoot.hasKey("coolantTank")) {
       NBTTagCompound tankRoot = message.nbtRoot.getCompoundTag("coolantTank");
@@ -78,11 +79,12 @@ public class ClientUtil {
 
   public static void setStirlingBurnTime(PacketBurnTime message, int x, int y, int z) {
 
-    TileEntityStirlingGenerator tile = (TileEntityStirlingGenerator) Minecraft.getMinecraft().theWorld.getTileEntity(x, y, z);
-    if(tile == null) {
+    TileEntity te = Minecraft.getMinecraft().theWorld.getTileEntity(x, y, z);
+    if (!(te instanceof TileEntityStirlingGenerator)) {
       //no loaded on client when receiving message, can happen when loading the chunks 
       return;
     }
+    TileEntityStirlingGenerator tile = (TileEntityStirlingGenerator) te;
 
     tile.burnTime = message.burnTime;
     tile.totalBurnTime = message.totalBurnTime;


### PR DESCRIPTION
This builds upon #2834, which eliminates so many getTileEntity() calls. (Either pull only this or the other one first, in which case I'll rebase this one.)

Once https://github.com/SleepyTrousers/EnderCore/pull/17 is in Ender IO's required EnderCore, I'll do the calls that have a IBlockAccess.
