### PR TITLE
Fixed pickaxe interrupting while charging

### DIFF
--- a/src/main/java/crazypants/enderio/base/item/darksteel/ItemDarkSteelPickaxe.java
+++ b/src/main/java/crazypants/enderio/base/item/darksteel/ItemDarkSteelPickaxe.java
@@ -411,4 +411,32 @@ public class ItemDarkSteelPickaxe extends ItemPickaxe implements IAdvancedToolti
     }
   }
 
+  @Override
+  public boolean shouldCauseBlockBreakReset(ItemStack oldStack, ItemStack newStack) {
+    // This is the offending method, there are a few things going on here to make sure we don't break anything.
+    // The vanilla behavior is to reset the "block break" on item change and/or metadata change and/or NBT change
+    // since we use NBT to store the energy value, when a wireless charger updates the NBT the default behavior
+    // will reset progress.
+    // So first thing first, if by vanilla standards it's ok to keep going, keep going
+    if (!super.shouldCauseBlockBreakReset(oldStack, newStack))
+      return false;
+    
+    // Make sure the only difference is in NBT
+    if (oldStack.isEmpty() != newStack.isEmpty() || oldStack.hasTagCompound() != newStack.hasTagCompound())
+      return true;
+    
+    boolean isDifferentItem = newStack.getItem() != oldStack.getItem();
+    boolean isDifferentMeta = newStack.isItemStackDamageable() && newStack.getMetadata() != oldStack.getMetadata(); 
+    if (isDifferentItem || isDifferentMeta)
+      return true;
+    
+    // Here comes the tricky part, in theory we could totally ignore NBT but that could cause problems
+    // and honestly will be an ugly hack. Instead we'll use a deep comparer that ignores the energy
+    // tag.
+    if (!oldStack.hasTagCompound() && !newStack.hasTagCompound())
+      return false;
+    
+    return !EnergyUpgradeManager.compareNbt(oldStack.getTagCompound(), newStack.getTagCompound());
+  }
+  
 }

--- a/src/main/java/crazypants/enderio/base/item/darksteel/upgrade/energy/EnergyUpgradeManager.java
+++ b/src/main/java/crazypants/enderio/base/item/darksteel/upgrade/energy/EnergyUpgradeManager.java
@@ -7,7 +7,9 @@ import javax.annotation.Nonnull;
 import crazypants.enderio.base.handler.darksteel.AbstractUpgrade;
 import crazypants.enderio.base.item.darksteel.upgrade.energy.EnergyUpgrade.EnergyUpgradeHolder;
 import crazypants.enderio.base.lang.LangPower;
+import crazypants.enderio.util.NbtComparer;
 import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
 
 public abstract class EnergyUpgradeManager {
 
@@ -15,6 +17,15 @@ public abstract class EnergyUpgradeManager {
   protected static final @Nonnull String KEY_ENERGY = "energy";
   protected static final @Nonnull Random RANDOM = new Random();
 
+ // Should this really be here.
+ // TODO: Consider refactoring in the future
+ private static final NbtComparer energyInvarientNbtComparer;
+
+ static {
+   energyInvarientNbtComparer = new NbtComparer();
+   energyInvarientNbtComparer.addInvarientTagKey(EnergyUpgradeManager.KEY_ENERGY);
+ }
+  
   public static EnergyUpgrade.EnergyUpgradeHolder loadFromItem(@Nonnull ItemStack stack) {
     EnergyUpgrade energyUpgrade = EnergyUpgrade.loadAnyFromItem(stack);
     return energyUpgrade != null ? energyUpgrade.getEnergyUpgradeHolder(stack) : null;
@@ -102,6 +113,10 @@ public abstract class EnergyUpgradeManager {
       return 0;
     }
     return eu.getCapacity();
+  }
+  
+  public static boolean compareNbt(NBTTagCompound oldNbt, NBTTagCompound newNbt) {
+    return energyInvarientNbtComparer.compare(oldNbt, newNbt);
   }
 
 }

--- a/src/main/java/crazypants/enderio/util/NbtComparer.java
+++ b/src/main/java/crazypants/enderio/util/NbtComparer.java
@@ -1,0 +1,52 @@
+package crazypants.enderio.util;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import net.minecraft.nbt.NBTBase;
+import net.minecraft.nbt.NBTTagCompound;
+
+public class NbtComparer {
+	private final HashSet<String> invarientTagsKeys;
+	
+	public NbtComparer() {
+		this.invarientTagsKeys = new HashSet<>();
+	}
+	
+	public void addInvarientTagKey(String tagKey) {
+	  this.invarientTagsKeys.add(tagKey);
+	}
+	
+	public boolean removeInvarientTagKey(String tagKey) {
+	  return this.invarientTagsKeys.remove(tagKey);
+	}
+	
+	public boolean compare(NBTTagCompound left, NBTTagCompound right) {
+	  if (left == right) // reference equality
+	    return true;
+	  
+	  // I can't imagine NBT trees being deep enough to cause StackOverflow
+	  Set<String> leftKeys = left.getKeySet();
+	  Set<String> rightKeys = right.getKeySet();
+	  
+	  for (String key : leftKeys) {
+      if (this.invarientTagsKeys.contains(key))
+        continue;
+
+      if (!rightKeys.contains(key))
+        return false;
+      
+      if (!this.compareInternal(left.getTag(key), right.getTag(key)))
+        return false;
+    }
+	  
+	  return true;
+	}
+	
+	private boolean compareInternal(NBTBase left, NBTBase right) {
+	  if (left instanceof NBTTagCompound && right instanceof NBTTagCompound)
+	    return compare((NBTTagCompound)left, (NBTTagCompound)right);
+	  
+	  return left.equals(right);
+	}
+}


### PR DESCRIPTION
Fixed the issue where the pickaxe (or any other tool) will be interrupted while it's being charged by a wireless charger.
The issue was happening because the default behavior was to reset block break progress on and `ItemStack` change, that includes NBT which is used to store the tools' energy.

The current implementation tries to as strict as possible when it comes to resetting the progress. This is done by running a deep equality comparison of the old and new NBT trees while ignoring the `energy` key.

I'm not a big fan of the current state of things though, feel free to suggest a different approach.
What I had in mind was:
* Store the energy value on an internal variable and to (re)store it from/to NBT when needed. Not sure how to do this. And client-server sync may be a problem.
* Separate the upgrade entirely from the pick and use some sort of compose-able item proxy