### PR TITLE
Small Fixes for the Farm (actually one big one, too)

### DIFF
--- a/src/main/java/crazypants/enderio/machine/farm/TileFarmStation.java
+++ b/src/main/java/crazypants/enderio/machine/farm/TileFarmStation.java
@@ -416,7 +416,6 @@ public class TileFarmStation extends AbstractPoweredTaskEntity {
       }
       bc = getNextCoord();
     }
-    lastScanned = bc;
 
     Block block = worldObj.getBlock(bc.x, bc.y, bc.z);
     if(block == null) {
@@ -667,11 +666,11 @@ public class TileFarmStation extends AbstractPoweredTaskEntity {
       nextX = loc.x - size;
       nextZ += 1;
       if(nextZ > loc.z + size) {
-        lastScanned = null;
-        return getNextCoord();
+        nextX = loc.x - size;
+        nextZ = loc.z - size;
       }
     }
-    return new BlockCoord(nextX, lastScanned.y, nextZ);
+    return lastScanned = new BlockCoord(nextX, lastScanned.y, nextZ);
   }
 
   public void toggleLockedState(int slot) {

--- a/src/main/java/crazypants/enderio/machine/farm/farmers/MelonFarmer.java
+++ b/src/main/java/crazypants/enderio/machine/farm/farmers/MelonFarmer.java
@@ -18,9 +18,9 @@ public class MelonFarmer extends CustomSeedFarmer {
 
   @Override
   public boolean prepareBlock(TileFarmStation farm, BlockCoord bc, Block block, int meta) {
-    int xVal = farm.getLocation().x % 2; 
-    int zVal = farm.getLocation().z % 2;
-    if(bc.x % 2 != xVal || bc.z % 2 != zVal) {
+    int xVal = farm.getLocation().x & 1;
+    int zVal = farm.getLocation().z & 1;
+    if ((bc.x & 1) != xVal || (bc.z & 1) != zVal) {
       //if we have melon seeds, we still want ot return true here so they are not planted by the default plantable
       //handlers
       return canPlant(farm.getSeedTypeInSuppliesFor(bc));


### PR DESCRIPTION
* Prevent Farm becoming stuck if 20 or more blocks are in an unloaded chunk **or on itself**
* Fix MelonFarmer not working for parts of the farm that are on the other side of the X=0 or Z=0 border