### PR TITLE
Request - Check ToolUtil for equipped tool rather than just YetaWrench Item

### DIFF
--- a/src/main/java/crazypants/enderio/conduit/BlockConduitBundle.java
+++ b/src/main/java/crazypants/enderio/conduit/BlockConduitBundle.java
@@ -644,7 +644,7 @@ public class BlockConduitBundle extends BlockEio<TileConduitBundle> implements I
   @Override
   public void onBlockClicked(World world, BlockPos pos, EntityPlayer player) {
     ItemStack equipped = player.getHeldItemMainhand();
-    if (!player.isSneaking() || equipped == null || equipped.getItem() != itemYetaWrench.getItem()) {
+    if (!player.isSneaking() || equipped == null || !ToolUtil.isToolEquipped(player, EnumHand.MAIN_HAND)) {
       return;
     }
     ConduitUtil.openConduitGui(world, pos, player);


### PR DESCRIPTION
When Crouch-Left-Clicking conduit bundles to get the GUI up, it only checks for a Yeta wrench, is it acceptable to extend this to all ITool implementations?

I've implemented ITool on my item and would really love to have this functionality (beyond waiting for the block to finish breaking in survival before I cancel it and manually bring up the GUI).