### PR TITLE
Keep meta when dropping painted glowstone as item

### DIFF
--- a/src/main/java/crazypants/enderio/machine/painter/BlockPaintedGlowstone.java
+++ b/src/main/java/crazypants/enderio/machine/painter/BlockPaintedGlowstone.java
@@ -217,6 +217,11 @@ public class BlockPaintedGlowstone extends BlockEio implements ITileEntityProvid
   }
 
   @Override
+  public int damageDropped(int meta) {
+    return meta;
+  }
+
+  @Override
   protected void processDrop(World world, int x, int y, int z, TileEntityEnder te, ItemStack drop) {
     TileEntityPaintedBlock tef = (TileEntityPaintedBlock) te;
     if(tef != null) {


### PR DESCRIPTION
re #2789

I think that is the only painted block aside from facades that connects textures? All others aren't solid.