### PR TITLE
Implement vanilla TileEntity rotation/mirroring functions

### DIFF
--- a/src/main/java/crazypants/enderio/machine/AbstractMachineEntity.java
+++ b/src/main/java/crazypants/enderio/machine/AbstractMachineEntity.java
@@ -32,7 +32,9 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.EnumFacing;
+import net.minecraft.util.Mirror;
 import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.Rotation;
 import net.minecraft.world.World;
 import net.minecraftforge.fml.client.FMLClientHandler;
 import net.minecraftforge.fml.relauncher.Side;
@@ -156,6 +158,44 @@ public abstract class AbstractMachineEntity extends TileEntityEio
   public void setFacing(EnumFacing facing) {
     this.facing = facing == null ? EnumFacing.SOUTH : facing;
     markDirty();
+  }
+
+  // TileEntity.rotate(Rotation)
+  @Override
+  public void func_189667_a(final Rotation rotation) {
+    if (rotation == Rotation.NONE) {
+      return;
+    }
+    setFacing(rotation.rotate(getFacing()));
+    if (faceModes != null) {
+      Map<EnumFacing, IoMode> rotatedFaceModes = new EnumMap<EnumFacing, IoMode>(EnumFacing.class);
+      for (final EnumFacing side : faceModes.keySet()) {
+        rotatedFaceModes.put(rotation.rotate(side), faceModes.get(side));
+      }
+      faceModes = rotatedFaceModes;
+    }
+    forceClientUpdate.set();
+    notifyNeighbours = true;
+    updateBlock();
+  }
+
+  // TileEntity.mirror(Mirror)
+  @Override
+  public void func_189668_a(final Mirror mirror) {
+    if (mirror == Mirror.NONE) {
+      return;
+    }
+    setFacing(mirror.mirror(getFacing()));
+    if (faceModes != null) {
+      Map<EnumFacing, IoMode> mirroredFaceModes = new EnumMap<EnumFacing, IoMode>(EnumFacing.class);
+      for (final EnumFacing side : faceModes.keySet()) {
+        mirroredFaceModes.put(mirror.mirror(side), faceModes.get(side));
+      }
+      faceModes = mirroredFaceModes;
+    }
+    forceClientUpdate.set();
+    notifyNeighbours = true;
+    updateBlock();
   }
 
   public abstract boolean isActive();

--- a/src/main/java/crazypants/enderio/teleport/telepad/DialerFacing.java
+++ b/src/main/java/crazypants/enderio/teleport/telepad/DialerFacing.java
@@ -2,6 +2,8 @@ package crazypants.enderio.teleport.telepad;
 
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.IStringSerializable;
+import net.minecraft.util.Mirror;
+import net.minecraft.util.Rotation;
 
 import static net.minecraft.util.EnumFacing.DOWN;
 import static net.minecraft.util.EnumFacing.EAST;
@@ -70,4 +72,35 @@ public enum DialerFacing implements IStringSerializable {
     return EnumFacing.values()[ordinal() / 4];
   }
 
+  public DialerFacing rotate(final Rotation rotation) {
+    switch (getSide()) {
+      case UP:
+      case DOWN:
+        return values()[(this.ordinal() / 4) * 4 + rotation.rotate(getInputSide()).ordinal() - 2];
+      default:
+        switch (getInputSide()) {
+          case UP:
+          case DOWN:
+            return values()[rotation.rotate(getSide()).ordinal() * 4 + getMeta()];
+          default:
+            return values()[rotation.rotate(getSide()).ordinal() * 4 + rotation.rotate(getInputSide()).ordinal() % 2];
+        }
+    }
+  }
+
+  public DialerFacing mirror(final Mirror mirror) {
+    switch (getSide()) {
+      case UP:
+      case DOWN:
+        return values()[(this.ordinal() / 4) * 4 + mirror.mirror(getInputSide()).ordinal() - 2];
+      default:
+        switch (getInputSide()) {
+          case UP:
+          case DOWN:
+            return values()[mirror.mirror(getSide()).ordinal() * 4 + getMeta()];
+          default:
+            return values()[mirror.mirror(getSide()).ordinal() * 4 + mirror.mirror(getInputSide()).ordinal() % 2];
+        }
+    }
+  }
 }

--- a/src/main/java/crazypants/enderio/teleport/telepad/TileDialingDevice.java
+++ b/src/main/java/crazypants/enderio/teleport/telepad/TileDialingDevice.java
@@ -14,6 +14,8 @@ import crazypants.enderio.teleport.telepad.packet.PacketTargetList;
 import info.loenwind.autosave.annotations.Store;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.EnumFacing;
+import net.minecraft.util.Mirror;
+import net.minecraft.util.Rotation;
 import net.minecraft.util.math.MathHelper;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.items.CapabilityItemHandler;
@@ -222,6 +224,24 @@ public class TileDialingDevice extends TileEntityEio implements IInternalPowerRe
   public void setFacing(DialerFacing facing) {
     this.facing = facing;
     markDirty();
+  }
+
+  // TileEntity.rotate(Rotation)
+  @Override
+  public void func_189667_a(final Rotation rotation) {
+    if (rotation == Rotation.NONE) {
+      return;
+    }
+    setFacing(getFacing().rotate(rotation));
+  }
+
+  // TileEntity.mirror(Mirror)
+  @Override
+  public void func_189668_a(final Mirror mirror) {
+    if (mirror == Mirror.NONE) {
+      return;
+    }
+    setFacing(getFacing().mirror(mirror));
   }
 
   public int getPowerScaled(int scale) {


### PR DESCRIPTION
This implements the vanilla rotate/mirror methods in TileEntities that are rotatable. This allows mods that want to rotate blocks to do so without additional special code.