### PR TITLE
Improve handling of single-input recipes

### DIFF
--- a/resources/assets/enderio/config/AlloySmelterRecipes_Core.xml
+++ b/resources/assets/enderio/config/AlloySmelterRecipes_Core.xml
@@ -145,50 +145,12 @@
         <itemStack modID="EnderIO" itemName="blockFusedQuartz" itemMeta="0" exp="0.5" />
       </output>
     </recipe>
-    <recipe name="Fused Quartz 2 Slots" energyCost="10000" >
-      <input>
-        <itemStack modID="minecraft" itemName="quartz" number="4" />
-        <itemStack modID="minecraft" itemName="quartz" number="4" />
-      </input>
-      <output>
-        <itemStack modID="EnderIO" itemName="blockFusedQuartz" itemMeta="0" exp="0.5" number="2" />
-      </output>
-    </recipe>
-    <recipe name="Fused Quartz 3 Slots" energyCost="15000" >
-      <input>
-        <itemStack modID="minecraft" itemName="quartz" number="4" />
-        <itemStack modID="minecraft" itemName="quartz" number="4" />
-        <itemStack modID="minecraft" itemName="quartz" number="4" />
-      </input>
-      <output>
-        <itemStack modID="EnderIO" itemName="blockFusedQuartz" itemMeta="0" exp="0.5" number="3" />
-      </output>
-    </recipe>
     <recipe name="Fused Glass" energyCost="2500" >
       <input>
         <itemStack oreDictionary="sand" />
       </input>
       <output>
         <itemStack modID="EnderIO" itemName="blockFusedQuartz" itemMeta="1" exp="0.2" />
-      </output>
-    </recipe>
-    <recipe name="Fused Glass 2 Slots" energyCost="5000" >
-      <input>
-        <itemStack oreDictionary="sand" />
-        <itemStack oreDictionary="sand" />
-      </input>
-      <output>
-        <itemStack modID="EnderIO" itemName="blockFusedQuartz" itemMeta="1" exp="0.2" number="2" />
-      </output>
-    </recipe>
-    <recipe name="Fused Glass 3 Slots" energyCost="7500" >
-      <input>
-        <itemStack oreDictionary="sand" />
-        <itemStack oreDictionary="sand" />
-        <itemStack oreDictionary="sand" />
-      </input>
-      <output>
-        <itemStack modID="EnderIO" itemName="blockFusedQuartz" itemMeta="1" exp="0.2" number="3" />
       </output>
     </recipe>
     <recipe name="Enlightened Fused Quartz" energyCost="5000" >

--- a/src/main/java/crazypants/enderio/config/Config.java
+++ b/src/main/java/crazypants/enderio/config/Config.java
@@ -108,6 +108,7 @@ public final class Config {
   public static boolean useHardRecipes = false;
   public static boolean addPeacefulRecipes = false;
   public static boolean allowExternalTickSpeedup = true;
+  public static boolean crateSyntheticRecipes = true;
 
   public static boolean useSteelInChassi = false;
 
@@ -611,6 +612,13 @@ public final class Config {
         "The number of conduits crafted per recipe.").getInt(numConduitsPerRecipe);
     transceiverUseEasyRecipe= config.get(sectionRecipe.name, "transceiverUseEasyRecipe", transceiverUseEasyRecipe, "When enabled the dim trans. will use a cheaper recipe")
         .getBoolean(useHardRecipes);
+    crateSyntheticRecipes = config
+        .get(
+            sectionRecipe.name,
+            "crateSyntheticRecipes",
+            crateSyntheticRecipes,
+            "Automatically create alloy smelter recipes with double and tripple inputs and different slot allocations (1+1+1, 2+1, 1+2, 3 and 2) for single-input recipes.")
+        .getBoolean(crateSyntheticRecipes);
 
     allowExternalTickSpeedup = config.get(sectionMisc.name, "allowExternalTickSpeedup", allowExternalTickSpeedup,
         "Allows machines to run faster if another mod speeds up the tickrate. Running at higher tickrates is "

--- a/src/main/java/crazypants/enderio/machine/MachineRecipeRegistry.java
+++ b/src/main/java/crazypants/enderio/machine/MachineRecipeRegistry.java
@@ -3,6 +3,7 @@ package crazypants.enderio.machine;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -19,7 +20,7 @@ public class MachineRecipeRegistry {
   public Map<String, IMachineRecipe> getRecipesForMachine(String machineName) {
     Map<String, IMachineRecipe> res = machineRecipes.get(machineName);
     if(res == null) {
-      res = new HashMap<String, IMachineRecipe>();
+      res = new LinkedHashMap<String, IMachineRecipe>();
       machineRecipes.put(machineName, res);
     }
     return res;

--- a/src/main/java/crazypants/enderio/machine/recipe/OreDictionaryRecipeInput.java
+++ b/src/main/java/crazypants/enderio/machine/recipe/OreDictionaryRecipeInput.java
@@ -64,7 +64,8 @@ public class OreDictionaryRecipeInput extends RecipeInput {
 
   @Override
   public String toString() {
-    return "OreDictionaryRecipeInput [oreId=" + oreId + " name=" + OreDictionary.getOreName(oreId) + "]";
+    return "OreDictionaryRecipeInput [oreId=" + oreId + " name=" + OreDictionary.getOreName(oreId) + " amount="
+        + getInput().stackSize + "]";
   }
 
 }

--- a/src/main/java/crazypants/enderio/machine/recipe/RecipeConfig.java
+++ b/src/main/java/crazypants/enderio/machine/recipe/RecipeConfig.java
@@ -289,6 +289,8 @@ public class RecipeConfig {
 
     private String name;
 
+    private boolean invalidated = false;
+
     private RecipeElement(String name) {
       this.name = name;
     }
@@ -323,7 +325,7 @@ public class RecipeConfig {
     }
 
     public boolean isValid() {
-      return !inputs.isEmpty() && !outputs.isEmpty();
+      return !invalidated && !inputs.isEmpty() && !outputs.isEmpty();
     }
 
     public float getEnergyRequired() {
@@ -342,9 +344,14 @@ public class RecipeConfig {
       this.bonusType = bonusType;
     }
 
+    public void invalidate() {
+      invalidated = true;
+    }
+
     @Override
     public String toString() {
-      return "Recipe [input=" + inputs + ", outputs=" + outputs + ", energyRequired=" + energyRequired + ", bonusType=" + bonusType + "]";
+      return "Recipe [" + (invalidated ? "INVALID " : "") + "input=" + inputs + ", outputs=" + outputs + ", energyRequired="
+          + energyRequired + ", bonusType=" + bonusType + "]";
     }
 
   }

--- a/src/main/java/crazypants/enderio/machine/recipe/RecipeConfig.java
+++ b/src/main/java/crazypants/enderio/machine/recipe/RecipeConfig.java
@@ -11,6 +11,7 @@ import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -217,7 +218,7 @@ public class RecipeConfig {
 
     private final String name;
 
-    private Map<String, RecipeElement> recipes = new HashMap<String, RecipeElement>();
+    private Map<String, RecipeElement> recipes = new LinkedHashMap<String, RecipeElement>();
 
     private boolean enabled = true;
 

--- a/src/main/java/crazypants/enderio/machine/recipe/RecipeConfigParser.java
+++ b/src/main/java/crazypants/enderio/machine/recipe/RecipeConfigParser.java
@@ -342,6 +342,7 @@ public class RecipeConfigParser extends DefaultHandler {
   private void addInputStack(Attributes attributes) {
     RecipeInput stack = getItemStack(attributes);
     if(stack == null) {
+      recipe.invalidate();
       return;
     }
     recipe.addInput(stack);


### PR DESCRIPTION
* Single input alloy smelter recipes now will get multi-slot variants
added automatically
* There's a config flag to disable this
* Removed existing partila multi-slot recipes
* Fixed code that depends on the order of recipes in a HashMap
* Fixed code that depends on the order of machineRecipes in a HashMap

re #3026, #1070

Note: We still have a problem with recipes that need only a single item but more than 1 of it. So the 4xnetherQuartz one will fail on an input of "64/1/0". And if there is a vanilla recipe available for smelting netherQuartz, it will take over.

To fix this, we'd need to replace large parts of the recipe system.