### PR TITLE
Fix Combustion Generator updating (Fixes #4396)

### DIFF
--- a/src/main/java/crazypants/enderio/machines/machine/generator/combustion/BlockCombustionGenerator.java
+++ b/src/main/java/crazypants/enderio/machines/machine/generator/combustion/BlockCombustionGenerator.java
@@ -194,6 +194,8 @@ public class BlockCombustionGenerator<T extends TileCombustionGenerator> extends
         }
       }
     }
+    
+    super.neighborChanged(state, world, pos, blockIn, fromPos);
   }
 
 }


### PR DESCRIPTION
Fixes the issue where the Combustion Generator tile entity was not receiving neighbor updates (neighborChanged) not being called.