### PR TITLE
Fix for obelisk renderer

### DIFF
--- a/src/main/java/crazypants/enderio/machine/obelisk/ObeliskRenderer.java
+++ b/src/main/java/crazypants/enderio/machine/obelisk/ObeliskRenderer.java
@@ -85,6 +85,7 @@ public class ObeliskRenderer implements ISimpleBlockRenderingHandler {
     if (icons == null) {
       CubeRenderer.render(bb, icon, xform2, true);
     } else {
+      icons[1] = IconUtil.blankTexture;
       CubeRenderer.render(bb, icons, xform2, true);
     }
 


### PR DESCRIPTION
Having two identical top faces renders with a strange wobble because the
positions are not 100.000% identical. So only render one top face.