### PR TITLE
Modules now depend on each other

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -214,12 +214,15 @@ subprojects {
     build.dependsOn sourceJar, apiJar
 }
 
-subprojects { sub ->
-	sub.evaluate()
-	
+subprojects {
+	if (file('dependencies.gradle').exists())
+		apply from: 'dependencies.gradle'
+		
 	minecraft {
-		replace '@VERSION@', project.version
-		replace 'DEFAULT_DEPENDENCIES;', "\"${project.dependencyString}\";"
+		replace '@VERSION@', version
+		
+		if (project.hasProperty('dependencyString'))
+			replace 'DEFAULT_DEPENDENCIES;', "\"${dependencyString}\";"
 	}
 }
 

--- a/enderio-base/dependencies.gradle
+++ b/enderio-base/dependencies.gradle
@@ -1,0 +1,5 @@
+modDependencies {
+	forge { requireAfter(forge_version) }
+	endercore { requireAfter(endercore_version) }
+	jei { loadAfter(jei_version) }
+}

--- a/enderio-base/enderio-base.gradle
+++ b/enderio-base/enderio-base.gradle
@@ -21,9 +21,3 @@ dependencies {
 	compile "appeng:appliedenergistics2:${ae_version}:api"
 	compile "net.darkhax.tesla:Tesla:${tesla_version}"
 }
-
-modDependencies {
-	forge { requireAfter(forge_version) }
-	endercore { requireAfter(endercore_version) }
-	jei { loadAfter(jei_version) }
-}

--- a/enderio-base/gradle.properties
+++ b/enderio-base/gradle.properties
@@ -1,1 +1,2 @@
+module_mod_id=enderio
 include_in_build=true

--- a/enderio-conduits/dependencies.gradle
+++ b/enderio-conduits/dependencies.gradle
@@ -1,0 +1,12 @@
+modDependencies {
+	forge { requireAfter(forge_version) }
+	endercore { requireAfter(endercore_version) }
+	jei { loadAfter(jei_version) }
+}
+
+def localDependencies = project(':enderio-base')
+localDependencies.each { dep ->
+	modDependencies {
+		"${dep.module_mod_id}" { loadAfter(dep.version) }
+	}
+}

--- a/enderio-conduits/enderio-conduits.gradle
+++ b/enderio-conduits/enderio-conduits.gradle
@@ -1,9 +1,3 @@
 dependencies {
 	compile project(":enderio-base")
 }
-
-modDependencies {
-	forge { requireAfter(forge_version) }
-	endercore { requireAfter(endercore_version) }
-	jei { loadAfter(jei_version) }
-}

--- a/enderio-conduits/gradle.properties
+++ b/enderio-conduits/gradle.properties
@@ -1,1 +1,2 @@
+module_mod_id=enderioconduits
 include_in_build=false

--- a/enderio-invpanel/dependencies.gradle
+++ b/enderio-invpanel/dependencies.gradle
@@ -1,0 +1,13 @@
+modDependencies {
+	forge { requireAfter(forge_version) }
+	endercore { requireAfter(endercore_version) }
+	jei { loadAfter(jei_version) }
+}
+
+def localDependencies = [ project(':enderio-base'), project(':enderio-machines'), project(':enderio-conduits') ]
+localDependencies.each { dep ->
+	modDependencies {
+		"${dep.module_mod_id}" { loadAfter(dep.version) }
+	}
+}
+

--- a/enderio-invpanel/enderio-invpanel.gradle
+++ b/enderio-invpanel/enderio-invpanel.gradle
@@ -3,9 +3,3 @@ dependencies {
 	compile project(":enderio-machines")
 	compile project(":enderio-conduits")
 }
-
-modDependencies {
-	forge { requireAfter(forge_version) }
-	endercore { requireAfter(endercore_version) }
-	jei { loadAfter(jei_version) }
-}

--- a/enderio-invpanel/gradle.properties
+++ b/enderio-invpanel/gradle.properties
@@ -1,1 +1,2 @@
+module_mod_id=enderioinvpanel
 include_in_build=false

--- a/enderio-machines/dependencies.gradle
+++ b/enderio-machines/dependencies.gradle
@@ -1,0 +1,12 @@
+modDependencies {
+	forge { requireAfter(forge_version) }
+	endercore { requireAfter(endercore_version) }
+	jei { loadAfter(jei_version) }
+}
+
+def localDependencies = project(':enderio-base')
+localDependencies.each { dep ->
+	modDependencies {
+		"${dep.module_mod_id}" { loadAfter(dep.version) }
+	}
+}

--- a/enderio-machines/enderio-machines.gradle
+++ b/enderio-machines/enderio-machines.gradle
@@ -1,9 +1,3 @@
 dependencies {
 	compile project(":enderio-base")
 }
-
-modDependencies {
-	forge { requireAfter(forge_version) }
-	enderio { requireAfter(project(":enderio-base").version) }
-	jei { loadAfter(jei_version) }
-}

--- a/enderio-machines/gradle.properties
+++ b/enderio-machines/gradle.properties
@@ -1,1 +1,2 @@
+module_mod_id=enderiomachines
 include_in_build=true


### PR DESCRIPTION
Modified some project configuration ordering to allow modules to easily
depend on each other. Dependencies are now defined in
`dependencies.gradle'.