### PR TITLE
Added Additional Hooks to make it easier to add Custom Conduits

### DIFF
--- a/src/main/java/crazypants/enderio/conduit/AbstractItemConduit.java
+++ b/src/main/java/crazypants/enderio/conduit/AbstractItemConduit.java
@@ -32,22 +32,30 @@ import crazypants.enderio.ModObject;
 public abstract class AbstractItemConduit extends Item implements IConduitItem {
 
   protected ModObject modObj;
+  
+  protected String unlocalisedName;
 
   protected ItemConduitSubtype[] subtypes;
 
   protected IIcon[] icons;
 
+  protected AbstractItemConduit(String unlocalisedName, ItemConduitSubtype... subtypes) {
+	  this.unlocalisedName = unlocalisedName;
+	  this.subtypes = subtypes;
+	  setCreativeTab(EnderIOTab.tabEnderIO);
+	  setUnlocalizedName(this.unlocalisedName);
+	  setMaxStackSize(64);
+	  setHasSubtypes(true);
+  }
+  
+  
   protected AbstractItemConduit(ModObject modObj, ItemConduitSubtype... subtypes) {
+    this(modObj.unlocalisedName,subtypes);
     this.modObj = modObj;
-    this.subtypes = subtypes;
-    setCreativeTab(EnderIOTab.tabEnderIO);
-    setUnlocalizedName(modObj.unlocalisedName);
-    setMaxStackSize(64);
-    setHasSubtypes(true);
   }
 
   protected void init() {
-    GameRegistry.registerItem(this, modObj.unlocalisedName);
+    GameRegistry.registerItem(this, unlocalisedName);
   }
 
   @Override

--- a/src/main/java/crazypants/enderio/conduit/ConduitUtil.java
+++ b/src/main/java/crazypants/enderio/conduit/ConduitUtil.java
@@ -1,5 +1,7 @@
 package crazypants.enderio.conduit;
 
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -60,23 +62,51 @@ public class ConduitUtil {
   public static final Random RANDOM = new Random();
 
   public static AbstractConduitNetwork<?, ?> createNetworkForType(Class<? extends IConduit> type) {
-    if(IRedstoneConduit.class.isAssignableFrom(type)) {
-      return new RedstoneConduitNetwork();
-    } else if(IPowerConduit.class.isAssignableFrom(type)) {
-      return new PowerConduitNetwork();
-    } else if(EnderLiquidConduit.class.isAssignableFrom(type)) {
-      return new EnderLiquidConduitNetwork();
-    } else if(AdvancedLiquidConduit.class.isAssignableFrom(type)) {
-      return new AdvancedLiquidConduitNetwork();
-    } else if(ILiquidConduit.class.isAssignableFrom(type)) {
-      return new LiquidConduitNetwork();
-    } else if(IItemConduit.class.isAssignableFrom(type)) {
-      return new ItemConduitNetwork();
-    } else if(IGasConduit.class.isAssignableFrom(type)) {
-      return new GasConduitNetwork();
-    } else if(IMEConduit.class.isAssignableFrom(type)) {
-      return new MEConduitNetwork();
-    }
+ 
+	
+	Method m = null;
+	try {
+		m = type.getDeclaredMethod("getNetworkClass", (Class<?>[])null);
+	} catch (NoSuchMethodException e) {
+	} catch (SecurityException e) {
+	}
+	Object network = null; 
+	if (m != null)
+	{
+		try {
+			network = m.invoke(null, (Object[])null);
+		} catch (IllegalAccessException e) {
+		} catch (IllegalArgumentException e) {
+		} catch (InvocationTargetException e) {
+		}
+	}
+	if (network != null)
+	{
+		try {
+			return (AbstractConduitNetwork<?, ?>) ((Class) network).newInstance();
+		} catch (InstantiationException e) {
+			e.printStackTrace();
+		} catch (IllegalAccessException e) {
+			e.printStackTrace();
+		}
+	}
+	else if(IRedstoneConduit.class.isAssignableFrom(type)) {
+	  return new RedstoneConduitNetwork();
+	} else if(IPowerConduit.class.isAssignableFrom(type)) {
+	  return new PowerConduitNetwork();
+	} else if(EnderLiquidConduit.class.isAssignableFrom(type)) {
+	  return new EnderLiquidConduitNetwork();
+	} else if(AdvancedLiquidConduit.class.isAssignableFrom(type)) {
+	  return new AdvancedLiquidConduitNetwork();
+	} else if(ILiquidConduit.class.isAssignableFrom(type)) {
+	  return new LiquidConduitNetwork();
+	} else if(IItemConduit.class.isAssignableFrom(type)) {
+	  return new ItemConduitNetwork();
+	} else if(IGasConduit.class.isAssignableFrom(type)) {
+	  return new GasConduitNetwork();
+	} else if(IMEConduit.class.isAssignableFrom(type)) {
+	  return new MEConduitNetwork();
+	}
     FMLCommonHandler.instance().raiseException(new Exception("Could not determine network type for class " + type), "ConduitUtil.createNetworkForType", false);
     return null;
   }


### PR DESCRIPTION
Make a few modifications that would prevent crashes when trying to use a custom conduit class implementing IConduit with a custom network.

Also, made it easier to extend AbstractItemConduit for creating items for your Conduits.