### PR TITLE
Modified Molten Ender Teleport

### DIFF
--- a/src/main/java/crazypants/enderio/fluid/BlockFluidEio.java
+++ b/src/main/java/crazypants/enderio/fluid/BlockFluidEio.java
@@ -51,6 +51,7 @@ import net.minecraftforge.client.event.RenderBlockOverlayEvent;
 import net.minecraftforge.client.event.RenderBlockOverlayEvent.OverlayType;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.entity.living.LivingSpawnEvent;
+import net.minecraftforge.event.entity.living.EnderTeleportEvent;
 import net.minecraftforge.fluids.BlockFluidClassic;
 import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.IFluidBlock;
@@ -833,7 +834,15 @@ public class BlockFluidEio extends BlockFluidClassic {
         if (isClear(world, entity)) {
           entity.setPosition(origX, origY, origZ);
           if (entity instanceof EntityPlayerMP) {
-            ((EntityPlayerMP) entity).connection.setPlayerLocation(targetX, targetY, targetZ, entity.rotationYaw, entity.rotationPitch);
+            EnderTeleportEvent event = new EnderTeleportEvent((EntityPlayerMP) entity, targetX, targetY, targetZ, 0);
+            if (!MinecraftForge.EVENT_BUS.post(event)) {
+        		  ((EntityPlayerMP) entity).connection.setPlayerLocation(event.getTargetX(), event.getTargetY(), event.getTargetZ(), entity.rotationYaw, entity.rotationPitch);
+        	  }
+          } else if (entity instanceof EntityLiving) {
+        	  EnderTeleportEvent event = new EnderTeleportEvent((EntityLiving) entity, targetX, targetY, targetZ, 0);
+        	  if (!MinecraftForge.EVENT_BUS.post(event)) {
+        		  entity.setPositionAndUpdate(event.getTargetX(), event.getTargetY(), event.getTargetZ());
+        	  }
           } else {
             entity.setPositionAndRotation(targetX, targetY, targetZ, entity.rotationYaw, entity.rotationPitch);
           }

--- a/src/main/java/crazypants/enderio/fluid/BlockFluidEio.java
+++ b/src/main/java/crazypants/enderio/fluid/BlockFluidEio.java
@@ -836,13 +836,13 @@ public class BlockFluidEio extends BlockFluidClassic {
           if (entity instanceof EntityPlayerMP) {
             EnderTeleportEvent event = new EnderTeleportEvent((EntityPlayerMP) entity, targetX, targetY, targetZ, 0);
             if (!MinecraftForge.EVENT_BUS.post(event)) {
-        		  ((EntityPlayerMP) entity).connection.setPlayerLocation(event.getTargetX(), event.getTargetY(), event.getTargetZ(), entity.rotationYaw, entity.rotationPitch);
+              ((EntityPlayerMP) entity).connection.setPlayerLocation(event.getTargetX(), event.getTargetY(), event.getTargetZ(), entity.rotationYaw, entity.rotationPitch);
         	  }
           } else if (entity instanceof EntityLiving) {
-        	  EnderTeleportEvent event = new EnderTeleportEvent((EntityLiving) entity, targetX, targetY, targetZ, 0);
-        	  if (!MinecraftForge.EVENT_BUS.post(event)) {
-        		  entity.setPositionAndUpdate(event.getTargetX(), event.getTargetY(), event.getTargetZ());
-        	  }
+            EnderTeleportEvent event = new EnderTeleportEvent((EntityLiving) entity, targetX, targetY, targetZ, 0);
+            if (!MinecraftForge.EVENT_BUS.post(event)) {
+              entity.setPositionAndUpdate(event.getTargetX(), event.getTargetY(), event.getTargetZ());
+            }
           } else {
             entity.setPositionAndRotation(targetX, targetY, targetZ, entity.rotationYaw, entity.rotationPitch);
           }


### PR DESCRIPTION
Modified the teleportation for molten ender to trigger an event as if an ender pearl has been thrown for the teleportation of a mob/player. I did this mainly to work with the Dark Utils Ender Tether as it adjusts the teleport destination based on the EnderTeleportEvent. Teleport still behaves as normal and random if there is nothing that intercepts the event.