### PR TITLE
Fix Fluid Conduit failure to extract

### DIFF
--- a/src/main/java/crazypants/enderio/conduit/liquid/LiquidConduit.java
+++ b/src/main/java/crazypants/enderio/conduit/liquid/LiquidConduit.java
@@ -145,7 +145,7 @@ public class LiquidConduit extends AbstractTankConduit {
             }
           }
           if(!foundFluid) {
-            return;
+            continue;
           }
 
           FluidStack couldDrain = extTank.drain(dir.getOpposite(), MAX_EXTRACT_PER_TICK, false);


### PR DESCRIPTION
A Fluid Conduit adjacent to multiple fluid containers, set to "Extract" on all of them, will stop extracting as soon as any of them become empty. A quick look at the source code suggests this line is the problem. 

So, I'm giving you a completely untested change to a no-longer-maintained branch of your project just in case somebody finds it useful. Cheers!