### PR TITLE
Fix render pass mixup

### DIFF
--- a/src/main/java/crazypants/enderio/conduit/render/ConduitBundleRenderer.java
+++ b/src/main/java/crazypants/enderio/conduit/render/ConduitBundleRenderer.java
@@ -50,6 +50,7 @@ import crazypants.enderio.conduit.geom.CollidableComponent;
 import crazypants.enderio.conduit.geom.ConduitConnectorType;
 import crazypants.enderio.conduit.geom.ConduitGeometryUtil;
 import crazypants.enderio.config.Config;
+import crazypants.util.RenderPassHelper;
 
 @SideOnly(Side.CLIENT)
 public class ConduitBundleRenderer extends TileEntitySpecialRenderer implements ISimpleBlockRenderingHandler {
@@ -108,14 +109,15 @@ public class ConduitBundleRenderer extends TileEntitySpecialRenderer implements 
   @Override
   public boolean renderWorldBlock(IBlockAccess world, int x, int y, int z, Block block, int modelId, RenderBlocks rb) {
 
-    //If the MC renderer is told that an alpha pass is required ( see BlockConduitBundle.getRenderBlockPass() ) put
-    //nothing is actually added to the tessellator in this pass then the renderer will crash. We cant selectively
-    //enable the alpha pass based on state so the only work around is to ensure we always render something in this
-    //pass. Throwing in a polygon with a 0 area does the job
-    //See: https://github.com/MinecraftForge/MinecraftForge/issues/981
-    int pass = MinecraftForgeClient.getRenderPass();
-    pass = pass >= 0 ? pass : ForgeHooksClient.getWorldRenderPass();
+    int pass = RenderPassHelper.getBlockRenderPass();
     if(pass == 1) {
+      // If the MC renderer is told that an alpha pass is required ( see
+      // BlockConduitBundle.getRenderBlockPass() ) put nothing is actually added
+      // to the tessellator in this pass then the renderer will crash. We can't
+      // selectively enable the alpha pass based on state so the only work
+      // around is to ensure we always render something in this pass. Throwing
+      // in a polygon with a 0 area does the job
+      // See: https://github.com/MinecraftForge/MinecraftForge/issues/981
       Tessellator.instance.addVertexWithUV(x, y, z, 0, 0);
       Tessellator.instance.addVertexWithUV(x, y, z, 0, 0);
       Tessellator.instance.addVertexWithUV(x, y, z, 0, 0);

--- a/src/main/java/crazypants/enderio/enderface/GuiEnderface.java
+++ b/src/main/java/crazypants/enderio/enderface/GuiEnderface.java
@@ -40,6 +40,7 @@ import crazypants.enderio.conduit.BlockConduitBundle;
 import crazypants.enderio.config.Config;
 import crazypants.enderio.network.PacketHandler;
 import crazypants.enderio.teleport.TravelController;
+import crazypants.util.RenderPassHelper;
 
 public class GuiEnderface extends GuiScreen {
 
@@ -272,7 +273,7 @@ public class GuiEnderface extends GuiScreen {
         Vector3d trans = new Vector3d((-origin.x) + eye.x, (-origin.y) + eye.y, (-origin.z) + eye.z);
         for (int pass = 0; pass < 2; pass++) {
 
-          ForgeHooksClient.setRenderPass(pass);
+          RenderPassHelper.setBlockRenderPass(pass);
           setGlStateForPass(pass);
 
           Tessellator.instance.startDrawingQuads();
@@ -286,6 +287,7 @@ public class GuiEnderface extends GuiScreen {
           }
           Tessellator.instance.draw();
           Tessellator.instance.setTranslation(0, 0, 0);
+          RenderPassHelper.clearBlockRenderPass();
         }
 
         RenderHelper.enableStandardItemLighting();
@@ -300,7 +302,7 @@ public class GuiEnderface extends GuiScreen {
 
         for (int pass = 0; pass < 2; pass++) {
 
-          ForgeHooksClient.setRenderPass(pass);
+          RenderPassHelper.setEntityRenderPass(pass);
           setGlStateForPass(pass);
 
           for (ViewableBlocks ug : blocks) {
@@ -310,11 +312,13 @@ public class GuiEnderface extends GuiScreen {
               at.x += ug.bc.x - ioX;
               at.y += ug.bc.y - ioY;
               at.z += ug.bc.z - ioZ;
+              GL11.glPushAttrib(GL11.GL_ALL_ATTRIB_BITS);
               TileEntityRendererDispatcher.instance.renderTileEntityAt(tile, at.x, at.y, at.z, 0);
+              GL11.glPopAttrib();
             }
           }
+          RenderPassHelper.clearEntityRenderPass();
         }
-        ForgeHooksClient.setRenderPass(-1);
         setGlStateForPass(0);
         TravelController.instance.setSelectionEnabled(true);
 

--- a/src/main/java/crazypants/enderio/gui/IoConfigRenderer.java
+++ b/src/main/java/crazypants/enderio/gui/IoConfigRenderer.java
@@ -49,6 +49,7 @@ import crazypants.enderio.machine.IoMode;
 import crazypants.enderio.machine.PacketIoMode;
 import crazypants.enderio.network.PacketHandler;
 import crazypants.enderio.teleport.TravelController;
+import crazypants.util.RenderPassHelper;
 
 public class IoConfigRenderer {
 
@@ -372,12 +373,11 @@ public class IoConfigRenderer {
         doTileEntityRenderPass(neighbours, pass);
       }
     }
-    ForgeHooksClient.setRenderPass(-1);
     setGlStateForPass(0, false);
   }
 
   private void doTileEntityRenderPass(List<BlockCoord> blocks, int pass) {
-    ForgeHooksClient.setRenderPass(pass);
+    RenderPassHelper.setEntityRenderPass(pass);
     for (BlockCoord bc : blocks) {
       TileEntity tile = world.getTileEntity(bc.x, bc.y, bc.z);
       if(tile != null) {
@@ -385,13 +385,16 @@ public class IoConfigRenderer {
         at.x += bc.x - origin.x;
         at.y += bc.y - origin.y;
         at.z += bc.z - origin.z;
+        GL11.glPushAttrib(GL11.GL_ALL_ATTRIB_BITS);
         TileEntityRendererDispatcher.instance.renderTileEntityAt(tile, at.x, at.y, at.z, 0);
+        GL11.glPopAttrib();
       }
     }
+    RenderPassHelper.clearEntityRenderPass();
   }
 
   private void doWorldRenderPass(Vector3d trans, List<BlockCoord> blocks, int pass) {
-    ForgeHooksClient.setRenderPass(pass);
+    RenderPassHelper.setBlockRenderPass(pass);
 
     Tessellator.instance.startDrawingQuads();
     Tessellator.instance.setTranslation(trans.x, trans.y, trans.z);
@@ -416,6 +419,7 @@ public class IoConfigRenderer {
 
     Tessellator.instance.draw();
     Tessellator.instance.setTranslation(0, 0, 0);
+    RenderPassHelper.clearBlockRenderPass();
   }
 
   private void setGlStateForPass(int pass, boolean isNeighbour) {

--- a/src/main/java/crazypants/enderio/machine/generator/zombie/ZombieGeneratorRenderer.java
+++ b/src/main/java/crazypants/enderio/machine/generator/zombie/ZombieGeneratorRenderer.java
@@ -23,6 +23,7 @@ import com.enderio.core.common.vecmath.Vector3d;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import crazypants.util.RenderPassHelper;
 
 @SideOnly(Side.CLIENT)
 public class ZombieGeneratorRenderer extends TileEntitySpecialRenderer implements IItemRenderer {
@@ -46,9 +47,9 @@ public class ZombieGeneratorRenderer extends TileEntitySpecialRenderer implement
 
     GL11.glPushMatrix();
     GL11.glTranslatef((float) x, (float) y, (float) z);
-    if(MinecraftForgeClient.getRenderPass() == 0) {
+    if (RenderPassHelper.getEntityRenderPass() == 0) {
       renderModel(gen.facing);
-    } else if(MinecraftForgeClient.getRenderPass() == 1) {
+    } else if (RenderPassHelper.getEntityRenderPass() == 1) {
       renderFluid(gen);
     }
     GL11.glPopMatrix();

--- a/src/main/java/crazypants/util/RenderPassHelper.java
+++ b/src/main/java/crazypants/util/RenderPassHelper.java
@@ -1,0 +1,82 @@
+package crazypants.util;
+
+import java.lang.reflect.Field;
+
+import net.minecraftforge.client.ForgeHooksClient;
+import net.minecraftforge.client.MinecraftForgeClient;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+import crazypants.enderio.Log;
+
+@SideOnly(Side.CLIENT)
+public class RenderPassHelper {
+
+  private static Field worldRenderPass = null;
+  private static int savedWorldRenderPass = -1;
+  private static int savedEntityRenderPass = -1;
+
+  static {
+    try {
+      worldRenderPass = ForgeHooksClient.class.getDeclaredField("worldRenderPass");
+      worldRenderPass.setAccessible(true);
+    } catch (Exception e) {
+      Log.warn("Failed to access ForgeHooksClient.worldRenderPass because of: " + e);
+      e.printStackTrace();
+    }
+  }
+
+  private RenderPassHelper() {
+  }
+
+  public static void setBlockRenderPass(int pass) {
+    savedWorldRenderPass = ForgeHooksClient.getWorldRenderPass();
+    savedEntityRenderPass = MinecraftForgeClient.getRenderPass();
+    setBlockRenderPassImpl(pass);
+    setEntityRenderPass(pass);
+  }
+
+  private static void setBlockRenderPassImpl(int pass) {
+    if (worldRenderPass != null) {
+      try {
+        worldRenderPass.setInt(null, pass);
+      } catch (Exception e) {
+        Log.warn("Failed to access ForgeHooksClient.worldRenderPass because of: " + e);
+        e.printStackTrace();
+        worldRenderPass = null;
+      }
+    }
+  }
+
+  public static void clearBlockRenderPass() {
+    setBlockRenderPassImpl(savedWorldRenderPass);
+    setEntityRenderPass(savedEntityRenderPass);
+  }
+
+  public static int getBlockRenderPass() {
+    int pass = ForgeHooksClient.getWorldRenderPass();
+    if (pass < 0) {
+      // We are outside Minecraft's block rendering, so most probably we are
+      // being rendered by some mod. But it forgot to set the current block
+      // render pass. Maybe it set the entity render pass instead?
+      pass = MinecraftForgeClient.getRenderPass();
+      if (pass < 0) {
+        // No, it didn't. That's not good. Let's assume pass 0, that one renders
+        // more stuff.
+        pass = 0;
+      }
+    }
+    return pass;
+  }
+
+  public static void setEntityRenderPass(int pass) {
+    ForgeHooksClient.setRenderPass(pass);
+  }
+
+  public static void clearEntityRenderPass() {
+    ForgeHooksClient.setRenderPass(-1);
+  }
+
+  public static int getEntityRenderPass() {
+    return MinecraftForgeClient.getRenderPass();
+  }
+}


### PR DESCRIPTION
Forge stores the current render pass for blocks and tile entities in different locations. As that is not documented, it is often mixed up.

re #2862