### PR TITLE
register fluids before items

### DIFF
--- a/src/main/java/crazypants/enderio/EnderIO.java
+++ b/src/main/java/crazypants/enderio/EnderIO.java
@@ -114,10 +114,10 @@ public class EnderIO {
 
     ConduitGeometryUtil.setupBounds((float) Config.conduitScale);
 
-    ModObject.preInit(event);
-
     fluids = new Fluids();
     fluids.registerFluids();
+
+    ModObject.preInit(event);
 
     DarkSteelItems.createDarkSteelArmorItems();
     DarkSteelController.instance.register();


### PR DESCRIPTION
With fluids being registered before items are created, `ItemRodOfReturn` can't find `ender_distillation`, which leads to an NPE when attempting to render the item, in say, the creative tab.

```
[04:04:38] [Client thread/WARN] [EnderIO/EnderIO]: ItemRodOfReturn: Could not find fluid 'ender_distillation' using default fluid null
```

```
Description: Rendering screen

java.lang.IllegalArgumentException: Cannot create a fluidstack from a null fluid
	at net.minecraftforge.fluids.FluidStack.<init>(FluidStack.java:47)
	at crazypants.enderio.teleport.telepad.ItemRodOfReturn.getFluid(ItemRodOfReturn.java:418)
	at crazypants.enderio.teleport.telepad.ItemRodOfReturn$FluidCapabilityProvider$1.getContents(ItemRodOfReturn.java:469)
	at crazypants.enderio.item.PowerBarOverlayRenderHelper$FluidBarOverlayRenderHelper.render(PowerBarOverlayRenderHelper.java:215)
	at crazypants.enderio.teleport.telepad.ItemRodOfReturn.renderItemOverlayIntoGUI(ItemRodOfReturn.java:267)
	at com.enderio.core.common.transform.EnderCoreMethods.renderItemOverlayIntoGUI(EnderCoreMethods.java:172)
```
