### PR TITLE
Show Block Name in GuiExternalConnectionSelector. Fixes #1984

### DIFF
--- a/src/main/java/crazypants/enderio/conduit/gui/GuiExternalConnectionSelector.java
+++ b/src/main/java/crazypants/enderio/conduit/gui/GuiExternalConnectionSelector.java
@@ -5,11 +5,13 @@ import java.awt.Point;
 import java.util.HashSet;
 import java.util.Set;
 
+import net.minecraft.block.Block;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.entity.EntityClientPlayerMP;
 import net.minecraft.client.gui.GuiButton;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.client.renderer.Tessellator;
+import net.minecraft.init.Blocks;
 import net.minecraftforge.common.util.ForgeDirection;
 
 import com.enderio.core.client.render.ColorUtil;
@@ -26,6 +28,8 @@ public class GuiExternalConnectionSelector extends GuiScreen {
 
   Set<ForgeDirection> cons;
   IConduitBundle cb;
+  String adjacentBlockNames[] = new String[6];
+  Point textPositions[] = new Point[6];
 
   public GuiExternalConnectionSelector(IConduitBundle cb) {
     this.cb = cb;
@@ -54,11 +58,22 @@ public class GuiExternalConnectionSelector extends GuiScreen {
     player.openGui(EnderIO.instance, GuiHandler.GUI_ID_EXTERNAL_CONNECTION_BASE + dir.ordinal(), player.worldObj, loc.x, loc.y, loc.z);
   }
 
+  protected String getBlockNameForDirection(ForgeDirection direction) {
+    BlockCoord coords = cb.getLocation();
+    Block b = cb.getWorld().getBlock(coords.x + direction.offsetX, coords.y + direction.offsetY, coords.z + direction.offsetZ);
+    if (b != null && b != Blocks.air) {
+      return b.getLocalizedName();
+    }
+    return null;
+  }
+
   @Override
   public void initGui() {
     GuiButton b;
     for (ForgeDirection dir : ForgeDirection.VALID_DIRECTIONS) {
       Point p = getOffsetForDir(dir);
+      adjacentBlockNames[dir.ordinal()] = getBlockNameForDirection(dir);
+      textPositions[dir.ordinal()] = new Point(p.x, p.y + 20);
       b = new GuiButton(dir.ordinal(), p.x, p.y, 60, 20, dir.toString());
       buttonList.add(b);
       if(!cons.contains(dir)) {
@@ -85,6 +100,14 @@ public class GuiExternalConnectionSelector extends GuiScreen {
     int y = height / 2 - butHeight * 3 - 5;
     Tessellator.instance.startDrawingQuads();
     drawString(Minecraft.getMinecraft().fontRenderer, txt, x, y, ColorUtil.getARGB(Color.white));
+    for (int i = 0; i < 6; i++) {
+      String blockName = adjacentBlockNames[i];
+      if (blockName == null) {
+        continue;
+      }
+      int textWidth = Minecraft.getMinecraft().fontRenderer.getStringWidth(blockName);
+      drawString(Minecraft.getMinecraft().fontRenderer, blockName, textPositions[i].x + 60 / 2 - textWidth / 2, textPositions[i].y, ColorUtil.getARGB(Color.gray));
+    }
     Tessellator.instance.draw();
 
   }


### PR DESCRIPTION
Its been a year, since #1984, so i thought i might give it a shot.

![image](https://cloud.githubusercontent.com/assets/527679/14961435/c8602ac0-1099-11e6-8c73-92681b5f5d3b.png)

For 1.7.10. I hope you still accept PRs for it and that it can be easily ported to 1.9.8 and above.