### PR TITLE
Limit smelting XP the same way vanilla does (thx to mmelvin0)

### DIFF
--- a/src/main/java/crazypants/enderio/machine/alloy/VanillaSmeltingRecipe.java
+++ b/src/main/java/crazypants/enderio/machine/alloy/VanillaSmeltingRecipe.java
@@ -124,6 +124,10 @@ public class VanillaSmeltingRecipe implements IMachineRecipe {
       return 0;
     }
     float result = FurnaceRecipes.smelting().func_151398_b(output);
+    if (result > 1.0f) {
+      // see net.minecraft.inventory.SlotFurnace.onCrafting(ItemStack)
+      result = 1.0f;
+    }
     return result * output.stackSize;
   }
 


### PR DESCRIPTION
re #1530

Root cause: Some mods (e.g. Biomes of Plenty) register smelting recipes with invalid XP multipliers. Vanilla ignores them.