### PR TITLE
Rewrite LootManager to use a standard Loot Table. Closes #3927

### DIFF
--- a/src/main/java/crazypants/enderio/LootManager.java
+++ b/src/main/java/crazypants/enderio/LootManager.java
@@ -65,82 +65,105 @@ public class LootManager {
 
     if (evt.getName().equals(LootTableList.CHESTS_SIMPLE_DUNGEON)) {
 
-        lp.addEntry(createLootEntry(itemAlloy.getItem(), Alloy.DARK_STEEL.ordinal(), 1, 3, 25, Config.lootDarkSteel));
-        lp.addEntry(createLootEntry(itemConduitProbe.getItem(), 10, Config.lootItemConduitProbe));
-        lp.addEntry(createLootEntry(Items.QUARTZ, 3, 16, 25, Config.lootQuartz));
-        lp.addEntry(createLootEntry(Items.NETHER_WART, 1, 4, 20, Config.lootNetherWart));
-        lp.addEntry(createLootEntry(Items.ENDER_PEARL, 1, 2, 30, Config.lootEnderPearl));
-        lp.addEntry(createLootEntry(DarkSteelItems.itemDarkSteelSword, 10, Config.lootTheEnder));
-        lp.addEntry(createLootEntry(DarkSteelItems.itemDarkSteelBoots, 10, Config.lootDarkSteelBoots));
-        lp.addEntry(createLootCapacitor(15, true));
-        lp.addEntry(createLootCapacitor(15, true));
-        lp.addEntry(createLootCapacitor(15, true));
-        //175
-    } else if (evt.getName().equals(LootTableList.CHESTS_VILLAGE_BLACKSMITH)) {
-    	
-        lp.addEntry(createLootEntry(itemAlloy.getItem(), Alloy.ELECTRICAL_STEEL.ordinal(), 2, 6, 20, Config.lootElectricSteel));
-        lp.addEntry(createLootEntry(itemAlloy.getItem(), Alloy.REDSTONE_ALLOY.ordinal(), 3, 6, 35, Config.lootRedstoneAlloy));
-        lp.addEntry(createLootEntry(itemAlloy.getItem(), Alloy.DARK_STEEL.ordinal(), 3, 6, 35, Config.lootDarkSteel));
-        lp.addEntry(createLootEntry(itemAlloy.getItem(), Alloy.PULSATING_IRON.ordinal(), 1, 2, 30, Config.lootPhasedIron));
-        lp.addEntry(createLootEntry(itemAlloy.getItem(), Alloy.VIBRANT_ALLOY.ordinal(), 1, 2, 20, Config.lootPhasedGold));
-        lp.addEntry(createLootEntry(DarkSteelItems.itemDarkSteelSword, 1, 1, 25, Config.lootTheEnder));
-        lp.addEntry(createLootEntry(DarkSteelItems.itemDarkSteelBoots, 1, 1, 25, Config.lootDarkSteelBoots));
-        lp.addEntry(createLootCapacitor(10, true));
-        //200
-    } else if (evt.getName().equals(LootTableList.CHESTS_DESERT_PYRAMID)) {
+        if (Config.lootDarkSteel) {
+          lp.addEntry(createLootEntry(itemAlloy.getItem(), Alloy.DARK_STEEL.ordinal(), 1, 3, 0.25F));
+        }
+        if (Config.lootItemConduitProbe) {
+          lp.addEntry(createLootEntry(itemConduitProbe.getItem(), 0.10F));
+        }
+        if (Config.lootQuartz) {
+          lp.addEntry(createLootEntry(Items.QUARTZ, 3, 16, 0.25F));
+        }
+        if (Config.lootNetherWart) {
+          lp.addEntry(createLootEntry(Items.NETHER_WART, 1, 4, 0.20F));
+        }
+        if (Config.lootEnderPearl) {
+          lp.addEntry(createLootEntry(Items.ENDER_PEARL, 1, 2, 0.30F));
+        }
+        if (Config.lootTheEnder) {
+          lp.addEntry(createLootEntry(DarkSteelItems.itemDarkSteelSword, 0.1F));
+        }
+        if (Config.lootDarkSteelBoots) {
+          lp.addEntry(createLootEntry(DarkSteelItems.itemDarkSteelBoots, 0.1F));
+        }
+        lp.addEntry(createLootCapacitor(0.15F));
+        lp.addEntry(createLootCapacitor(0.15F));
+        lp.addEntry(createLootCapacitor(0.15F));
 
-        lp.addEntry(createLootEntry(DarkSteelItems.itemDarkSteelSword, 20, Config.lootTheEnder));
-        lp.addEntry(createLootEntry(itemTravelStaff.getItem(), 10, Config.lootTravelStaff));
-        lp.addEntry(createLootCapacitor(25, true));
-    } else if (evt.getName().equals(LootTableList.CHESTS_JUNGLE_TEMPLE)) {
+      } else if (evt.getName().equals(LootTableList.CHESTS_VILLAGE_BLACKSMITH)) {
 
-        lp.addEntry(createLootEntry(DarkSteelItems.itemDarkSteelSword, 1, 1, 25, Config.lootTheEnder));
-        lp.addEntry(createLootEntry(itemTravelStaff.getItem(), 1, 1, 10, Config.lootTravelStaff));
-        lp.addEntry(createLootCapacitor(25, true));
-      	lp.addEntry(createLootCapacitor(25, true));
-    }
+        if (Config.lootElectricSteel) {
+          lp.addEntry(createLootEntry(itemAlloy.getItem(), Alloy.ELECTRICAL_STEEL.ordinal(), 2, 6, 0.20F));
+        }
+        if (Config.lootRedstoneAlloy) {
+          lp.addEntry(createLootEntry(itemAlloy.getItem(), Alloy.REDSTONE_ALLOY.ordinal(), 3, 6, 0.35F));
+        }
+        if (Config.lootDarkSteel) {
+          lp.addEntry(createLootEntry(itemAlloy.getItem(), Alloy.DARK_STEEL.ordinal(), 3, 6, 0.35F));
+        }
+        if (Config.lootPhasedIron) {
+          lp.addEntry(createLootEntry(itemAlloy.getItem(), Alloy.PULSATING_IRON.ordinal(), 1, 2, 0.3F));
+        }
+        if (Config.lootPhasedGold) {
+          lp.addEntry(createLootEntry(itemAlloy.getItem(), Alloy.VIBRANT_ALLOY.ordinal(), 1, 2, 0.2F));
+        }
+        if (Config.lootTheEnder) {
+          lp.addEntry(createLootEntry(DarkSteelItems.itemDarkSteelSword, 1, 1, 0.25F));
+        }
+        if (Config.lootDarkSteelBoots) {
+          lp.addEntry(createLootEntry(DarkSteelItems.itemDarkSteelBoots, 1, 1, 0.25F));
+        }
+        lp.addEntry(createLootCapacitor(0.1F));
+
+      } else if (evt.getName().equals(LootTableList.CHESTS_DESERT_PYRAMID)) {
+
+        if (Config.lootTheEnder) {
+          lp.addEntry(createLootEntry(DarkSteelItems.itemDarkSteelSword, 0.2F));
+        }
+        if (Config.lootTravelStaff) {
+          lp.addEntry(createLootEntry(itemTravelStaff.getItem(), 0.1F));
+        }
+        lp.addEntry(createLootCapacitor(25));
+
+      } else if (evt.getName().equals(LootTableList.CHESTS_JUNGLE_TEMPLE)) {
+
+        if (Config.lootTheEnder) {
+          lp.addEntry(createLootEntry(DarkSteelItems.itemDarkSteelSword, 1, 1, 0.25F));
+        }
+        if (Config.lootTravelStaff) {
+          lp.addEntry(createLootEntry(itemTravelStaff.getItem(), 1, 1, 0.1F));
+        }
+        lp.addEntry(createLootCapacitor(0.25F));
+        lp.addEntry(createLootCapacitor(0.25F));
+      }
     table.addPool(lp); 
   }
   
-  //Each loot entry in a pool must have a unique name
-  private int emptyCount = 0;
-  private LootEntry createLootEntry(Item item, int chance, boolean enabled) {
-	  return createLootEntry(item, 1, 1, chance, enabled);
+  private LootEntry createLootEntry(Item item, float chance) {
+	  return createLootEntry(item, 1, 1, chance);
   }
 
-  private LootEntry createLootEntry(Item item, int minSize, int maxSize, int chance, boolean enabled) {
-    return createLootEntry(item, 0, minSize, maxSize, chance, enabled);
+  private LootEntry createLootEntry(Item item, int minSize, int maxSize, float chance) {
+    return createLootEntry(item, 0, minSize, maxSize, chance);
   }
-
-  /**If enabled is true, an empty loot entry of the same weight is added.
-   *This maintains the generation probabilities of other EIO loot.
-   * Without this, disabling loot in the config would change the generation probabilities of other loot. 
-   **/
-  private LootEntry createLootEntry(Item item, int ordinal, int minStackSize, int maxStackSize, int chance, boolean enabled) {
-	  if(!enabled) {
-		  emptyCount++;
-		  return new LootEntryEmpty(chance, 1, NO_CONDITIONS, "empty" + emptyCount);
-	  }
+  
+  /*
+   * All loot entries are given the same weight, the generation probabilities depend on the RandomChance condition. 
+   */
+  private LootEntry createLootEntry(Item item, int ordinal, int minStackSize, int maxStackSize, float chance) {
+	  LootCondition[] chanceCond = new LootCondition[]{new RandomChance(chance)};
 	  if(item.isDamageable()) {
-		  return new LootEntryItem(item, 1, 1, new LootFunction[]{setCount(minStackSize, maxStackSize), setDamage(ordinal)}, NO_CONDITIONS, item.getRegistryName().toString() + ":" + ordinal);
+		  return new LootEntryItem(item, 1, 1, new LootFunction[]{setCount(minStackSize, maxStackSize), setDamage(ordinal)}, chanceCond, item.getRegistryName().toString() + ":" + ordinal);
 	  }
 	  else {
-		  return new LootEntryItem(item, 1, 1, new LootFunction[]{setCount(minStackSize, maxStackSize), setMetadata(ordinal)}, NO_CONDITIONS, item.getRegistryName().toString() + "|empty:" + ordinal);  
+		  return new LootEntryItem(item, 1, 1, new LootFunction[]{setCount(minStackSize, maxStackSize), setMetadata(ordinal)}, chanceCond, item.getRegistryName().toString() + ":" + ordinal);  
 	  }
   }
   
   int capCount = 0; //Each loot entry in a pool must have a unique name
-  /**If enabled is true an empty loot entry of the same weight is added.
-  *This maintains the generation probabilities of other EIO loot.
-  * Without this, disabling loot in the config would change the generation probabilities of other loot. 
-  **/
-  private LootEntry createLootCapacitor(int weight, boolean enabled) {
-	  if(!enabled) {
-		  return new LootEntryEmpty(weight, 1, NO_CONDITIONS, "empty" + emptyCount);
-		  
-	  }
+  private LootEntry createLootCapacitor(float chance) {
 	  capCount++;
-	  return new LootEntryItem(itemBasicCapacitor.getItem(), weight, 1, new LootFunction[]{ls, setMetadata(3)}, NO_CONDITIONS, itemBasicCapacitor.getItem().getRegistryName().toString() + capCount);
+	  return new LootEntryItem(itemBasicCapacitor.getItem(), 1, 1, new LootFunction[]{ls, setMetadata(3)}, new LootCondition[]{new RandomChance(chance)}, itemBasicCapacitor.getItem().getRegistryName().toString() + capCount);
   }
 	
   private SetCount setCount(int min, int max) {

--- a/src/main/java/crazypants/enderio/LootManager.java
+++ b/src/main/java/crazypants/enderio/LootManager.java
@@ -1,25 +1,14 @@
 package crazypants.enderio;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.Random;
-
 import crazypants.enderio.capacitor.LootSelector;
 import crazypants.enderio.config.Config;
 import crazypants.enderio.item.darksteel.DarkSteelItems;
 import crazypants.enderio.material.Alloy;
-import crazypants.util.Prep;
 import net.minecraft.init.Items;
 import net.minecraft.item.Item;
-import net.minecraft.item.ItemStack;
-import net.minecraft.world.storage.loot.LootContext;
-import net.minecraft.world.storage.loot.LootEntry;
-import net.minecraft.world.storage.loot.LootPool;
-import net.minecraft.world.storage.loot.LootTable;
-import net.minecraft.world.storage.loot.LootTableList;
-import net.minecraft.world.storage.loot.RandomValueRange;
-import net.minecraft.world.storage.loot.conditions.LootCondition;
+import net.minecraft.world.storage.loot.*;
+import net.minecraft.world.storage.loot.functions.*;
+import net.minecraft.world.storage.loot.conditions.*;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.LootTableLoadEvent;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
@@ -57,7 +46,7 @@ public class LootManager {
 //  return EnumActionResult.PASS;
 //}
 
-  
+  private static final LootCondition[] NO_CONDITIONS = new LootCondition[0];
   private static LootManager INSTANCE = new LootManager();
 
   public static void register() {
@@ -72,181 +61,99 @@ public class LootManager {
 
     LootTable table = evt.getTable();
 
-    InnerPool lp = new InnerPool();
+    LootPool lp = new LootPool(new LootEntry[0], NO_CONDITIONS, new RandomValueRange(1, 3), new RandomValueRange(0, 0), EnderIO.MOD_NAME);
 
     if (evt.getName().equals(LootTableList.CHESTS_SIMPLE_DUNGEON)) {
 
-      if (Config.lootDarkSteel) {
-        lp.addItem(createLootEntry(itemAlloy.getItem(), Alloy.DARK_STEEL.ordinal(), 1, 3, 0.25));
-      }
-      if (Config.lootItemConduitProbe) {
-        lp.addItem(createLootEntry(itemConduitProbe.getItem(), 0.10));
-      }
-      if (Config.lootQuartz) {
-        lp.addItem(createLootEntry(Items.QUARTZ, 3, 16, 0.25));
-      }
-      if (Config.lootNetherWart) {
-        lp.addItem(createLootEntry(Items.NETHER_WART, 1, 4, 0.20));
-      }
-      if (Config.lootEnderPearl) {
-        lp.addItem(createLootEntry(Items.ENDER_PEARL, 1, 2, 0.30));
-      }
-      if (Config.lootTheEnder) {
-        lp.addItem(createLootEntry(DarkSteelItems.itemDarkSteelSword, 0.1));
-      }
-      if (Config.lootDarkSteelBoots) {
-        lp.addItem(createLootEntry(DarkSteelItems.itemDarkSteelBoots, 0.1));
-      }
-      lp.addItem(createLootCapacitor(0.15));
-      lp.addItem(createLootCapacitor(0.15));
-      lp.addItem(createLootCapacitor(0.15));
-
+        lp.addEntry(createLootEntry(itemAlloy.getItem(), Alloy.DARK_STEEL.ordinal(), 1, 3, 25, Config.lootDarkSteel));
+        lp.addEntry(createLootEntry(itemConduitProbe.getItem(), 10, Config.lootItemConduitProbe));
+        lp.addEntry(createLootEntry(Items.QUARTZ, 3, 16, 25, Config.lootQuartz));
+        lp.addEntry(createLootEntry(Items.NETHER_WART, 1, 4, 20, Config.lootNetherWart));
+        lp.addEntry(createLootEntry(Items.ENDER_PEARL, 1, 2, 30, Config.lootEnderPearl));
+        lp.addEntry(createLootEntry(DarkSteelItems.itemDarkSteelSword, 10, Config.lootTheEnder));
+        lp.addEntry(createLootEntry(DarkSteelItems.itemDarkSteelBoots, 10, Config.lootDarkSteelBoots));
+        lp.addEntry(createLootCapacitor(15, true));
+        lp.addEntry(createLootCapacitor(15, true));
+        lp.addEntry(createLootCapacitor(15, true));
+        //175
     } else if (evt.getName().equals(LootTableList.CHESTS_VILLAGE_BLACKSMITH)) {
-
-      if (Config.lootElectricSteel) {
-        lp.addItem(createLootEntry(itemAlloy.getItem(), Alloy.ELECTRICAL_STEEL.ordinal(), 2, 6, 0.20));
-      }
-      if (Config.lootRedstoneAlloy) {
-        lp.addItem(createLootEntry(itemAlloy.getItem(), Alloy.REDSTONE_ALLOY.ordinal(), 3, 6, 0.35));
-      }
-      if (Config.lootDarkSteel) {
-        lp.addItem(createLootEntry(itemAlloy.getItem(), Alloy.DARK_STEEL.ordinal(), 3, 6, 0.35));
-      }
-      if (Config.lootPhasedIron) {
-        lp.addItem(createLootEntry(itemAlloy.getItem(), Alloy.PULSATING_IRON.ordinal(), 1, 2, 0.3));
-      }
-      if (Config.lootPhasedGold) {
-        lp.addItem(createLootEntry(itemAlloy.getItem(), Alloy.VIBRANT_ALLOY.ordinal(), 1, 2, 0.2));
-      }
-      if (Config.lootTheEnder) {
-        lp.addItem(createLootEntry(DarkSteelItems.itemDarkSteelSword, 1, 1, 0.25));
-      }
-      if (Config.lootDarkSteelBoots) {
-        lp.addItem(createLootEntry(DarkSteelItems.itemDarkSteelBoots, 1, 1, 0.25));
-      }
-      lp.addItem(createLootCapacitor(0.1));
-
+    	
+        lp.addEntry(createLootEntry(itemAlloy.getItem(), Alloy.ELECTRICAL_STEEL.ordinal(), 2, 6, 20, Config.lootElectricSteel));
+        lp.addEntry(createLootEntry(itemAlloy.getItem(), Alloy.REDSTONE_ALLOY.ordinal(), 3, 6, 35, Config.lootRedstoneAlloy));
+        lp.addEntry(createLootEntry(itemAlloy.getItem(), Alloy.DARK_STEEL.ordinal(), 3, 6, 35, Config.lootDarkSteel));
+        lp.addEntry(createLootEntry(itemAlloy.getItem(), Alloy.PULSATING_IRON.ordinal(), 1, 2, 30, Config.lootPhasedIron));
+        lp.addEntry(createLootEntry(itemAlloy.getItem(), Alloy.VIBRANT_ALLOY.ordinal(), 1, 2, 20, Config.lootPhasedGold));
+        lp.addEntry(createLootEntry(DarkSteelItems.itemDarkSteelSword, 1, 1, 25, Config.lootTheEnder));
+        lp.addEntry(createLootEntry(DarkSteelItems.itemDarkSteelBoots, 1, 1, 25, Config.lootDarkSteelBoots));
+        lp.addEntry(createLootCapacitor(10, true));
+        //200
     } else if (evt.getName().equals(LootTableList.CHESTS_DESERT_PYRAMID)) {
 
-      if (Config.lootTheEnder) {
-        lp.addItem(createLootEntry(DarkSteelItems.itemDarkSteelSword, 0.2));
-      }
-      if (Config.lootTravelStaff) {
-        lp.addItem(createLootEntry(itemTravelStaff.getItem(), 0.1));
-      }
-      lp.addItem(createLootCapacitor(25));
-
+        lp.addEntry(createLootEntry(DarkSteelItems.itemDarkSteelSword, 20, Config.lootTheEnder));
+        lp.addEntry(createLootEntry(itemTravelStaff.getItem(), 10, Config.lootTravelStaff));
+        lp.addEntry(createLootCapacitor(25, true));
     } else if (evt.getName().equals(LootTableList.CHESTS_JUNGLE_TEMPLE)) {
 
-      if (Config.lootTheEnder) {
-        lp.addItem(createLootEntry(DarkSteelItems.itemDarkSteelSword, 1, 1, 0.25));
-      }
-      if (Config.lootTravelStaff) {
-        lp.addItem(createLootEntry(itemTravelStaff.getItem(), 1, 1, 0.1));
-      }
-      lp.addItem(createLootCapacitor(0.25));
-      lp.addItem(createLootCapacitor(0.25));
+        lp.addEntry(createLootEntry(DarkSteelItems.itemDarkSteelSword, 1, 1, 25, Config.lootTheEnder));
+        lp.addEntry(createLootEntry(itemTravelStaff.getItem(), 1, 1, 10, Config.lootTravelStaff));
+        lp.addEntry(createLootCapacitor(25, true));
+      	lp.addEntry(createLootCapacitor(25, true));
     }
-    if (!lp.isEmpty()) {
-      table.addPool(lp);
-    }
-    
+    table.addPool(lp); 
+  }
+  
+  //Each loot entry in a pool must have a unique name
+  private int emptyCount = 0;
+  private LootEntry createLootEntry(Item item, int chance, boolean enabled) {
+	  return createLootEntry(item, 1, 1, chance, enabled);
   }
 
-  private LootItem createLootEntry(Item item, double chance) {
-    return new LootItem(new ItemStack(item), chance, 1, 1);
+  private LootEntry createLootEntry(Item item, int minSize, int maxSize, int chance, boolean enabled) {
+    return createLootEntry(item, 0, minSize, maxSize, chance, enabled);
   }
 
-  private LootItem createLootEntry(Item item, int minSize, int maxSize, double chance) {
-    return new LootItem(new ItemStack(item), chance, minSize, maxSize);
+  /**If enabled is true, an empty loot entry of the same weight is added.
+   *This maintains the generation probabilities of other EIO loot.
+   * Without this, disabling loot in the config would change the generation probabilities of other loot. 
+   **/
+  private LootEntry createLootEntry(Item item, int ordinal, int minStackSize, int maxStackSize, int chance, boolean enabled) {
+	  if(!enabled) {
+		  emptyCount++;
+		  return new LootEntryEmpty(chance, 1, NO_CONDITIONS, "empty" + emptyCount);
+	  }
+	  if(item.isDamageable()) {
+		  return new LootEntryItem(item, 1, 1, new LootFunction[]{setCount(minStackSize, maxStackSize), setDamage(ordinal)}, NO_CONDITIONS, item.getRegistryName().toString() + ":" + ordinal);
+	  }
+	  else {
+		  return new LootEntryItem(item, 1, 1, new LootFunction[]{setCount(minStackSize, maxStackSize), setMetadata(ordinal)}, NO_CONDITIONS, item.getRegistryName().toString() + "|empty:" + ordinal);  
+	  }
+  }
+  
+  int capCount = 0; //Each loot entry in a pool must have a unique name
+  /**If enabled is true an empty loot entry of the same weight is added.
+  *This maintains the generation probabilities of other EIO loot.
+  * Without this, disabling loot in the config would change the generation probabilities of other loot. 
+  **/
+  private LootEntry createLootCapacitor(int weight, boolean enabled) {
+	  if(!enabled) {
+		  return new LootEntryEmpty(weight, 1, NO_CONDITIONS, "empty" + emptyCount);
+		  
+	  }
+	  capCount++;
+	  return new LootEntryItem(itemBasicCapacitor.getItem(), weight, 1, new LootFunction[]{ls, setMetadata(3)}, NO_CONDITIONS, itemBasicCapacitor.getItem().getRegistryName().toString() + capCount);
+  }
+	
+  private SetCount setCount(int min, int max) {
+	  return new SetCount(NO_CONDITIONS, new RandomValueRange(min, min));
+  }
+  
+  private SetDamage setDamage(int damage) {
+	  return new SetDamage(NO_CONDITIONS, new RandomValueRange(damage));
+  }
+  
+  private SetMetadata setMetadata(int meta) {
+	  return new SetMetadata(NO_CONDITIONS, new RandomValueRange(meta));
   }
 
-  private LootItem createLootEntry(Item item, int ordinal, int minStackSize, int maxStackSize, double chance) {
-    return new LootItem(new ItemStack(item, 1, ordinal), chance, minStackSize, maxStackSize);
-  }
-
-  private LootItem createLootCapacitor(double weight) {
-    return new CapItem(weight);
-  }
-
-
-  private static LootSelector ls = new LootSelector(new LootCondition[0]);
-
-  private static class CapItem extends LootItem {
-
-    public CapItem(double chance) {
-      super(new ItemStack(itemBasicCapacitor.getItem(), 1, 3), chance);
-    }
-
-    @Override
-    public ItemStack createStack(Random rnd) {
-      ItemStack res = item.copy();
-      ls.apply(res, rnd, null);
-      return res;
-    }
-  }
-
-  private static class LootItem {
-
-    ItemStack item;
-    double chance;
-    int minSize;
-    int maxSize;
-
-    public LootItem(ItemStack item, double chance) {
-      this(item, chance, 1, 1);
-    }
-
-    public LootItem(ItemStack item, double chance, int minSize, int maxSize) {
-      this.item = item;
-      this.chance = chance;
-      this.minSize = minSize;
-      this.maxSize = maxSize;
-    }
-
-    public ItemStack createStack(Random rnd) {
-      int size = minSize;
-      if (maxSize > minSize) {
-        size += rnd.nextInt(maxSize - minSize + 1);
-      }
-
-      ItemStack result = item.copy();
-      result.stackSize = size;
-      return result;
-    }
-  }
-
-  private static class InnerPool extends LootPool {
-
-    private final List<LootItem> items = new ArrayList<LootItem>();
-
-    public InnerPool() {
-      super(new LootEntry[0], new LootCondition[0], new RandomValueRange(0, 0), new RandomValueRange(0, 0), EnderIO.MOD_NAME);
-    }
-
-    public boolean isEmpty() {
-      return items.isEmpty();
-    }
-
-    public void addItem(LootItem entry) {
-      if (entry != null) {
-        items.add(entry);
-      }
-
-    }
-
-    @Override
-    public void generateLoot(Collection<ItemStack> stacks, Random rand, LootContext context) {
-      for (LootItem entry : items) {
-        if (rand.nextDouble() < entry.chance) {
-          ItemStack stack = entry.createStack(rand);
-          if (Prep.isValid(stack)) {
-//            System.out.println("LootManager.InnerPool.generateLoot: Added " + stack.getDisplayName() + " " + stack);
-            stacks.add(stack);
-          }
-        }
-      }
-    }
-  }
-
+  private static LootSelector ls = new LootSelector(NO_CONDITIONS);
 }

--- a/src/main/java/crazypants/enderio/capacitor/LootSelector.java
+++ b/src/main/java/crazypants/enderio/capacitor/LootSelector.java
@@ -21,6 +21,7 @@ import net.minecraft.util.WeightedRandom;
 import net.minecraft.world.storage.loot.LootContext;
 import net.minecraft.world.storage.loot.conditions.LootCondition;
 import net.minecraft.world.storage.loot.functions.LootFunction;
+import net.minecraft.world.storage.loot.functions.LootFunctionManager;
 
 public class LootSelector extends LootFunction {
   public LootSelector(LootCondition[] conditionsIn) {
@@ -161,6 +162,10 @@ public class LootSelector extends LootFunction {
 
   private WeightedUpgrade getUpgrade(Random rand) {
     return WeightedRandom.getRandomItem(rand, WeightedUpgrade.getWeightedupgrades()).getUpgrade();
+  }
+
+  static {
+    LootFunctionManager.registerFunction(new Serializer());
   }
 
   public static class Serializer extends LootFunction.Serializer<LootSelector> {


### PR DESCRIPTION
See title. This fixes the issue discussed in #3927 
Loot weights will need to be adjusted as the loot weight system behaves differently to the previous probability based system. I tried to do this myself mathematically and failed due to differences between the two systems. The values will have to be adjusted by a process of guess and check, or something better if anyone knows of it.

A test world that can be used to easily test the loot tables can be found [here](https://drive.google.com/open?id=0B_IqTUgN98IXaVdjV0JtcFphZU0).
The world contains 4 buttons that each place a chest that uses one of the four loot tables modified by EnderIO.