### PR TITLE
OreDict modern alloy names, too

### DIFF
--- a/src/main/java/crazypants/enderio/conduit/ConduitRecipes.java
+++ b/src/main/java/crazypants/enderio/conduit/ConduitRecipes.java
@@ -35,12 +35,12 @@ public class ConduitRecipes {
     ItemStack fusedQuartz = new ItemStack(EnderIO.blockFusedQuartz, 1, 0);
     ItemStack fusedGlass = new ItemStack(EnderIO.blockFusedQuartz, 1, BlockFusedQuartz.Type.GLASS.ordinal());
 
-    String electricalSteel = ELECTRICAL_STEEL.oreIngot;
-    String phasedGold = PHASED_GOLD.oreIngot;
-    String conductiveIron = CONDUCTIVE_IRON.oreIngot;
-    String energeticGold = ENERGETIC_ALLOY.oreIngot;
+    String electricalSteel = ELECTRICAL_STEEL.getOreIngot();
+    String phasedGold = PHASED_GOLD.getOreIngot();
+    String conductiveIron = CONDUCTIVE_IRON.getOreIngot();
+    String energeticGold = ENERGETIC_ALLOY.getOreIngot();
     String phasedIronNugget = PHASED_IRON_NUGGET.oreDict;
-    String redstoneAlloy = REDSTONE_ALLOY.oreIngot;
+    String redstoneAlloy = REDSTONE_ALLOY.getOreIngot();
 
     String binder = CONDUIT_BINDER.oreDict;
 

--- a/src/main/java/crazypants/enderio/enderface/EnderfaceRecipes.java
+++ b/src/main/java/crazypants/enderio/enderface/EnderfaceRecipes.java
@@ -11,7 +11,7 @@ public class EnderfaceRecipes {
   public static void addRecipes() {
 
     ItemStack fusedQuartz = new ItemStack(EnderIO.blockFusedQuartz, 1, 0);
-    String electricalSteel = Alloy.ELECTRICAL_STEEL.oreIngot;
+    String electricalSteel = Alloy.ELECTRICAL_STEEL.getOreIngot();
     RecipeUtil.addShaped(new ItemStack(EnderIO.blockEnderIo), "sqs", "qeq", "sqs", 's', electricalSteel, 'q', fusedQuartz, 'e', new ItemStack(Items.ender_eye));
   }
 

--- a/src/main/java/crazypants/enderio/item/ItemRecipes.java
+++ b/src/main/java/crazypants/enderio/item/ItemRecipes.java
@@ -17,12 +17,12 @@ public class ItemRecipes {
 
   public static void addRecipes() {
     ItemStack basicGear = new ItemStack(EnderIO.itemMachinePart, 1, MachinePart.BASIC_GEAR.ordinal());
-    String electricalSteel = ELECTRICAL_STEEL.oreIngot;
-    String conductiveIron = CONDUCTIVE_IRON.oreIngot;
+    String electricalSteel = ELECTRICAL_STEEL.getOreIngot();
+    String conductiveIron = CONDUCTIVE_IRON.getOreIngot();
     String vibCry = VIBRANT_CYSTAL.oreDict;
-    String enAlloy = ENERGETIC_ALLOY.oreIngot;
-    String darkSteel = DARK_STEEL.oreIngot;
-    String soularium = SOULARIUM.oreIngot;
+    String enAlloy = ENERGETIC_ALLOY.getOreIngot();
+    String darkSteel = DARK_STEEL.getOreIngot();
+    String soularium = SOULARIUM.getOreIngot();
 
     // Wrench
     ItemStack wrench = new ItemStack(EnderIO.itemYetaWench, 1, 0);

--- a/src/main/java/crazypants/enderio/item/darksteel/DarkSteelRecipeManager.java
+++ b/src/main/java/crazypants/enderio/item/darksteel/DarkSteelRecipeManager.java
@@ -79,7 +79,7 @@ public class DarkSteelRecipeManager {
       return;
     }
 
-    if(evt.left.getItem() instanceof IDarkSteelItem && OreDictionaryHelper.hasName(evt.right, Alloy.DARK_STEEL.oreIngot)) {
+    if(evt.left.getItem() instanceof IDarkSteelItem && OreDictionaryHelper.hasName(evt.right, Alloy.DARK_STEEL.getOreIngot())) {
       handleRepair(evt);
     } else {    
       handleUpgrade(evt);

--- a/src/main/java/crazypants/enderio/machine/MachineRecipes.java
+++ b/src/main/java/crazypants/enderio/machine/MachineRecipes.java
@@ -42,12 +42,12 @@ public class MachineRecipes {
     ItemStack sentientEnder = new ItemStack(EnderIO.itemFrankenSkull, 1, FrankenSkull.SENTIENT_ENDER.ordinal());
     ItemStack obsidian = new ItemStack(Blocks.obsidian);
 
-    String electricalSteel = ELECTRICAL_STEEL.oreIngot;
-    String darkSteel = DARK_STEEL.oreIngot;
-    String energeticAlloy = ENERGETIC_ALLOY.oreIngot;
-    String phasedGold = PHASED_GOLD.oreIngot;
-    String phasedIron = PHASED_IRON.oreIngot;
-    String soularium = SOULARIUM.oreIngot;
+    String electricalSteel = ELECTRICAL_STEEL.getOreIngot();
+    String darkSteel = DARK_STEEL.getOreIngot();
+    String energeticAlloy = ENERGETIC_ALLOY.getOreIngot();
+    String phasedGold = PHASED_GOLD.getOreIngot();
+    String phasedIron = PHASED_IRON.getOreIngot();
+    String soularium = SOULARIUM.getOreIngot();
 
     String vibCry = VIBRANT_CYSTAL.oreDict;
     String pulCry = PULSATING_CYSTAL.oreDict;

--- a/src/main/java/crazypants/enderio/material/Alloy.java
+++ b/src/main/java/crazypants/enderio/material/Alloy.java
@@ -1,5 +1,8 @@
 package crazypants.enderio.material;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import net.minecraft.item.ItemStack;
 
 import org.apache.commons.lang3.StringUtils;
@@ -10,25 +13,33 @@ public enum Alloy {
 
   ELECTRICAL_STEEL("electricalSteel", 6.0f),
   ENERGETIC_ALLOY("energeticAlloy", 7.0f),
-  PHASED_GOLD("phasedGold", 4.0f),
+  PHASED_GOLD("phasedGold", 4.0f, "vibrantAlloy"),
   REDSTONE_ALLOY("redstoneAlloy", 1.0f),
   CONDUCTIVE_IRON("conductiveIron", 5.2f),
-  PHASED_IRON("phasedIron", 7.0f),
+  PHASED_IRON("phasedIron", 7.0f, "pulsatingIron"),
   DARK_STEEL("darkSteel", 10.0f),
   SOULARIUM("soularium", 10.0f);
 
   public final String unlocalisedName;
   public final String iconKey;
-  public final String oreIngot;
-  public final String oreBlock;
+  private final List<String> oreIngots = new ArrayList<String>();
+  private final List<String> oreBlocks = new ArrayList<String>();
   private final float hardness;
 
-  private Alloy(String baseName, float hardness) {
+  private Alloy(String baseName, float hardness, String oreDictName) {
     this.unlocalisedName = "enderio." + baseName;
     this.iconKey = "enderio:" + baseName;
-    this.oreIngot = "ingot" + StringUtils.capitalize(baseName);
-    this.oreBlock = "block" + StringUtils.capitalize(baseName);
+    if(oreDictName != null) {
+      this.oreIngots.add("ingot" + StringUtils.capitalize(oreDictName));
+      this.oreBlocks.add("block" + StringUtils.capitalize(oreDictName));
+    }
+    this.oreIngots.add("ingot" + StringUtils.capitalize(baseName));
+    this.oreBlocks.add("block" + StringUtils.capitalize(baseName));
     this.hardness = hardness;
+  }
+
+  private Alloy(String baseName, float hardness) {
+    this(baseName, hardness, null);
   }
 
   public float getHardness() {
@@ -49,5 +60,21 @@ public enum Alloy {
 
   public ItemStack getStackBlock(int size) {
     return new ItemStack(EnderIO.blockIngotStorage, size, ordinal());
+  }
+
+  public String getOreIngot() {
+    return oreIngots.get(0);
+  }
+
+  public String getOreBlock() {
+    return oreBlocks.get(0);
+  }
+
+  public List<String> getOreIngots() {
+    return oreIngots;
+  }
+
+  public List<String> getOreBlocks() {
+    return oreBlocks;
   }
 }

--- a/src/main/java/crazypants/enderio/material/MaterialRecipes.java
+++ b/src/main/java/crazypants/enderio/material/MaterialRecipes.java
@@ -24,29 +24,23 @@ import static crazypants.util.RecipeUtil.*;
 public class MaterialRecipes {
 
   public static void registerDependantOresInDictionary() {
-    if (hasCopper()) {
-      OreDictionary.registerOre("dustCopper", new ItemStack(EnderIO.itemPowderIngot, 1, PowderIngot.POWDER_COPPER.ordinal()));
-    }
-    if (hasTin()) {
-      OreDictionary.registerOre("dustTin", new ItemStack(EnderIO.itemPowderIngot, 1, PowderIngot.POWDER_TIN.ordinal()));
-    }
-    if (PowderIngot.POWDER_ENDER.isDependancyMet()) {
-      OreDictionary.registerOre("dustEnderPearl", new ItemStack(EnderIO.itemPowderIngot, 1, PowderIngot.POWDER_ENDER.ordinal()));
-      PowderIngot.POWDER_ENDER.ignoreRuntimeDependencyCheck = true;
-      // because the line above would trigger it
-    }
-    //Enderium Base
-    if (OreDictionaryHelper.hasEnderium()) {
-      OreDictionary.registerOre("ingotEnderiumBase", new ItemStack(EnderIO.itemPowderIngot, 1, PowderIngot.INGOT_ENDERIUM_BASE.ordinal()));
+    // late registration for powders that only exist if the ingot from another
+    // mod exists
+    for (PowderIngot powder : PowderIngot.values()) {
+      if (powder.hasDependancy() && powder.isDependancyMet()) {
+        OreDictionary.registerOre(powder.oreDictName, new ItemStack(EnderIO.itemPowderIngot, 1, powder.ordinal()));
+        powder.setRegistered();
+      }
     }
   }
 
   public static void registerOresInDictionary() {
     //Ore Dictionary Registration
-    OreDictionary.registerOre("dustCoal", new ItemStack(EnderIO.itemPowderIngot, 1, PowderIngot.POWDER_COAL.ordinal()));
-    OreDictionary.registerOre("dustIron", new ItemStack(EnderIO.itemPowderIngot, 1, PowderIngot.POWDER_IRON.ordinal()));
-    OreDictionary.registerOre("dustGold", new ItemStack(EnderIO.itemPowderIngot, 1, PowderIngot.POWDER_GOLD.ordinal()));
-    OreDictionary.registerOre("dustObsidian", new ItemStack(EnderIO.itemPowderIngot, 1, PowderIngot.POWDER_OBSIDIAN.ordinal()));
+    for (PowderIngot powder : PowderIngot.values()) {
+      if (!powder.hasDependancy()) {
+        OreDictionary.registerOre(powder.oreDictName, new ItemStack(EnderIO.itemPowderIngot, 1, powder.ordinal()));
+      }
+    }
     
     for (Alloy alloy : Alloy.values()) {
       boolean isPrimaryName = true;

--- a/src/main/java/crazypants/enderio/material/MaterialRecipes.java
+++ b/src/main/java/crazypants/enderio/material/MaterialRecipes.java
@@ -49,8 +49,27 @@ public class MaterialRecipes {
     OreDictionary.registerOre("dustObsidian", new ItemStack(EnderIO.itemPowderIngot, 1, PowderIngot.POWDER_OBSIDIAN.ordinal()));
     
     for (Alloy alloy : Alloy.values()) {
-      OreDictionary.registerOre(alloy.oreIngot, new ItemStack(EnderIO.itemAlloy, 1, alloy.ordinal()));
-      OreDictionary.registerOre(alloy.oreBlock, new ItemStack(EnderIO.blockIngotStorage, 1, alloy.ordinal()));
+      boolean isPrimaryName = true;
+      for (String oreDictName : alloy.getOreIngots()) {
+        OreDictionary.registerOre(oreDictName, alloy.getStackIngot());
+        if (isPrimaryName) {
+          isPrimaryName = false;
+        } else {
+          // Allow free conversion of additional/legacy oreDict name items into
+          // our item because we only register recipes for the primary oreDict
+          // name. Use a 2-to-2 recipe because the 1-to-n is already in use.
+          addShapeless(alloy.getStackIngot(2), oreDictName, oreDictName);
+        }
+      }
+      isPrimaryName = true;
+      for (String oreDictName : alloy.getOreBlocks()) {
+        OreDictionary.registerOre(oreDictName, alloy.getStackBlock());
+        if (isPrimaryName) {
+          isPrimaryName = false;
+        } else {
+          addShapeless(alloy.getStackBlock(2), oreDictName, oreDictName);
+        }
+      }
     }
 
     OreDictionary.registerOre("nuggetPulsatingIron", new ItemStack(EnderIO.itemMaterial, 1, Material.PHASED_IRON_NUGGET.ordinal()));
@@ -89,10 +108,10 @@ public class MaterialRecipes {
 
     ItemStack fusedQuartzFrame = new ItemStack(EnderIO.itemFusedQuartzFrame, 1, 0);
 
-    String energeticAlloy = ENERGETIC_ALLOY.oreIngot;
-    String phasedGold = PHASED_GOLD.oreIngot;
-    String phasedIron = PHASED_IRON.oreIngot;
-    String darkSteel = DARK_STEEL.oreIngot;
+    String energeticAlloy = ENERGETIC_ALLOY.getOreIngot();
+    String phasedGold = PHASED_GOLD.getOreIngot();
+    String phasedIron = PHASED_IRON.getOreIngot();
+    String darkSteel = DARK_STEEL.getOreIngot();
 
     ItemStack capacitor = new ItemStack(itemBasicCapacitor, 1, 0);
 
@@ -181,18 +200,18 @@ public class MaterialRecipes {
       ItemStack reinfObs = new ItemStack(EnderIO.blockReinforcedObsidian);
       String corners = darkSteel;
       if (Config.reinforcedObsidianUseDarkSteelBlocks) {
-        corners = Alloy.DARK_STEEL.oreBlock;
+        corners = Alloy.DARK_STEEL.getOreBlock();
       }
       addShaped(reinfObs, "dbd", "bob", "dbd", 'd', corners, 'b', EnderIO.blockDarkIronBars, 'o', Blocks.obsidian);
     }
 
-    addShaped(EnderIO.blockDarkSteelAnvil, "bbb", " i ", "iii", 'b', DARK_STEEL.oreBlock, 'i', darkSteel);
+    addShaped(EnderIO.blockDarkSteelAnvil, "bbb", " i ", "iii", 'b', DARK_STEEL.getOreBlock(), 'i', darkSteel);
 
     addShaped(new ItemStack(EnderIO.blockDarkSteelLadder, 12), "b", "b", "b", 'b', EnderIO.blockDarkIronBars);
 
     for (Alloy alloy : Alloy.values()) {
-      addShaped(alloy.getStackBlock(), "iii", "iii", "iii", 'i', alloy.oreIngot);
-      addShapeless(alloy.getStackIngot(9), alloy.oreBlock);
+      addShaped(alloy.getStackBlock(), "iii", "iii", "iii", 'i', alloy.getOreIngot());
+      addShapeless(alloy.getStackIngot(9), alloy.getOreBlock());
     }
 
     //Food

--- a/src/main/java/crazypants/enderio/material/PowderIngot.java
+++ b/src/main/java/crazypants/enderio/material/PowderIngot.java
@@ -4,14 +4,14 @@ import static com.enderio.core.common.util.OreDictionaryHelper.*;
 
 public enum PowderIngot {
 
-  POWDER_COAL("powderCoal", null),
-  POWDER_IRON("powderIron", null),
-  POWDER_GOLD("powderGold", null),
-  POWDER_COPPER("powderCopper", INGOT_COPPER),
-  POWDER_TIN("powderTin", INGOT_TIN),
- POWDER_ENDER("powderEnder", DUST_ENDERPEARL, true),
-  INGOT_ENDERIUM_BASE("ingotEnderiumBase", INGOT_ENDERIUM),
-  POWDER_OBSIDIAN("powderObsidian", null),
+  POWDER_COAL("powderCoal", null, "dustCoal"), //
+  POWDER_IRON("powderIron", null, "dustIron"), //
+  POWDER_GOLD("powderGold", null, "dustGold"), //
+  POWDER_COPPER("powderCopper", INGOT_COPPER, "dustCopper"), //
+  POWDER_TIN("powderTin", INGOT_TIN, "dustTin"), //
+  POWDER_ENDER("powderEnder", DUST_ENDERPEARL, "dustEnderPearl", true), //
+  INGOT_ENDERIUM_BASE("ingotEnderiumBase", INGOT_ENDERIUM, "ingotEnderiumBase"), //
+  POWDER_OBSIDIAN("powderObsidian", null, "dustObsidian"), //
   FLOUR("dustWheat", null);
   // POWDER_LEAD("powderLead", "Lead Powder", "powderLead"),
   // POWDER_SILVER("powderSilver", "Silver Powder", "powderSilver"),
@@ -24,20 +24,30 @@ public enum PowderIngot {
   // INGOT_ELECTRUM("ingotElectrum", "Electrum Ingot", "ingotElectrum");
 
   public final String unlocalisedName;
+  public final String oreDictName;
   public final String iconKey;
   public final String oreDictDependancy;
   public final boolean reverseDependency;
   public boolean ignoreRuntimeDependencyCheck = false;
 
-  private PowderIngot(String unlocalisedName, String oreDictDependancy, boolean reverseDependency) {
+  private PowderIngot(String unlocalisedName, String oreDictDependancy, String oreDictName, boolean reverseDependency) {
     this.unlocalisedName = "enderio." + unlocalisedName;
     iconKey = "enderio:" + unlocalisedName;
+    this.oreDictName = oreDictName;
     this.oreDictDependancy = oreDictDependancy;
     this.reverseDependency = reverseDependency;
   }
 
+  private PowderIngot(String unlocalisedName, String oreDictDependancy, boolean reverseDependency) {
+    this(unlocalisedName, oreDictDependancy, unlocalisedName, reverseDependency);
+  }
+
+  private PowderIngot(String unlocalisedName, String oreDictDependancy, String oreDictName) {
+    this(unlocalisedName, oreDictDependancy, oreDictName, false);
+  }
+
   private PowderIngot(String unlocalisedName, String oreDictDependancy) {
-    this(unlocalisedName, oreDictDependancy, false);
+    this(unlocalisedName, oreDictDependancy, unlocalisedName, false);
   }
 
   public boolean isDependancyMet() {
@@ -47,4 +57,11 @@ public enum PowderIngot {
     return isRegistered(oreDictDependancy) == !reverseDependency;
   }
 
+  public boolean hasDependancy() {
+    return oreDictDependancy == null;
+  }
+
+  public void setRegistered() {
+    ignoreRuntimeDependencyCheck = true;
+  }
 }

--- a/src/main/java/crazypants/enderio/thaumcraft/ThaumcraftCompat.java
+++ b/src/main/java/crazypants/enderio/thaumcraft/ThaumcraftCompat.java
@@ -36,38 +36,38 @@ public class ThaumcraftCompat {
     ThaumcraftApi.registerObjectTag("dustCoal", new AspectList().add(getAspects(Items.coal)));
     ThaumcraftApi.registerObjectTag("itemSilicon", new AspectList().add(Aspect.FIRE, 1).add(Aspect.ORDER, 1).add(Aspect.SENSES, 1));
 
-    ThaumcraftApi.registerObjectTag(Alloy.ELECTRICAL_STEEL.oreIngot, new AspectList()
+    ThaumcraftApi.registerObjectTag(Alloy.ELECTRICAL_STEEL.getOreIngot(), new AspectList()
         .add(getAspects("dustCoal"))
         .add(getAspects(Items.iron_ingot))
         .add(getAspects("itemSilicon")));
 
-    ThaumcraftApi.registerObjectTag(Alloy.ENERGETIC_ALLOY.oreIngot, new AspectList()
+    ThaumcraftApi.registerObjectTag(Alloy.ENERGETIC_ALLOY.getOreIngot(), new AspectList()
         .add(getAspects(Items.glowstone_dust))
         .add(getAspects(Items.redstone))
         .add(getAspects(Items.gold_ingot)));
 
-    ThaumcraftApi.registerObjectTag(Alloy.PHASED_GOLD.oreIngot, new AspectList()
+    ThaumcraftApi.registerObjectTag(Alloy.PHASED_GOLD.getOreIngot(), new AspectList()
         .add(getAspects(Items.ender_pearl))
         .add(getAspects("ingotEnergeticAlloy")));
 
-    ThaumcraftApi.registerObjectTag(Alloy.REDSTONE_ALLOY.oreIngot, new AspectList()
+    ThaumcraftApi.registerObjectTag(Alloy.REDSTONE_ALLOY.getOreIngot(), new AspectList()
         .add(getAspects(Items.redstone))
         .add(getAspects("itemSilicon")));
 
-    ThaumcraftApi.registerObjectTag(Alloy.CONDUCTIVE_IRON.oreIngot, new AspectList()
+    ThaumcraftApi.registerObjectTag(Alloy.CONDUCTIVE_IRON.getOreIngot(), new AspectList()
         .add(getAspects(Items.redstone))
         .add(getAspects(Items.iron_ingot)));
 
-    ThaumcraftApi.registerObjectTag(Alloy.PHASED_IRON.oreIngot, new AspectList()
+    ThaumcraftApi.registerObjectTag(Alloy.PHASED_IRON.getOreIngot(), new AspectList()
         .add(getAspects(Items.ender_pearl))
         .add(getAspects(Items.iron_ingot)));
 
-    ThaumcraftApi.registerObjectTag(Alloy.DARK_STEEL.oreIngot, new AspectList()
+    ThaumcraftApi.registerObjectTag(Alloy.DARK_STEEL.getOreIngot(), new AspectList()
         .add(getAspects(Items.iron_ingot))
         .add(getAspects("dustCoal"))
         .add(getAspects(Blocks.obsidian)));
 
-    ThaumcraftApi.registerObjectTag(Alloy.SOULARIUM.oreIngot, new AspectList()
+    ThaumcraftApi.registerObjectTag(Alloy.SOULARIUM.getOreIngot(), new AspectList()
         .add(getAspects(Blocks.soul_sand))
         .add(getAspects(Items.gold_ingot)));
 
@@ -80,19 +80,19 @@ public class ThaumcraftCompat {
         .add(getAspects(EnderIO.blockEndermanSkull))
         .add(getAspects(Items.potionitem)).add(getAspects(Items.potionitem))
         .add(getAspects(new ItemStack(EnderIO.itemBasicCapacitor, 1, Capacitors.BASIC_CAPACITOR.ordinal())))
-        .add(getAspects(Alloy.SOULARIUM.oreIngot)).add(getAspects(Alloy.SOULARIUM.oreIngot)));
+        .add(getAspects(Alloy.SOULARIUM.getOreIngot())).add(getAspects(Alloy.SOULARIUM.getOreIngot())));
 
     ThaumcraftApi.registerObjectTag(new ItemStack(EnderIO.itemFrankenSkull, 1, FrankenSkull.ZOMBIE_ELECTRODE.ordinal()), new AspectList()
         .add(getAspects(new ItemStack(Items.skull, 1, 2)))
         .add(getAspects("itemSilicon")).add(getAspects("itemSilicon"))
         .add(getAspects(new ItemStack(EnderIO.itemBasicCapacitor, 1, Capacitors.BASIC_CAPACITOR.ordinal())))
-        .add(getAspects(Alloy.ENERGETIC_ALLOY.oreIngot)).add(getAspects(Alloy.ENERGETIC_ALLOY.oreIngot)));
+        .add(getAspects(Alloy.ENERGETIC_ALLOY.getOreIngot())).add(getAspects(Alloy.ENERGETIC_ALLOY.getOreIngot())));
 
     ThaumcraftApi.registerObjectTag(new ItemStack(EnderIO.itemFrankenSkull, 1, FrankenSkull.ZOMBIE_CONTROLLER.ordinal()), new AspectList()
         .add(getAspects(new ItemStack(Items.skull, 1, 2)))
         .add(getAspects("itemSilicon")).add(getAspects("itemSilicon"))
         .add(getAspects(new ItemStack(EnderIO.itemBasicCapacitor, 1, Capacitors.BASIC_CAPACITOR.ordinal())))
-        .add(getAspects(Alloy.SOULARIUM.oreIngot)).add(getAspects(Alloy.SOULARIUM.oreIngot)));
+        .add(getAspects(Alloy.SOULARIUM.getOreIngot())).add(getAspects(Alloy.SOULARIUM.getOreIngot())));
 
     ThaumcraftApi.registerObjectTag(new ItemStack(EnderIO.itemFrankenSkull, 1, FrankenSkull.FRANKEN_ZOMBIE.ordinal()), new AspectList()
         .add(Aspect.UNDEAD, 2)
@@ -103,8 +103,8 @@ public class ThaumcraftCompat {
     ThaumcraftApi.registerObjectTag(new ItemStack(EnderIO.itemFrankenSkull, 1, FrankenSkull.ENDER_RESONATOR.ordinal()), new AspectList()
         .add(getAspects(EnderIO.blockEndermanSkull))
         .add(getAspects("itemSilicon")).add(getAspects("itemSilicon"))
-        .add(getAspects(Alloy.PHASED_GOLD.oreIngot))
-        .add(getAspects(Alloy.SOULARIUM.oreIngot)).add(getAspects(Alloy.SOULARIUM.oreIngot)));
+        .add(getAspects(Alloy.PHASED_GOLD.getOreIngot()))
+        .add(getAspects(Alloy.SOULARIUM.getOreIngot())).add(getAspects(Alloy.SOULARIUM.getOreIngot())));
 
     ThaumcraftApi.registerObjectTag(new ItemStack(EnderIO.itemMaterial, 1, Material.ENDER_CRYSTAL.ordinal()), new AspectList()
         .add(Aspect.AIR, 2)


### PR DESCRIPTION
* re #2839
* Legacy oreDict names are still registered
* Recipes only use the primary/new oreDict name
* Conversion recipes for items with the legacy oreDict names into EIO items (that can be used in recipes) are registered, too

* re #2945
* powders are auto-registered so it doesn't get missed when a new power is added (like it happened with flour)