### PR TITLE
Don't replace an object that is in use elsewhere

### DIFF
--- a/src/main/java/crazypants/enderio/conduit/item/filter/ItemFilter.java
+++ b/src/main/java/crazypants/enderio/conduit/item/filter/ItemFilter.java
@@ -51,6 +51,19 @@ public class ItemFilter implements IInventory, IItemFilter {
 
   private boolean isAdvanced; 
 
+  public void copyFrom(ItemFilter o) {
+    isBlacklist = o.isBlacklist;
+    matchMeta = o.matchMeta;
+    matchNBT = o.matchNBT;
+    useOreDict = o.useOreDict;
+    sticky = o.sticky;
+    fuzzyMode = o.fuzzyMode;
+    items = o.items;
+    oreIds.clear();
+    oreIds.addAll(o.oreIds);
+    isAdvanced = o.isAdvanced;
+  }
+
   public ItemFilter() {
     this(5, false);
   }

--- a/src/main/java/crazypants/enderio/machine/transceiver/TileTransceiver.java
+++ b/src/main/java/crazypants/enderio/machine/transceiver/TileTransceiver.java
@@ -244,11 +244,11 @@ public class TileTransceiver extends AbstractPoweredTaskEntity implements IFluid
 
     if(nbtRoot.hasKey("sendItemFilter")) {
       NBTTagCompound itemRoot = nbtRoot.getCompoundTag("sendItemFilter");
-      sendItemFilter = (ItemFilter) FilterRegister.loadFilterFromNbt(itemRoot);
+      sendItemFilter.copyFrom((ItemFilter) FilterRegister.loadFilterFromNbt(itemRoot));
     }
     if(nbtRoot.hasKey("recieveItemFilter")) {
       NBTTagCompound itemRoot = nbtRoot.getCompoundTag("recieveItemFilter");
-      recieveItemFilter = (ItemFilter) FilterRegister.loadFilterFromNbt(itemRoot);
+      recieveItemFilter.copyFrom((ItemFilter) FilterRegister.loadFilterFromNbt(itemRoot));
     }
 
     if(nbtRoot.hasKey("bufferStacks")) {


### PR DESCRIPTION
The item filter is in use in the GUI. If it is replaced in the TE by the
server copy, the client will have 2 different copies of it.

re #2693