### PR TITLE
Made Stirling Generator more configurable

### DIFF
--- a/src/main/java/crazypants/enderio/config/Config.java
+++ b/src/main/java/crazypants/enderio/config/Config.java
@@ -271,6 +271,12 @@ public final class Config {
   public static int zombieGeneratorTicksPerBucketFuel = 10000;
 
   public static int stirlingGeneratorBaseRfPerTick = 20;
+  public static float stirlingGeneratorEnergyMultiplierT1 = 1f;
+  public static float stirlingGeneratorEnergyMultiplierT2 = 2f;
+  public static float stirlingGeneratorEnergyMultiplierT3 = 4f;
+  public static float stirlingGeneratorBurnTimeMultiplierT1 = 1f / 2f;
+  public static float stirlingGeneratorBurnTimeMultiplierT2 = 1f / 1.5f;
+  public static float stirlingGeneratorBurnTimeMultiplierT3 = 1f / 1.5f;
 
   public static boolean combustionGeneratorUseOpaqueModel = true;
 
@@ -1020,6 +1026,20 @@ public final class Config {
 
     stirlingGeneratorBaseRfPerTick = config.get(sectionPower.name, "stirlingGeneratorBaseRfPerTick", stirlingGeneratorBaseRfPerTick,
         "The amount of power generated per tick.").getInt(stirlingGeneratorBaseRfPerTick);
+
+    stirlingGeneratorEnergyMultiplierT1 = (float) config.get(sectionPower.name, "stirlingGeneratorEnergyMultiplierT1",
+        stirlingGeneratorEnergyMultiplierT1, "Energy multiplier for the Stirling Generator, Tier 1 machine").getDouble();
+    stirlingGeneratorEnergyMultiplierT2 = (float) config.get(sectionPower.name, "stirlingGeneratorEnergyMultiplierT2",
+        stirlingGeneratorEnergyMultiplierT2, "Energy multiplier for the Stirling Generator, Tier 2 machine").getDouble();
+    stirlingGeneratorEnergyMultiplierT3 = (float) config.get(sectionPower.name, "stirlingGeneratorEnergyMultiplierT3",
+        stirlingGeneratorEnergyMultiplierT3, "Energy multiplier for the Stirling Generator, Tier 3 machine").getDouble();
+
+    stirlingGeneratorBurnTimeMultiplierT1 = (float) config.get(sectionPower.name, "stirlingGeneratorBurnTimeMultiplierT1",
+        stirlingGeneratorBurnTimeMultiplierT1, "Burn time multiplier for the Stirling Generator, Tier 1 machine").getDouble();
+    stirlingGeneratorBurnTimeMultiplierT2 = (float) config.get(sectionPower.name, "stirlingGeneratorBurnTimeMultiplierT2",
+        stirlingGeneratorBurnTimeMultiplierT2, "Burn time multiplier for the Stirling Generator, Tier 2 machine").getDouble();
+    stirlingGeneratorBurnTimeMultiplierT3 = (float) config.get(sectionPower.name, "stirlingGeneratorBurnTimeMultiplierT3",
+        stirlingGeneratorBurnTimeMultiplierT3, "Burn time multiplier for the Stirling Generator, Tier 3 machine").getDouble();
 
     addFuelTooltipsToAllFluidContainers = config.get(sectionPersonal.name, "addFuelTooltipsToAllFluidContainers", addFuelTooltipsToAllFluidContainers,
         "If true, the RF/t and burn time of the fuel will be displayed in all tooltips for fluid containers with fuel.").getBoolean(

--- a/src/main/java/crazypants/enderio/machine/generator/stirling/GuiStirlingGenerator.java
+++ b/src/main/java/crazypants/enderio/machine/generator/stirling/GuiStirlingGenerator.java
@@ -18,6 +18,7 @@ import com.enderio.core.client.render.RenderUtil;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import crazypants.enderio.EnderIO;
+import crazypants.enderio.config.Config;
 import crazypants.enderio.machine.gui.GuiPoweredMachineBase;
 import crazypants.enderio.machine.power.PowerDisplayUtil;
 import crazypants.enderio.power.Capacitors;
@@ -45,7 +46,7 @@ public class GuiStirlingGenerator extends GuiPoweredMachineBase<TileEntityStirli
   }
 
   private static float getFactor(Capacitors upgrade) {
-    return TileEntityStirlingGenerator.getEnergyMultiplier(upgrade) /
+    return TileEntityStirlingGenerator.getEnergyMultiplier(upgrade) *
             TileEntityStirlingGenerator.getBurnTimeMultiplier(upgrade);
   }
 
@@ -111,7 +112,8 @@ public class GuiStirlingGenerator extends GuiPoweredMachineBase<TileEntityStirli
     int sw = fr.getStringWidth(txt);
     fr.drawStringWithShadow(txt, guiLeft + xSize / 2 - sw / 2, y, ColorUtil.getRGB(Color.WHITE));
 
-    txt = EnderIO.lang.localize("stirlingGenerator.burnRate") + " " + (getTileEntity().getBurnTimeMultiplier()) + "x";
+    txt = EnderIO.lang.localize("stirlingGenerator.burnRate") + " "
+        + (getTileEntity().getBurnTimeMultiplier() / Config.stirlingGeneratorBurnTimeMultiplierT1) + "x";
     sw = fr.getStringWidth(txt);
     y += fr.FONT_HEIGHT + 3;
     fr.drawStringWithShadow(txt, guiLeft + xSize / 2 - sw / 2, y, ColorUtil.getRGB(Color.WHITE));

--- a/src/main/java/crazypants/enderio/machine/generator/stirling/TileEntityStirlingGenerator.java
+++ b/src/main/java/crazypants/enderio/machine/generator/stirling/TileEntityStirlingGenerator.java
@@ -21,8 +21,6 @@ import crazypants.enderio.power.PowerDistributor;
 
 public class TileEntityStirlingGenerator extends AbstractGeneratorEntity implements ISidedInventory, IProgressTile {
 
-  public static final int ENERGY_PER_TICK = Config.stirlingGeneratorBaseRfPerTick;
-
   // public for alloy smelter
   public static final String SOUND_NAME = "generator.stirling";
 
@@ -118,11 +116,11 @@ public class TileEntityStirlingGenerator extends AbstractGeneratorEntity impleme
 
   @Override
   public int getPowerUsePerTick() {
-    return Math.round(ENERGY_PER_TICK * getEnergyMultiplier());
+    return Math.round(Config.stirlingGeneratorBaseRfPerTick * getEnergyMultiplier());
   }
 
   public int getBurnTime(ItemStack item) {
-    return Math.round(TileEntityFurnace.getItemBurnTime(item) / getBurnTimeMultiplier());
+    return Math.round(TileEntityFurnace.getItemBurnTime(item) * getBurnTimeMultiplier());
   }
 
   @Override
@@ -187,11 +185,11 @@ public class TileEntityStirlingGenerator extends AbstractGeneratorEntity impleme
 
   public static float getEnergyMultiplier(Capacitors capacitorType) {
     if(capacitorType == Capacitors.ACTIVATED_CAPACITOR) {
-      return 2;
+      return Config.stirlingGeneratorEnergyMultiplierT2;
     } else if(capacitorType == Capacitors.ENDER_CAPACITOR) {
-      return 4;
+      return Config.stirlingGeneratorEnergyMultiplierT3;
     }
-    return 1;
+    return Config.stirlingGeneratorEnergyMultiplierT1;
   }
 
   private float getEnergyMultiplier() {
@@ -200,11 +198,11 @@ public class TileEntityStirlingGenerator extends AbstractGeneratorEntity impleme
 
   public static float getBurnTimeMultiplier(Capacitors capacitorType) {
     if(capacitorType == Capacitors.ACTIVATED_CAPACITOR) {
-      return 1.5f;
+      return Config.stirlingGeneratorBurnTimeMultiplierT2;
     } else if(capacitorType == Capacitors.ENDER_CAPACITOR) {
-      return 1.5f;
+      return Config.stirlingGeneratorBurnTimeMultiplierT3;
     }
-    return 2;
+    return Config.stirlingGeneratorBurnTimeMultiplierT1;
   }
 
   public float getBurnTimeMultiplier() {


### PR DESCRIPTION
* Added config settings for burn time and energy multiplier
* Normalized burn rate display to base value
* Increased efficiency of octa-upgraded generator a tiny bit (6x instead
of 5.3x) to avoid oddity of having the burn time display not change with
the second upgrade
* Fixed base RF config setting not responding to runtime config changes