### PR TITLE
Remove Name

### DIFF
--- a/resources/assets/enderio/lang/en_us.lang
+++ b/resources/assets/enderio/lang/en_us.lang
@@ -1,4 +1,4 @@
-itemGroup.enderio.machines=EnderIO Machines
+//Machines Lang
 
 enderio.gui.combustion_generator.output=Generating: %s
 enderio.gui.combustion_generator.coolantTank.empty=Coolant


### PR DESCRIPTION
Removed the creative tab name for the machines tab, so it can be put into the enderio base lang file. (where the code is that creates the creative tabs)