### PR TITLE
Fixed bad configuration ordering in build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -214,11 +214,13 @@ subprojects {
     build.dependsOn sourceJar, apiJar
 }
 
-configure(subprojects) {
-    minecraft {
-        replace '@VERSION@', project.version
-        replace 'DEFAULT_DEPENDENCIES;', "\"${project.dependencyString}\";"
-    }
+subprojects { sub ->
+	sub.evaluate()
+	
+	minecraft {
+		replace '@VERSION@', project.version
+		replace 'DEFAULT_DEPENDENCIES;', "\"${project.dependencyString}\";"
+	}
 }
 
 jar.doFirst {


### PR DESCRIPTION
Fixed a problem where the dependency replacement ran before the
replacement target was configured.