### PR TITLE
Fix zero comparator signal on near-empty storage

### DIFF
--- a/src/main/java/crazypants/enderio/machine/capbank/TileCapBank.java
+++ b/src/main/java/crazypants/enderio/machine/capbank/TileCapBank.java
@@ -693,7 +693,8 @@ public class TileCapBank extends TileEntityEio implements IInternalPowerReceiver
   }
 
   public int getComparatorOutput() {
-    return (int) (((double) getEnergyStored() / (double) getMaxEnergyStored()) * 15);
+    double stored = getEnergyStored();
+    return stored == 0 ? 0 : (int) (1 + stored / getMaxEnergyStored() * 14);
   }
 
   @Override

--- a/src/main/java/crazypants/enderio/machine/power/TileCapacitorBank.java
+++ b/src/main/java/crazypants/enderio/machine/power/TileCapacitorBank.java
@@ -269,7 +269,8 @@ public class TileCapacitorBank extends TileEntityEio implements IInternalPowerHa
   }
   
   public int getComparatorOutput() {
-    return (int) (((double) getEnergyStored() / (double) getMaxEnergyStored()) * 15);
+    double stored = getEnergyStored();
+    return stored == 0 ? 0 : (int) (1 + stored / getMaxEnergyStored() * 14);
   }
 
   public List<GaugeBounds> getGaugeBounds() {

--- a/src/main/java/crazypants/enderio/machine/tank/TileTank.java
+++ b/src/main/java/crazypants/enderio/machine/tank/TileTank.java
@@ -297,7 +297,11 @@ public class TileTank extends AbstractMachineEntity implements IFluidHandler, IT
   
   public int getComparatorOutput() {
     FluidTankInfo info = getTankInfo(null)[0];
-    return info == null || info.fluid == null ? 0 : (int) (((double) info.fluid.amount / (double) info.capacity) * 15);
+    if (info == null || info.fluid == null) {
+      return 0;
+    }
+
+    return info.fluid.amount == 0 ? 0 : (int) (1 + ((double) info.fluid.amount / (double) info.capacity) * 14);
   }
 
   private boolean processItems(boolean redstoneCheckPassed) {


### PR DESCRIPTION
Comparators output a zero power level both when attached to empty storage, and nearly empty storage. This makes it impossible to differentiate between the two. The new semantics in this patch are equivalent to those used by Minecraft for chests, etc.

**Before:**
![comparator_old](https://cloud.githubusercontent.com/assets/434951/10926330/7686a398-8253-11e5-93b7-0d294657de1c.png)

**After:**
![comparator_new](https://cloud.githubusercontent.com/assets/434951/10926333/7abdf33a-8253-11e5-81de-5b4981a4c200.png)
