### PR TITLE
Ignore non-vanilla buckets firing FillBucketEvent events

### DIFF
--- a/src/main/java/crazypants/enderio/fluid/BucketHandler.java
+++ b/src/main/java/crazypants/enderio/fluid/BucketHandler.java
@@ -4,6 +4,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import net.minecraft.block.Block;
+import net.minecraft.init.Items;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.MovingObjectPosition;
@@ -32,10 +33,13 @@ public class BucketHandler {
 
   @SubscribeEvent
   public void onBucketFill(FillBucketEvent event) {
-    ItemStack res = getFilledBucket(event.world, event.target);
-    if(res != null) {
-      event.result = res;
-      event.setResult(Result.ALLOW);
+    // no instanceof check, someone may subclass the vanilla bucket
+    if (event.current != null && event.current.getItem() == Items.bucket && event.current.stackSize > 0) {
+      ItemStack res = getFilledBucket(event.world, event.target);
+      if (res != null) {
+        event.result = res;
+        event.setResult(Result.ALLOW);
+      }
     }
   }
 


### PR DESCRIPTION
They need to handle this event themselves. We only handle converting
vanilla buckets into Ender IO buckets.

re #2703