### PR TITLE
fix mod log can't get ore id

### DIFF
--- a/src/main/java/crazypants/enderio/item/darksteel/ItemDarkSteelAxe.java
+++ b/src/main/java/crazypants/enderio/item/darksteel/ItemDarkSteelAxe.java
@@ -239,7 +239,9 @@ public class ItemDarkSteelAxe extends ItemAxe implements IAdvancedTooltipProvide
     if (logOreId == -1) {
       logOreId = OreDictionary.getOreID("logWood");
     }
-    int[] targetOreId = OreDictionary.getOreIDs(new ItemStack(bs.getBlock(), 1, bs.getBlock().getMetaFromState(bs)));
+    Item tItem=Item.getItemFromBlock(bs.getBlock());
+    if(tItem==null) return false;
+    int[] targetOreId = OreDictionary.getOreIDs(new ItemStack(tItem, 1, bs.getBlock().damageDropped(bs)));
     for (int id : targetOreId) {
       if (logOreId == id) {
         return true;


### PR DESCRIPTION
this add a null check for block I have happend
and the item meta of the drop block should use Block.damageDropped() not getMetaFromState()