### PR TITLE
Fix Immersive's hemp haversting

### DIFF
--- a/src/main/java/crazypants/enderio/machine/farm/farmers/HempFarmerIE.java
+++ b/src/main/java/crazypants/enderio/machine/farm/farmers/HempFarmerIE.java
@@ -48,17 +48,7 @@ public class HempFarmerIE implements IFarmerJoe {
 
   @Override
   public IHarvestResult harvestBlock(TileFarmStation farm, BlockCoord bc, Block block, IBlockState state) {
-    HarvestResult result = new HarvestResult();        
-    addResult(result, stemFarmer.harvestBlock(farm, bc, block, state));
-    addResult(result, seedFarmer.harvestBlock(farm, bc, block, state));
-    return result;
-  }
-  
-  private void addResult(HarvestResult result, IHarvestResult res) {
-    if(res != null) {
-      result.drops.addAll(res.getDrops());
-      result.harvestedBlocks.addAll(res.getHarvestedBlocks());
-    }
+    return stemFarmer.harvestBlock(farm, bc, block, state);
   }
 
 }


### PR DESCRIPTION
Actually EnderIO's farmer havresting Immersive Engineering's Industrial Hemp wrong: it harvest base block too (in addition to upper block). It causes re-plant loop and additional waiting time.

How it works now:
![screenshot 1](https://cloud.githubusercontent.com/assets/1416030/20411884/1f856be0-ad56-11e6-8262-2109ea97a7c7.png)

How it should works:
![screenshot 2](https://cloud.githubusercontent.com/assets/1416030/20411889/2a57946c-ad56-11e6-9872-ca3d635c293c.png)
![screenshot 3](https://cloud.githubusercontent.com/assets/1416030/20411890/2a71b504-ad56-11e6-8ffc-b59e0d3a9cf3.png)
