### PR TITLE
Update Integration for JEI version 3.11.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@
 /*.ipr
 /*.iws
 /atlassian-ide-plugin.xml
+/classes
 
 ## gedit
 *~

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ mod_version=3.0.1
 mod_appendix=beta
 
 waila_version=1.7.0-B3_1.9.4
-jei_version=3.8.1.242
+jei_version=3.11.1.270
 endercore_version=1.10.2-0.4.1.55-beta
 top_version=1.9.4-1.0.11-24
 forestry_version=forestry_1.10.2:5.2.5.216

--- a/src/main/java/crazypants/enderio/EnderIO.java
+++ b/src/main/java/crazypants/enderio/EnderIO.java
@@ -162,7 +162,7 @@ import static crazypants.enderio.EnderIO.MOD_NAME;
 import static crazypants.enderio.EnderIO.VERSION;
 import static crazypants.util.Things.TRAVEL_BLACKLIST;
 
-@Mod(modid = MODID, name = MOD_NAME, version = VERSION, dependencies = "after:endercore;after:Waila", guiFactory = "crazypants.enderio.config.ConfigFactoryEIO")
+@Mod(modid = MODID, name = MOD_NAME, version = VERSION, dependencies = "after:endercore;after:Waila;after:JEI@[3.11.1,)", guiFactory = "crazypants.enderio.config.ConfigFactoryEIO")
 public class EnderIO {
 
   public static final @Nonnull String MODID = "EnderIO";

--- a/src/main/java/crazypants/enderio/integration/jei/AlloyRecipeCategory.java
+++ b/src/main/java/crazypants/enderio/integration/jei/AlloyRecipeCategory.java
@@ -18,6 +18,7 @@ import mezz.jei.api.gui.IDrawableAnimated;
 import mezz.jei.api.gui.IDrawableStatic;
 import mezz.jei.api.gui.IGuiItemStackGroup;
 import mezz.jei.api.gui.IRecipeLayout;
+import mezz.jei.api.ingredients.IIngredients;
 import mezz.jei.api.recipe.BlankRecipeCategory;
 import mezz.jei.api.recipe.VanillaRecipeCategoryUid;
 import net.minecraft.client.Minecraft;
@@ -119,7 +120,7 @@ public class AlloyRecipeCategory extends BlankRecipeCategory<AlloyRecipeCategory
   }
   
   @Override
-  public void setRecipe(@Nonnull IRecipeLayout recipeLayout, @Nonnull AlloyRecipeCategory.AlloyRecipe recipeWrapper) {
+  public void setRecipe(@Nonnull IRecipeLayout recipeLayout, @Nonnull AlloyRecipeCategory.AlloyRecipe recipeWrapper, @Nonnull IIngredients ingredients) {
     IGuiItemStackGroup guiItemStacks = recipeLayout.getItemStacks();
 
     guiItemStacks.init(0, true, 53 - xOff, 16 - yOff);
@@ -127,15 +128,15 @@ public class AlloyRecipeCategory extends BlankRecipeCategory<AlloyRecipeCategory
     guiItemStacks.init(2, true, 102 - xOff, 16 - yOff);
     guiItemStacks.init(3, false, 78 - xOff, 57 - yOff);
 
-    List<?> inputs = recipeWrapper.getInputs();
+    List<List<ItemStack>> inputs = ingredients.getInputs(ItemStack.class);
     for (int index = 0; index < inputs.size(); index++) {
-      Object ingredients = inputs.get(index);
-      if (ingredients != null) {
-        guiItemStacks.setFromRecipe(index, ingredients);
+      List<ItemStack> input = inputs.get(index);
+      if (input != null) {
+        guiItemStacks.set(index, input);
       }
     }
-    List<?> outputs = recipeWrapper.getOutputs();
-    guiItemStacks.setFromRecipe(3, outputs);
+    List<ItemStack> outputs = ingredients.getOutputs(ItemStack.class);
+    guiItemStacks.set(3, outputs);
     currentRecipe = recipeWrapper;
   }
 

--- a/src/main/java/crazypants/enderio/integration/jei/CombustionRecipeCategory.java
+++ b/src/main/java/crazypants/enderio/integration/jei/CombustionRecipeCategory.java
@@ -2,6 +2,7 @@ package crazypants.enderio.integration.jei;
 
 import java.awt.Color;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -24,6 +25,7 @@ import mezz.jei.api.gui.IDrawable;
 import mezz.jei.api.gui.IGuiFluidStackGroup;
 import mezz.jei.api.gui.IGuiIngredient;
 import mezz.jei.api.gui.IRecipeLayout;
+import mezz.jei.api.ingredients.IIngredients;
 import mezz.jei.api.recipe.BlankRecipeCategory;
 import mezz.jei.api.recipe.BlankRecipeWrapper;
 import net.minecraft.client.Minecraft;
@@ -58,31 +60,9 @@ public class CombustionRecipeCategory extends BlankRecipeCategory<CombustionReci
     public void setInfoData(Map<Integer, ? extends IGuiIngredient<ItemStack>> ings) {
     }
 
-    @SuppressWarnings("null")
     @Override
-    public @Nonnull List<?> getInputs() {
-      return Collections.emptyList();
-    }
-
-    @SuppressWarnings("null")
-    @Override
-    public @Nonnull List<FluidStack> getFluidInputs() {
-      List<FluidStack> result = new ArrayList<FluidStack>();
-      result.add(fluidCoolant);
-      result.add(fluidFuel);
-      return result;
-    }
-
-    @SuppressWarnings("null")
-    @Override
-    public @Nonnull List<?> getOutputs() {
-      return Collections.emptyList();
-    }
-
-    @SuppressWarnings("null")
-    @Override
-    public @Nonnull List<FluidStack> getFluidOutputs() {
-      return Collections.emptyList();
+    public void getIngredients(@Nonnull IIngredients ingredients) {
+      ingredients.setInputs(FluidStack.class, Arrays.asList(fluidCoolant, fluidFuel));
     }
 
     @Override
@@ -176,14 +156,13 @@ public class CombustionRecipeCategory extends BlankRecipeCategory<CombustionReci
 
   @SuppressWarnings("null")
   @Override
-  public void setRecipe(@Nonnull IRecipeLayout recipeLayout, @Nonnull CombustionRecipeWrapper recipeWrapper) {
+  public void setRecipe(@Nonnull IRecipeLayout recipeLayout, @Nonnull CombustionRecipeWrapper recipeWrapper, @Nonnull IIngredients ingredients) {
     IGuiFluidStackGroup fluidStacks = recipeLayout.getFluidStacks();
 
-    fluidStacks.init(0, false, 114 - xOff, 21 - yOff, 15, 47, 1000, false, null);
-    fluidStacks.init(1, false, 48 - xOff, 21 - yOff, 15, 47, 1000, false, null);
+    fluidStacks.init(0, true, 114 - xOff, 21 - yOff, 15, 47, 1000, false, null);
+    fluidStacks.init(1, true, 48 - xOff, 21 - yOff, 15, 47, 1000, false, null);
 
-    fluidStacks.set(0, recipeWrapper.fluidCoolant);
-    fluidStacks.set(1, recipeWrapper.fluidFuel);
+    fluidStacks.set(ingredients);
   }
 
 }

--- a/src/main/java/crazypants/enderio/integration/jei/DarkSteelUpgradeRecipeCategory.java
+++ b/src/main/java/crazypants/enderio/integration/jei/DarkSteelUpgradeRecipeCategory.java
@@ -1,6 +1,7 @@
 package crazypants.enderio.integration.jei;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -10,6 +11,7 @@ import java.util.Set;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import mezz.jei.api.ingredients.IIngredients;
 import org.apache.commons.lang3.tuple.Triple;
 
 import crazypants.enderio.EnderIO;
@@ -54,17 +56,9 @@ public class DarkSteelUpgradeRecipeCategory extends BlankRecipeCategory<DarkStee
     }
 
     @Override
-    public @Nonnull List<?> getInputs() {
-      List<ItemStack> itemInputs = new ArrayList<ItemStack>();
-      itemInputs.add(stacks.getLeft());
-      itemInputs.add(stacks.getMiddle());
-      return itemInputs;
-    }
-
-    @SuppressWarnings("null")
-    @Override
-    public @Nonnull List<?> getOutputs() {
-      return Collections.singletonList(stacks.getRight());
+    public void getIngredients(@Nonnull IIngredients ingredients) {
+      ingredients.setInputs(ItemStack.class, Arrays.asList(stacks.getLeft(), stacks.getMiddle()));
+      ingredients.setOutput(ItemStack.class, stacks.getRight());
     }
 
   } // -------------------------------------
@@ -147,16 +141,14 @@ public class DarkSteelUpgradeRecipeCategory extends BlankRecipeCategory<DarkStee
 
   @SuppressWarnings("null")
   @Override
-  public void setRecipe(@Nonnull IRecipeLayout recipeLayout, @Nonnull DarkSteelUpgradeRecipeWrapper recipeWrapper) {
+  public void setRecipe(@Nonnull IRecipeLayout recipeLayout, @Nonnull DarkSteelUpgradeRecipeWrapper recipeWrapper, @Nonnull IIngredients ingredients) {
     IGuiItemStackGroup guiItemStacks = recipeLayout.getItemStacks();
 
     guiItemStacks.init(0, true, 27 - xOff - 1, 47 - yOff - 1);
     guiItemStacks.init(1, true, 76 - xOff - 1, 47 - yOff - 1);
     guiItemStacks.init(2, false, 134 - xOff - 1, 47 - yOff - 1);
 
-    guiItemStacks.setFromRecipe(0,recipeWrapper.stacks.getLeft());
-    guiItemStacks.setFromRecipe(1,recipeWrapper.stacks.getMiddle());
-    guiItemStacks.setFromRecipe(2,recipeWrapper.stacks.getRight());
+    guiItemStacks.set(ingredients);
   }
 
   public static class DarkSteelUpgradeSubtypeInterpreter implements ISubtypeInterpreter {

--- a/src/main/java/crazypants/enderio/integration/jei/EnchanterRecipeCategory.java
+++ b/src/main/java/crazypants/enderio/integration/jei/EnchanterRecipeCategory.java
@@ -1,6 +1,8 @@
 package crazypants.enderio.integration.jei;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -17,9 +19,9 @@ import mezz.jei.api.gui.IDrawable;
 import mezz.jei.api.gui.IGuiIngredient;
 import mezz.jei.api.gui.IGuiItemStackGroup;
 import mezz.jei.api.gui.IRecipeLayout;
+import mezz.jei.api.ingredients.IIngredients;
 import mezz.jei.api.recipe.BlankRecipeCategory;
 import mezz.jei.api.recipe.BlankRecipeWrapper;
-import mezz.jei.gui.ingredients.GuiIngredient;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.resources.I18n;
 import net.minecraft.enchantment.EnchantmentData;
@@ -60,9 +62,8 @@ public class EnchanterRecipeCategory extends BlankRecipeCategory<EnchanterRecipe
 
       ItemStack stack = null;
       IGuiIngredient<ItemStack> ging = currentIngredients.get(1);
-      if (ging instanceof GuiIngredient) {
-        GuiIngredient<ItemStack> gi = (GuiIngredient<ItemStack>) ging;
-        stack = gi.getIngredient();
+      if (ging != null) {
+        stack = ging.getDisplayedIngredient();
       }
       if (stack == null) {
         return;
@@ -78,23 +79,19 @@ public class EnchanterRecipeCategory extends BlankRecipeCategory<EnchanterRecipe
     }
 
     @Override
-    public @Nonnull List<?> getInputs() {
+    public void getIngredients(@Nonnull IIngredients ingredients) {
       List<ItemStack> itemInputs = new ArrayList<ItemStack>();
       List<ItemStack> lapizInputs = new ArrayList<ItemStack>();
       List<ItemStack> itemOutputs = new ArrayList<ItemStack>();
       getItemStacks(rec, itemInputs, lapizInputs, itemOutputs);
-      itemInputs.add(new ItemStack(Items.WRITABLE_BOOK));
-      itemInputs.addAll(lapizInputs);
-      return itemInputs;
-    }
 
-    @Override
-    public @Nonnull List<?> getOutputs() {
-      List<ItemStack> itemInputs = new ArrayList<ItemStack>();
-      List<ItemStack> lapizInputs = new ArrayList<ItemStack>();
-      List<ItemStack> itemOutputs = new ArrayList<ItemStack>();
-      getItemStacks(rec, itemInputs, lapizInputs, itemOutputs);
-      return itemOutputs;
+      List<List<ItemStack>> inputs = new ArrayList<List<ItemStack>>();
+      inputs.add(Collections.singletonList(new ItemStack(Items.WRITABLE_BOOK)));
+      inputs.add(itemInputs);
+      inputs.add(lapizInputs);
+
+      ingredients.setInputLists(ItemStack.class, inputs);
+      ingredients.setOutputs(ItemStack.class, itemOutputs);
     }
 
   }
@@ -159,7 +156,7 @@ public class EnchanterRecipeCategory extends BlankRecipeCategory<EnchanterRecipe
   }
 
   @Override
-  public void setRecipe(@Nonnull IRecipeLayout recipeLayout, @Nonnull EnchanterRecipeCategory.EnchanterRecipeWrapper recipeWrapper) {
+  public void setRecipe(@Nonnull IRecipeLayout recipeLayout, @Nonnull EnchanterRecipeCategory.EnchanterRecipeWrapper recipeWrapper, @Nonnull IIngredients ingredients) {
 
     currentRecipe = recipeWrapper;
 
@@ -173,16 +170,7 @@ public class EnchanterRecipeCategory extends BlankRecipeCategory<EnchanterRecipe
     guiItemStacks.init(2, true, 85 - xOff - 1, 34 - yOff);
     guiItemStacks.init(3, false, 144 - xOff - 1, 34 - yOff);
 
-    guiItemStacks.setFromRecipe(0, new ItemStack(Items.WRITABLE_BOOK));
-
-    EnchanterRecipe rec = currentRecipe.rec;
-    List<ItemStack> itemInputs = new ArrayList<ItemStack>();
-    List<ItemStack> lapizInputs = new ArrayList<ItemStack>();
-    List<ItemStack> itemOutputs = new ArrayList<ItemStack>();
-    getItemStacks(rec, itemInputs, lapizInputs, itemOutputs);
-    guiItemStacks.set(1, itemInputs);
-    guiItemStacks.set(2, lapizInputs);
-    guiItemStacks.set(3, itemOutputs);
+    guiItemStacks.set(ingredients);
   }
 
   private static void getItemStacks(EnchanterRecipe rec, List<ItemStack> itemInputs, List<ItemStack> lapizInputs, List<ItemStack> itemOutputs) {

--- a/src/main/java/crazypants/enderio/integration/jei/RecipeWrapper.java
+++ b/src/main/java/crazypants/enderio/integration/jei/RecipeWrapper.java
@@ -7,6 +7,7 @@ import javax.annotation.Nonnull;
 
 import crazypants.enderio.machine.recipe.IRecipe;
 import crazypants.enderio.machine.recipe.RecipeOutput;
+import mezz.jei.api.ingredients.IIngredients;
 import mezz.jei.api.recipe.BlankRecipeWrapper;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.FluidStack;
@@ -20,38 +21,33 @@ public class RecipeWrapper extends BlankRecipeWrapper {
   }
 
   @Override
-  public @Nonnull List<?> getInputs() {
+  public void getIngredients(@Nonnull IIngredients ingredients) {
     List<List<ItemStack>> inputStacks = recipe.getInputStackAlternatives();
-    return inputStacks != null ? inputStacks : new ArrayList<ItemStack>();
-  }
+    if (inputStacks != null) {
+      ingredients.setInputLists(ItemStack.class, inputStacks);
+    }
 
-  @Override
-  public @Nonnull List<?> getOutputs() {
     List<ItemStack> outputs = new ArrayList<ItemStack>();
     for(RecipeOutput out : recipe.getOutputs()) {
       if(out.getOutput() != null) {
         outputs.add(out.getOutput());
       }
     }
-    return outputs;
-  }
+    ingredients.setOutputs(ItemStack.class, outputs);
 
-  @Override
-  public @Nonnull List<FluidStack> getFluidInputs() {
     List<FluidStack> inputFluidStacks = recipe.getInputFluidStacks();
-    return inputFluidStacks != null ? inputFluidStacks : new ArrayList<FluidStack>();
-  }
+    if (inputFluidStacks != null) {
+      ingredients.setInputs(FluidStack.class, inputFluidStacks);
+    }
 
-  @Override
-  public @Nonnull List<FluidStack> getFluidOutputs() {
-    List<FluidStack> outputs = new ArrayList<FluidStack>();
+    List<FluidStack> fluidOutputs = new ArrayList<FluidStack>();
     for(RecipeOutput out : recipe.getOutputs()) {
       if(out.getFluidOutput() != null) {
-        outputs.add(out.getFluidOutput());
+        fluidOutputs.add(out.getFluidOutput());
       }
     }
-    return outputs;
-  }  
+    ingredients.setOutputs(FluidStack.class, fluidOutputs);
+  }
   
   public boolean isValid() {
     return recipe != null && recipe.isValid();

--- a/src/main/java/crazypants/enderio/integration/jei/SagMillRecipeCategory.java
+++ b/src/main/java/crazypants/enderio/integration/jei/SagMillRecipeCategory.java
@@ -23,6 +23,7 @@ import mezz.jei.api.gui.IDrawableStatic;
 import mezz.jei.api.gui.IGuiItemStackGroup;
 import mezz.jei.api.gui.IRecipeLayout;
 import mezz.jei.api.gui.ITooltipCallback;
+import mezz.jei.api.ingredients.IIngredients;
 import mezz.jei.api.recipe.BlankRecipeCategory;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.GlStateManager;
@@ -122,7 +123,7 @@ public class SagMillRecipeCategory extends BlankRecipeCategory<SagMillRecipeCate
   }
 
   @Override
-  public void setRecipe(@Nonnull IRecipeLayout recipeLayout, @Nonnull SagMillRecipeCategory.SagRecipe recipeWrapper) {
+  public void setRecipe(@Nonnull IRecipeLayout recipeLayout, @Nonnull SagMillRecipeCategory.SagRecipe recipeWrapper, @Nonnull IIngredients ingredients) {
 
     currentRecipe = recipeWrapper;
 
@@ -136,17 +137,17 @@ public class SagMillRecipeCategory extends BlankRecipeCategory<SagMillRecipeCate
     guiItemStacks.init(4, false, 111 - xOff, 58 - yOff);    
     guiItemStacks.init(5, false, 121 - xOff, 22 - yOff);
 
-    Object ingredients = currentRecipe.getInputs().get(0);
-    if (ingredients != null) {
-      guiItemStacks.setFromRecipe(0, ingredients);
+    List<ItemStack> inputs = ingredients.getInputs(ItemStack.class).get(0);
+    if (inputs != null) {
+      guiItemStacks.set(0, inputs);
     }
     int i = 1;
-    for (Object output : currentRecipe.getOutputs()) {
+    for (ItemStack output : ingredients.getOutputs(ItemStack.class)) {
       if (output != null) {
-        guiItemStacks.setFromRecipe(i, output);
+        guiItemStacks.set(i, output);
         i++;
       }
-    }    
+    }
     guiItemStacks.set(5, getBalls());       
   }
   

--- a/src/main/java/crazypants/enderio/integration/jei/SliceAndSpliceRecipeCategory.java
+++ b/src/main/java/crazypants/enderio/integration/jei/SliceAndSpliceRecipeCategory.java
@@ -19,6 +19,7 @@ import mezz.jei.api.gui.IDrawableAnimated;
 import mezz.jei.api.gui.IDrawableStatic;
 import mezz.jei.api.gui.IGuiItemStackGroup;
 import mezz.jei.api.gui.IRecipeLayout;
+import mezz.jei.api.ingredients.IIngredients;
 import mezz.jei.api.recipe.BlankRecipeCategory;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.GlStateManager;
@@ -114,7 +115,7 @@ public class SliceAndSpliceRecipeCategory extends BlankRecipeCategory<SliceAndSp
   }
   
   @Override
-  public void setRecipe(@Nonnull IRecipeLayout recipeLayout, @Nonnull SliceAndSpliceRecipeCategory.SliceAndSpliceRecipe recipeWrapper) {
+  public void setRecipe(@Nonnull IRecipeLayout recipeLayout, @Nonnull SliceAndSpliceRecipeCategory.SliceAndSpliceRecipe recipeWrapper, @Nonnull IIngredients ingredients) {
     currentRecipe = recipeWrapper;
 
     IGuiItemStackGroup guiItemStacks = recipeLayout.getItemStacks();
@@ -130,21 +131,21 @@ public class SliceAndSpliceRecipeCategory extends BlankRecipeCategory<SliceAndSp
     guiItemStacks.init(8, false, 133 - xOff, 48 - yOff);
 
     
-    guiItemStacks.setFromRecipe(0, getAxes());
-    guiItemStacks.setFromRecipe(1, getShears());
+    guiItemStacks.set(0, getAxes());
+    guiItemStacks.set(1, getShears());
     
     
-    List<?> inputs = recipeWrapper.getInputs();
+    List<List<ItemStack>> inputs = ingredients.getInputs(ItemStack.class);
     int slot = 2;
-    for(Object input : inputs) {
+    for(List<ItemStack> input : inputs) {
       if (input != null) {
-        guiItemStacks.setFromRecipe(slot, input);
+        guiItemStacks.set(slot, input);
       }
       ++slot;
     }    
-    Object output = recipeWrapper.getOutputs().get(0);
+    ItemStack output = ingredients.getOutputs(ItemStack.class).get(0);
     if (output != null) {
-      guiItemStacks.setFromRecipe(8, output);
+      guiItemStacks.set(8, output);
     }
   }
   

--- a/src/main/java/crazypants/enderio/integration/jei/SoulBinderRecipeCategory.java
+++ b/src/main/java/crazypants/enderio/integration/jei/SoulBinderRecipeCategory.java
@@ -24,6 +24,7 @@ import mezz.jei.api.gui.IDrawableAnimated;
 import mezz.jei.api.gui.IDrawableStatic;
 import mezz.jei.api.gui.IGuiItemStackGroup;
 import mezz.jei.api.gui.IRecipeLayout;
+import mezz.jei.api.ingredients.IIngredients;
 import mezz.jei.api.recipe.BlankRecipeCategory;
 import mezz.jei.api.recipe.BlankRecipeWrapper;
 import net.minecraft.client.Minecraft;
@@ -31,6 +32,7 @@ import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.resources.I18n;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.fml.common.asm.transformers.ItemStackTransformer;
 
 import static crazypants.enderio.machine.soul.ContainerSoulBinder.FIRST_INVENTORY_SLOT;
 import static crazypants.enderio.machine.soul.ContainerSoulBinder.FIRST_RECIPE_SLOT;
@@ -55,17 +57,11 @@ public class SoulBinderRecipeCategory extends BlankRecipeCategory<SoulBinderReci
       return recipe.getEnergyRequired();
     }
 
-    @SuppressWarnings("null")
     @Override
-    public @Nonnull List<?> getInputs() {
-      return Arrays.asList(new ItemStack(EnderIO.itemSoulVessel), recipe.getInputStack() );
+    public void getIngredients(@Nonnull IIngredients ingredients) {
+      ingredients.setInputs(ItemStack.class, Arrays.asList(new ItemStack(EnderIO.itemSoulVessel), recipe.getInputStack()));
+      ingredients.setOutputs(ItemStack.class, Arrays.asList(recipe.getOutputStack(), new ItemStack(EnderIO.itemSoulVessel)));
     }
-
-    @SuppressWarnings("null")
-    @Override
-    public @Nonnull List<?> getOutputs() {
-      return Arrays.asList(recipe.getOutputStack(), new ItemStack(EnderIO.itemSoulVessel));
-    }   
     
     @Override
     public void drawInfo(@Nonnull Minecraft minecraft, int recipeWidth, int recipeHeight, int mouseX, int mouseY) {           
@@ -147,7 +143,7 @@ public class SoulBinderRecipeCategory extends BlankRecipeCategory<SoulBinderReci
   }  
   
   @Override
-  public void setRecipe(@Nonnull IRecipeLayout recipeLayout, @Nonnull SoulBinderRecipeCategory.SoulBinderRecipeWrapper recipeWrapper) {
+  public void setRecipe(@Nonnull IRecipeLayout recipeLayout, @Nonnull SoulBinderRecipeCategory.SoulBinderRecipeWrapper recipeWrapper, @Nonnull IIngredients ingredients) {
     currentRecipe = recipeWrapper;
 
     IGuiItemStackGroup guiItemStacks = recipeLayout.getItemStacks();
@@ -167,19 +163,21 @@ public class SoulBinderRecipeCategory extends BlankRecipeCategory<SoulBinderReci
     }
     guiItemStacks.set(0, soulStacks);
 
-    guiItemStacks.setFromRecipe(1, inputStack != null ? inputStack : new ArrayList<ItemStack>());
+    if (inputStack != null) {
+      guiItemStacks.set(1, inputStack);
+    }
 
     if (EnderIO.itemBrokenSpawner == outputStack.getItem() || currentRecipe.recipe instanceof SoulBinderTunedPressurePlateRecipe) {
       List<ItemStack> outputs = new ArrayList<ItemStack>();
       for (CapturedMob soul : souls) {
         outputs.add(soul.toStack(outputStack.getItem(), outputStack.getMetadata(), 1));
       }      
-      guiItemStacks.setFromRecipe(2, outputs);
+      guiItemStacks.set(2, outputs);
     } else {
-      guiItemStacks.setFromRecipe(2, outputStack);
+      guiItemStacks.set(2, outputStack);
     }
 
-    guiItemStacks.setFromRecipe(3, new ItemStack(EnderIO.itemSoulVessel));
+    guiItemStacks.set(3, new ItemStack(EnderIO.itemSoulVessel));
   }
   
 }

--- a/src/main/java/crazypants/enderio/integration/jei/TankRecipeCategory.java
+++ b/src/main/java/crazypants/enderio/integration/jei/TankRecipeCategory.java
@@ -20,6 +20,7 @@ import mezz.jei.api.gui.IGuiFluidStackGroup;
 import mezz.jei.api.gui.IGuiIngredient;
 import mezz.jei.api.gui.IGuiItemStackGroup;
 import mezz.jei.api.gui.IRecipeLayout;
+import mezz.jei.api.ingredients.IIngredients;
 import mezz.jei.api.recipe.BlankRecipeCategory;
 import mezz.jei.api.recipe.BlankRecipeWrapper;
 import net.minecraft.client.Minecraft;
@@ -56,42 +57,21 @@ public class TankRecipeCategory extends BlankRecipeCategory<TankRecipeCategory.T
     public void setInfoData(Map<Integer, ? extends IGuiIngredient<ItemStack>> ings) {
     }
 
-    @SuppressWarnings("null")
     @Override
-    public @Nonnull List<?> getInputs() {
+    public void getIngredients(IIngredients ingredients) {
       if (itemInput != null) {
-        return Collections.singletonList(itemInput);
+        ingredients.setInputs(ItemStack.class, Collections.singletonList(itemInput));
       }
-      return Collections.emptyList();
-    }
-
-    @SuppressWarnings("null")
-    @Override
-    public @Nonnull List<FluidStack> getFluidInputs() {
       if (fluidInput != null) {
-        return Collections.singletonList(fluidInput);
+        ingredients.setInputs(FluidStack.class, Collections.singletonList(fluidInput));
       }
-      return Collections.emptyList();
-    }
-
-    @SuppressWarnings("null")
-    @Override
-    public @Nonnull List<?> getOutputs() {
       if (itemOutput != null) {
-        return Collections.singletonList(itemOutput);
+        ingredients.setOutput(ItemStack.class, itemOutput);
       }
-      return Collections.emptyList();
-    }
-
-    @SuppressWarnings("null")
-    @Override
-    public @Nonnull List<FluidStack> getFluidOutputs() {
       if (fluidOutput != null) {
-        return Collections.singletonList(fluidOutput);
+        ingredients.setOutput(FluidStack.class, fluidOutput);
       }
-      return Collections.emptyList();
     }
-
 
   } // -------------------------------------
 
@@ -183,7 +163,7 @@ public class TankRecipeCategory extends BlankRecipeCategory<TankRecipeCategory.T
 
   @SuppressWarnings("null")
   @Override
-  public void setRecipe(@Nonnull IRecipeLayout recipeLayout, @Nonnull TankRecipeWrapper recipeWrapper) {
+  public void setRecipe(@Nonnull IRecipeLayout recipeLayout, @Nonnull TankRecipeWrapper recipeWrapper, @Nonnull IIngredients ingredients) {
     IGuiItemStackGroup guiItemStacks = recipeLayout.getItemStacks();
     IGuiFluidStackGroup fluidStacks = recipeLayout.getFluidStacks();
 
@@ -194,13 +174,18 @@ public class TankRecipeCategory extends BlankRecipeCategory<TankRecipeCategory.T
 
     fluidStacks.init(0, false, 80 - xOff, 21 - yOff, 16, 47, 16000, true, null);
 
-    if (recipeWrapper.fluidInput == null) {
-      guiItemStacks.setFromRecipe(0, recipeWrapper.itemInput);
-      guiItemStacks.setFromRecipe(2, recipeWrapper.itemOutput);
+    List<List<ItemStack>> itemInputs = ingredients.getInputs(ItemStack.class);
+    List<ItemStack> itemOutputs = ingredients.getOutputs(ItemStack.class);
+    List<List<FluidStack>> fluidInputs = ingredients.getInputs(FluidStack.class);
+    List<ItemStack> inputIngredient = itemInputs.get(0);
+    ItemStack outputIngredient = itemOutputs.get(0);
+    if (fluidInputs.isEmpty()) {
+      guiItemStacks.set(0, inputIngredient);
+      guiItemStacks.set(2, outputIngredient);
       fluidStacks.set(0, recipeWrapper.fluidOutput);
     } else {
-      guiItemStacks.setFromRecipe(1, recipeWrapper.itemInput);
-      guiItemStacks.setFromRecipe(3, recipeWrapper.itemOutput);
+      guiItemStacks.set(1, inputIngredient);
+      guiItemStacks.set(3, outputIngredient);
       fluidStacks.set(0, recipeWrapper.fluidInput);
     }
   }

--- a/src/main/java/crazypants/enderio/integration/jei/VatRecipeCategory.java
+++ b/src/main/java/crazypants/enderio/integration/jei/VatRecipeCategory.java
@@ -23,8 +23,8 @@ import mezz.jei.api.gui.IDrawable;
 import mezz.jei.api.gui.IGuiIngredient;
 import mezz.jei.api.gui.IGuiItemStackGroup;
 import mezz.jei.api.gui.IRecipeLayout;
+import mezz.jei.api.ingredients.IIngredients;
 import mezz.jei.api.recipe.BlankRecipeCategory;
-import mezz.jei.gui.ingredients.GuiIngredient;
 import net.minecraft.client.Minecraft;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
@@ -94,12 +94,9 @@ public class VatRecipeCategory extends BlankRecipeCategory<VatRecipeCategory.Vat
     }
 
     private String getTextForSlot(int forSlot) {
-      ItemStack stack = null;
       IGuiIngredient<ItemStack> ging = currentIngredients.get(forSlot);
-      if (ging instanceof GuiIngredient) {
-        GuiIngredient<ItemStack> gi = (GuiIngredient<ItemStack>) ging;
-        stack = gi.getIngredient();
-      }
+      ItemStack stack = ging.getDisplayedIngredient();
+
       if (stack == null) {
         return null;
       }
@@ -184,7 +181,7 @@ public class VatRecipeCategory extends BlankRecipeCategory<VatRecipeCategory.Vat
   }
 
   @Override
-  public void setRecipe(@Nonnull IRecipeLayout recipeLayout, @Nonnull VatRecipeCategory.VatRecipeWrapper recipeWrapper) {
+  public void setRecipe(@Nonnull IRecipeLayout recipeLayout, @Nonnull VatRecipeCategory.VatRecipeWrapper recipeWrapper, @Nonnull IIngredients ingredients) {
 
     currentRecipe = recipeWrapper;
 

--- a/src/main/java/crazypants/enderio/machine/vat/VatRecipe.java
+++ b/src/main/java/crazypants/enderio/machine/vat/VatRecipe.java
@@ -1,5 +1,6 @@
 package crazypants.enderio.machine.vat;
 
+import java.util.Collections;
 import java.util.List;
 
 import org.apache.commons.lang3.NotImplementedException;
@@ -216,7 +217,7 @@ public class VatRecipe implements IRecipe {
 
   @Override
   public List<FluidStack> getInputFluidStacks() {
-    throw new NotImplementedException("");
+    return Collections.emptyList();
   }
 
   public float getMultiplierForInput(FluidStack item) {


### PR DESCRIPTION
The JEI update to 3.11.x is a big refactor and broke EnderIO integration (you are using some internal classes).
This PR updates the integration, moves away from deprecated methods, and sets the minimum JEI version to 3.11.1.