### PR TITLE
Revert hack to fix McJtyLib crashing us

### DIFF
--- a/enderio-base/src/main/java/crazypants/enderio/api/IMC.java
+++ b/enderio-base/src/main/java/crazypants/enderio/api/IMC.java
@@ -1,6 +1,6 @@
 package crazypants.enderio.api;
 
-import crazypants.enderio.api.redstone_dont_crash_us_mcjty.IRedstoneConnectable_dont_crash_us_mcjty;
+import crazypants.enderio.api.redstone.IRedstoneConnectable_dont_crash_us_mcjty;
 import crazypants.enderio.base.conduit.redstone.ConnectivityTool;
 import crazypants.enderio.base.config.Config;
 import crazypants.enderio.base.fluid.FluidFuelRegister;

--- a/enderio-base/src/main/java/crazypants/enderio/api/IMC.java
+++ b/enderio-base/src/main/java/crazypants/enderio/api/IMC.java
@@ -1,6 +1,6 @@
 package crazypants.enderio.api;
 
-import crazypants.enderio.api.redstone.IRedstoneConnectable_dont_crash_us_mcjty;
+import crazypants.enderio.api.redstone.IRedstoneConnectable;
 import crazypants.enderio.base.conduit.redstone.ConnectivityTool;
 import crazypants.enderio.base.config.Config;
 import crazypants.enderio.base.fluid.FluidFuelRegister;
@@ -82,7 +82,7 @@ public final class IMC {
 
   /**
    * Key for an string message to register a block as connectable to insulated redstone conduits. Calls {@link ConnectivityTool#registerRedstoneAware(String)}
-   * with the value of the message. The value has the same syntax that is used in the xml config files. Using {@link IRedstoneConnectable_dont_crash_us_mcjty}
+   * with the value of the message. The value has the same syntax that is used in the xml config files. Using {@link IRedstoneConnectable}
    * is generally preferred to this because it allows location-, state- and side-awareness.
    */
   public static final String REDSTONE_CONNECTABLE_ADD = "redstone:connectable:add";

--- a/enderio-base/src/main/java/crazypants/enderio/api/redstone/IRedstoneConnectable.java
+++ b/enderio-base/src/main/java/crazypants/enderio/api/redstone/IRedstoneConnectable.java
@@ -11,7 +11,7 @@ import net.minecraft.world.World;
  * <p>
  * Implementing on both is not recommended and will likely not work as expected.
  */
-public interface IRedstoneConnectable_dont_crash_us_mcjty {
+public interface IRedstoneConnectable {
 
   boolean shouldRedstoneConduitConnect(@Nonnull World world, @Nonnull BlockPos pos, @Nonnull EnumFacing from);
 

--- a/enderio-base/src/main/java/crazypants/enderio/api/redstone/IRedstoneConnectable_dont_crash_us_mcjty.java
+++ b/enderio-base/src/main/java/crazypants/enderio/api/redstone/IRedstoneConnectable_dont_crash_us_mcjty.java
@@ -1,4 +1,4 @@
-package crazypants.enderio.api.redstone_dont_crash_us_mcjty;
+package crazypants.enderio.api.redstone;
 
 import javax.annotation.Nonnull;
 

--- a/enderio-base/src/main/java/crazypants/enderio/api/redstone/package-info.java
+++ b/enderio-base/src/main/java/crazypants/enderio/api/redstone/package-info.java
@@ -1,5 +1,5 @@
 @API(apiVersion = EnderIOAPIProps.VERSION, owner = "enderio", provides = "enderioapi|redstone")
-package crazypants.enderio.api.redstone_dont_crash_us_mcjty;
+package crazypants.enderio.api.redstone;
 
 import crazypants.enderio.api.EnderIOAPIProps;
 import net.minecraftforge.fml.common.API;

--- a/enderio-base/src/main/java/crazypants/enderio/base/conduit/redstone/ConnectivityTool.java
+++ b/enderio-base/src/main/java/crazypants/enderio/base/conduit/redstone/ConnectivityTool.java
@@ -5,7 +5,7 @@ import javax.annotation.Nonnull;
 import com.enderio.core.common.BlockEnder;
 import com.enderio.core.common.util.stackable.Things;
 
-import crazypants.enderio.api.redstone.IRedstoneConnectable_dont_crash_us_mcjty;
+import crazypants.enderio.api.redstone.IRedstoneConnectable;
 import net.minecraft.block.Block;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.init.Blocks;
@@ -31,10 +31,10 @@ public class ConnectivityTool {
     if (state.getBlock().canConnectRedstone(state, world, pos, from) || shouldAutoConnectRedstone(state)) {
       return true;
     }
-    if (state.getBlock() instanceof IRedstoneConnectable_dont_crash_us_mcjty) {
-      return ((IRedstoneConnectable_dont_crash_us_mcjty) state.getBlock()).shouldRedstoneConduitConnect(world, pos, from);
+    if (state.getBlock() instanceof IRedstoneConnectable) {
+      return ((IRedstoneConnectable) state.getBlock()).shouldRedstoneConduitConnect(world, pos, from);
     }
-    IRedstoneConnectable_dont_crash_us_mcjty redstoneConnectable = BlockEnder.getAnyTileEntitySafe(world, pos, IRedstoneConnectable_dont_crash_us_mcjty.class);
+    IRedstoneConnectable redstoneConnectable = BlockEnder.getAnyTileEntitySafe(world, pos, IRedstoneConnectable.class);
     if (redstoneConnectable != null) {
       redstoneConnectable.shouldRedstoneConduitConnect(world, pos, from);
     }

--- a/enderio-base/src/main/java/crazypants/enderio/base/conduit/redstone/ConnectivityTool.java
+++ b/enderio-base/src/main/java/crazypants/enderio/base/conduit/redstone/ConnectivityTool.java
@@ -5,7 +5,7 @@ import javax.annotation.Nonnull;
 import com.enderio.core.common.BlockEnder;
 import com.enderio.core.common.util.stackable.Things;
 
-import crazypants.enderio.api.redstone_dont_crash_us_mcjty.IRedstoneConnectable_dont_crash_us_mcjty;
+import crazypants.enderio.api.redstone.IRedstoneConnectable_dont_crash_us_mcjty;
 import net.minecraft.block.Block;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.init.Blocks;

--- a/enderio-base/src/main/java/crazypants/enderio/base/machine/base/te/AbstractMachineEntity.java
+++ b/enderio-base/src/main/java/crazypants/enderio/base/machine/base/te/AbstractMachineEntity.java
@@ -11,7 +11,7 @@ import javax.annotation.Nullable;
 import com.enderio.core.common.NBTAction;
 import com.enderio.core.common.util.UserIdent;
 
-import crazypants.enderio.api.redstone_dont_crash_us_mcjty.IRedstoneConnectable_dont_crash_us_mcjty;
+import crazypants.enderio.api.redstone.IRedstoneConnectable_dont_crash_us_mcjty;
 import crazypants.enderio.base.TileEntityEio;
 import crazypants.enderio.base.capability.ItemTools.Limit;
 import crazypants.enderio.base.config.config.PersonalConfig;

--- a/enderio-base/src/main/java/crazypants/enderio/base/machine/base/te/AbstractMachineEntity.java
+++ b/enderio-base/src/main/java/crazypants/enderio/base/machine/base/te/AbstractMachineEntity.java
@@ -11,7 +11,7 @@ import javax.annotation.Nullable;
 import com.enderio.core.common.NBTAction;
 import com.enderio.core.common.util.UserIdent;
 
-import crazypants.enderio.api.redstone.IRedstoneConnectable_dont_crash_us_mcjty;
+import crazypants.enderio.api.redstone.IRedstoneConnectable;
 import crazypants.enderio.base.TileEntityEio;
 import crazypants.enderio.base.capability.ItemTools.Limit;
 import crazypants.enderio.base.config.config.PersonalConfig;
@@ -39,7 +39,7 @@ import net.minecraftforge.fml.relauncher.SideOnly;
 
 @Storable
 public abstract class AbstractMachineEntity extends TileEntityEio
-    implements IMachine, IRedstoneModeControlable, IRedstoneConnectable_dont_crash_us_mcjty, IIoConfigurable {
+    implements IMachine, IRedstoneModeControlable, IRedstoneConnectable, IIoConfigurable {
 
   private static final @Nonnull Limit PULL_PUSH_LIMIT = new Limit(1, 64);
 

--- a/enderio-conduits/src/main/java/crazypants/enderio/powertools/machine/capbank/BlockCapBank.java
+++ b/enderio-conduits/src/main/java/crazypants/enderio/powertools/machine/capbank/BlockCapBank.java
@@ -14,7 +14,7 @@ import com.enderio.core.common.util.NNList;
 import com.enderio.core.common.util.NullHelper;
 import com.enderio.core.common.vecmath.Vector3d;
 
-import crazypants.enderio.api.redstone.IRedstoneConnectable_dont_crash_us_mcjty;
+import crazypants.enderio.api.redstone.IRedstoneConnectable;
 import crazypants.enderio.base.BlockEio;
 import crazypants.enderio.base.gui.handler.IEioGuiHandler;
 import crazypants.enderio.base.init.IModObject;
@@ -71,7 +71,7 @@ import net.minecraftforge.fml.client.registry.ClientRegistry;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
-public class BlockCapBank extends BlockEio<TileCapBank> implements IEioGuiHandler.WithPos, IAdvancedTooltipProvider, IRedstoneConnectable_dont_crash_us_mcjty,
+public class BlockCapBank extends BlockEio<TileCapBank> implements IEioGuiHandler.WithPos, IAdvancedTooltipProvider, IRedstoneConnectable,
     ISmartRenderAwareBlock, IHaveTESR, ICustomSubItems, IPaintable.ISolidBlockPaintableBlock {
 
   public static BlockCapBank create(@Nonnull IModObject modObject) {

--- a/enderio-conduits/src/main/java/crazypants/enderio/powertools/machine/capbank/BlockCapBank.java
+++ b/enderio-conduits/src/main/java/crazypants/enderio/powertools/machine/capbank/BlockCapBank.java
@@ -14,7 +14,7 @@ import com.enderio.core.common.util.NNList;
 import com.enderio.core.common.util.NullHelper;
 import com.enderio.core.common.vecmath.Vector3d;
 
-import crazypants.enderio.api.redstone_dont_crash_us_mcjty.IRedstoneConnectable_dont_crash_us_mcjty;
+import crazypants.enderio.api.redstone.IRedstoneConnectable_dont_crash_us_mcjty;
 import crazypants.enderio.base.BlockEio;
 import crazypants.enderio.base.gui.handler.IEioGuiHandler;
 import crazypants.enderio.base.init.IModObject;

--- a/enderio-machines/src/main/java/crazypants/enderio/machines/machine/light/BlockElectricLight.java
+++ b/enderio-machines/src/main/java/crazypants/enderio/machines/machine/light/BlockElectricLight.java
@@ -4,7 +4,7 @@ import javax.annotation.Nonnull;
 
 import com.enderio.core.common.vecmath.Vector3f;
 
-import crazypants.enderio.api.redstone_dont_crash_us_mcjty.IRedstoneConnectable_dont_crash_us_mcjty;
+import crazypants.enderio.api.redstone.IRedstoneConnectable_dont_crash_us_mcjty;
 import crazypants.enderio.base.BlockEio;
 import crazypants.enderio.base.init.IModObject;
 import crazypants.enderio.base.render.IHaveRenderers;

--- a/enderio-machines/src/main/java/crazypants/enderio/machines/machine/light/BlockElectricLight.java
+++ b/enderio-machines/src/main/java/crazypants/enderio/machines/machine/light/BlockElectricLight.java
@@ -4,7 +4,7 @@ import javax.annotation.Nonnull;
 
 import com.enderio.core.common.vecmath.Vector3f;
 
-import crazypants.enderio.api.redstone.IRedstoneConnectable_dont_crash_us_mcjty;
+import crazypants.enderio.api.redstone.IRedstoneConnectable;
 import crazypants.enderio.base.BlockEio;
 import crazypants.enderio.base.init.IModObject;
 import crazypants.enderio.base.render.IHaveRenderers;
@@ -29,7 +29,7 @@ import net.minecraft.world.World;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
-public class BlockElectricLight extends BlockEio<TileElectricLight> implements IRedstoneConnectable_dont_crash_us_mcjty, IHaveRenderers {
+public class BlockElectricLight extends BlockEio<TileElectricLight> implements IRedstoneConnectable, IHaveRenderers {
 
   static final float BLOCK_HEIGHT = 0.05f;
   static final float BLOCK_WIDTH = 0.3f;

--- a/enderio-machines/src/main/java/crazypants/enderio/machines/machine/vacuum/BlockVacuumChest.java
+++ b/enderio-machines/src/main/java/crazypants/enderio/machines/machine/vacuum/BlockVacuumChest.java
@@ -5,7 +5,7 @@ import javax.annotation.Nullable;
 
 import com.enderio.core.api.client.gui.IResourceTooltipProvider;
 
-import crazypants.enderio.api.redstone_dont_crash_us_mcjty.IRedstoneConnectable_dont_crash_us_mcjty;
+import crazypants.enderio.api.redstone.IRedstoneConnectable_dont_crash_us_mcjty;
 import crazypants.enderio.base.BlockEio;
 import crazypants.enderio.base.gui.handler.IEioGuiHandler;
 import crazypants.enderio.base.init.IModObject;

--- a/enderio-machines/src/main/java/crazypants/enderio/machines/machine/vacuum/BlockVacuumChest.java
+++ b/enderio-machines/src/main/java/crazypants/enderio/machines/machine/vacuum/BlockVacuumChest.java
@@ -5,7 +5,7 @@ import javax.annotation.Nullable;
 
 import com.enderio.core.api.client.gui.IResourceTooltipProvider;
 
-import crazypants.enderio.api.redstone.IRedstoneConnectable_dont_crash_us_mcjty;
+import crazypants.enderio.api.redstone.IRedstoneConnectable;
 import crazypants.enderio.base.BlockEio;
 import crazypants.enderio.base.gui.handler.IEioGuiHandler;
 import crazypants.enderio.base.init.IModObject;
@@ -40,7 +40,7 @@ import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
 public class BlockVacuumChest extends BlockEio<TileVacuumChest> implements ISmartRenderAwareBlock, IEioGuiHandler.WithPos, IResourceTooltipProvider,
-    IRedstoneConnectable_dont_crash_us_mcjty, IPaintable.IBlockPaintableBlock, IPaintable.IWrenchHideablePaint, IHaveRenderers {
+    IRedstoneConnectable, IPaintable.IBlockPaintableBlock, IPaintable.IWrenchHideablePaint, IHaveRenderers {
 
   public static BlockVacuumChest create(@Nonnull IModObject modObject) {
     BlockVacuumChest res = new BlockVacuumChest(modObject);


### PR DESCRIPTION
I fixed McJtyLib to not bundle our API, so upgrading to McJtyLib 2.5.2 makes this no longer necessary.