### PR TITLE
Fixes ae"Compatibility" disabling all wooden gear

### DIFF
--- a/enderio-base/src/main/resources/assets/enderio/config/recipes/materials.xml
+++ b/enderio-base/src/main/resources/assets/enderio/config/recipes/materials.xml
@@ -260,9 +260,9 @@ XML editor will display that as tooltips when editing this file.
   <recipe name="Gear, Wood" required="true">
     <crafting>
       <grid>
-        <item /><item name="stickWood"/><item />
         <item name="stickWood"/><item /><item name="stickWood"/>
         <item /><item name="stickWood"/><item />
+        <item name="stickWood"/><item /><item name="stickWood"/>
       </grid>
       <output name="GEAR_WOOD"/>
     </crafting>


### PR DESCRIPTION
Ae2's gear is still registered even when disabled and the recipy conflicts. when it is disabled it willnot work with enderio machines and the ae2 dev wont fix.