### PR TITLE
Fall back to a sensible facing direction

### DIFF
--- a/src/main/java/crazypants/enderio/machine/AbstractMachineBlock.java
+++ b/src/main/java/crazypants/enderio/machine/AbstractMachineBlock.java
@@ -159,7 +159,7 @@ public abstract class AbstractMachineBlock<T extends AbstractMachineEntity> exte
 
     // used to render the block in the world
     TileEntity te = world.getTileEntity(x, y, z);
-    int facing = 0;
+    int facing = 3;
     if(te instanceof AbstractMachineEntity) {
       AbstractMachineEntity me = (AbstractMachineEntity) te;
       facing = me.facing;


### PR DESCRIPTION
Fall back to a sensible facing direction when there is no tileEntity.
This e.g. happens when a facade is painted as machine. Facing down won't
really render nicely---down is not a valid rotation for machines.

* re #2902 (partially)