### PR TITLE
Prevent Zombie Gen from being configured to death

### DIFF
--- a/src/main/java/crazypants/enderio/config/Config.java
+++ b/src/main/java/crazypants/enderio/config/Config.java
@@ -269,6 +269,7 @@ public final class Config {
 
   public static int zombieGeneratorRfPerTick = 80;
   public static int zombieGeneratorTicksPerBucketFuel = 10000;
+  public static int zombieGeneratorResumeTime = 200;
 
   public static int stirlingGeneratorBaseRfPerTick = 20;
 
@@ -1018,6 +1019,15 @@ public final class Config {
         "The amount of power generated per tick.").getInt(zombieGeneratorRfPerTick);
     zombieGeneratorTicksPerBucketFuel = config.get(sectionPower.name, "zombieGeneratorTicksPerMbFuel", zombieGeneratorTicksPerBucketFuel,
         "The number of ticks one bucket of fuel lasts.").getInt(zombieGeneratorTicksPerBucketFuel);
+
+    zombieGeneratorResumeTime = config
+        .get(
+        sectionPower.name,
+        "zombieGeneratorPauseTimeWhenFull",
+            zombieGeneratorResumeTime,
+            "When the zombie generator shuts off because it is full, how many ticks worth of runtime must be available in the power buffer before it starts up again?.")
+        .getInt(
+zombieGeneratorResumeTime);
 
     stirlingGeneratorBaseRfPerTick = config.get(sectionPower.name, "stirlingGeneratorBaseRfPerTick", stirlingGeneratorBaseRfPerTick,
         "The amount of power generated per tick.").getInt(stirlingGeneratorBaseRfPerTick);

--- a/src/main/java/crazypants/enderio/machine/generator/zombie/GuiZombieGenerator.java
+++ b/src/main/java/crazypants/enderio/machine/generator/zombie/GuiZombieGenerator.java
@@ -13,6 +13,7 @@ import com.enderio.core.client.render.ColorUtil;
 import com.enderio.core.client.render.RenderUtil;
 
 import crazypants.enderio.EnderIO;
+import crazypants.enderio.config.Config;
 import crazypants.enderio.fluid.Fluids;
 import crazypants.enderio.machine.IoMode;
 import crazypants.enderio.machine.gui.GuiPoweredMachineBase;
@@ -70,7 +71,7 @@ public class GuiZombieGenerator extends GuiPoweredMachineBase<TileZombieGenerato
     FontRenderer fr = getFontRenderer();
     int output = 0;
     if(gen.isActive()) {
-      output = gen.outputPerTick;
+      output = gen.getPowerUsePerTick();
     }
     String txt = EnderIO.lang.localize("combustionGenerator.output") + " " + PowerDisplayUtil.formatPower(output) + " " + PowerDisplayUtil.abrevation()
         + PowerDisplayUtil.perTickStr();
@@ -84,7 +85,7 @@ public class GuiZombieGenerator extends GuiPoweredMachineBase<TileZombieGenerato
       RenderUtil.renderGuiTank(gen.fuelTank.getFluid(), gen.fuelTank.getCapacity(), gen.fuelTank.getFluidAmount(), x, y, zLevel, 16, 47);
 
       if(gen.isActive()) {
-        txt = gen.tickPerBucketOfFuel / 1000 + " " + EnderIO.lang.localize("power.tmb");
+        txt = Config.zombieGeneratorTicksPerBucketFuel / 1000 + " " + EnderIO.lang.localize("power.tmb");
         sw = fr.getStringWidth(txt);
         fr.drawStringWithShadow(txt, x - sw / 2 + 7, y + fr.FONT_HEIGHT / 2 + 46, ColorUtil.getRGB(Color.WHITE));
       }


### PR DESCRIPTION
* Too high rf/t will no longer stall it (value will be decreased instead)
* Resume time can be configured (so rf/t can be configured higher than 500)
* Config values can be changed at runtime
* re #3170

(pun intended)