### PR TITLE
Allow both Yeta Wrench mouse actions to be off

### DIFF
--- a/src/main/java/crazypants/enderio/config/Config.java
+++ b/src/main/java/crazypants/enderio/config/Config.java
@@ -723,11 +723,6 @@ public final class Config {
 
     vacuumChestRange = config.get(sectionEfficiency.name, "vacumChestRange", vacuumChestRange, "The range of the vacuum chest").getInt(vacuumChestRange);
 
-    if(!useSneakMouseWheelYetaWrench && !useSneakRightClickYetaWrench) {
-      Log.warn("Both useSneakMouseWheelYetaWrench and useSneakRightClickYetaWrench are set to false. Enabling mouse wheel.");
-      useSneakMouseWheelYetaWrench = true;
-    }
-
     reinforcedObsidianEnabled = config.get(sectionItems.name, "reinforcedObsidianEnabled", reinforcedObsidianEnabled,
         "When set to false reinforced obsidian is not craftable.").getBoolean(reinforcedObsidianEnabled);
     reinforcedObsidianUseDarkSteelBlocks = config.get(sectionRecipe.name, "reinforcedObsidianUseDarkSteelBlocks", reinforcedObsidianUseDarkSteelBlocks,
@@ -1328,6 +1323,13 @@ public final class Config {
         "Internal power used per item extracted (not a stack of items)");
     inventoryPanelExtractCostPerOperation = config.getFloat("extractCostPerOperation", sectionInventoryPanel.name, inventoryPanelExtractCostPerOperation, 0.0f,
         10000.0f, "Internal power used per extract operation (independent of stack size)");
+  }
+
+  public static void checkYetaAccess() {
+    if(!useSneakMouseWheelYetaWrench && !useSneakRightClickYetaWrench) {
+      Log.warn("Both useSneakMouseWheelYetaWrench and useSneakRightClickYetaWrench are set to false. Enabling right click.");
+      useSneakRightClickYetaWrench = true;
+    }
   }
 
   public static void init() {

--- a/src/main/java/crazypants/enderio/item/KeyTracker.java
+++ b/src/main/java/crazypants/enderio/item/KeyTracker.java
@@ -17,6 +17,7 @@ import cpw.mods.fml.common.gameevent.InputEvent.KeyInputEvent;
 import crazypants.enderio.EnderIO;
 import crazypants.enderio.api.tool.IConduitControl;
 import crazypants.enderio.conduit.ConduitDisplayMode;
+import crazypants.enderio.config.Config;
 import crazypants.enderio.item.PacketMagnetState.SlotType;
 import crazypants.enderio.item.darksteel.DarkSteelController;
 import crazypants.enderio.item.darksteel.DarkSteelItems;
@@ -29,7 +30,6 @@ import crazypants.enderio.item.darksteel.upgrade.SpeedUpgrade;
 import crazypants.enderio.network.PacketHandler;
 import crazypants.enderio.thaumcraft.GogglesOfRevealingUpgrade;
 import crazypants.util.BaublesUtil;
-
 import static crazypants.enderio.item.darksteel.DarkSteelItems.itemMagnet;
 
 public class KeyTracker {
@@ -172,6 +172,9 @@ public class KeyTracker {
 
   private void handleYetaWrench() {
     if(!yetaWrenchMode.isPressed()) {
+      if (yetaWrenchMode.getKeyCode() == 0) {
+        Config.checkYetaAccess();
+      }
       return;
     }
     EntityClientPlayerMP player = Minecraft.getMinecraft().thePlayer;


### PR DESCRIPTION
if there's a keybinding set. Also switched to enabling right click instead of wheel---that one can be toggled mid-game.

re #3154