### PR TITLE
Sould Binder Fix

### DIFF
--- a/enderio-base/src/main/java/crazypants/enderio/base/machine/baselegacy/AbstractPoweredTaskEntity.java
+++ b/enderio-base/src/main/java/crazypants/enderio/base/machine/baselegacy/AbstractPoweredTaskEntity.java
@@ -338,7 +338,7 @@ public abstract class AbstractPoweredTaskEntity extends AbstractPowerConsumerEnt
   }
 
   protected int getNumCanMerge(@Nonnull ItemStack itemStack, @Nonnull ItemStack result) {
-    if (!itemStack.isItemEqual(result)) {
+    if (!itemStack.isItemEqual(result) || !ItemStack.areItemStackTagsEqual(itemStack, result)) {
       return 0;
     }
     return Math.min(itemStack.getMaxStackSize() - itemStack.getCount(), result.getCount());

--- a/enderio-machines/src/main/java/crazypants/enderio/machines/machine/soul/TileSoulBinder.java
+++ b/enderio-machines/src/main/java/crazypants/enderio/machines/machine/soul/TileSoulBinder.java
@@ -26,6 +26,7 @@ import crazypants.enderio.base.xp.XpUtil;
 import crazypants.enderio.machines.config.config.SoulBinderConfig;
 import crazypants.enderio.machines.network.PacketHandler;
 import crazypants.enderio.util.Prep;
+
 import info.loenwind.autosave.annotations.Storable;
 import info.loenwind.autosave.annotations.Store;
 import net.minecraft.item.ItemStack;
@@ -110,11 +111,7 @@ public class TileSoulBinder extends AbstractPoweredTaskEntity implements IHaveEx
     if (recipe == null) {
       return null;
     }
-    if(!getStackInSlot(3).isEmpty()) {
-    	
-    	return null;
-    	
-    }
+    
     int xpRequired = ((ISoulBinderRecipe) recipe).getExperienceRequired();
     if (xpCont.getExperienceTotal() >= xpRequired) {
       return recipe;

--- a/enderio-machines/src/main/java/crazypants/enderio/machines/machine/soul/TileSoulBinder.java
+++ b/enderio-machines/src/main/java/crazypants/enderio/machines/machine/soul/TileSoulBinder.java
@@ -36,7 +36,6 @@ import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.FluidTank;
 import net.minecraftforge.fluids.capability.CapabilityFluidHandler;
-
 import static crazypants.enderio.machines.capacitor.CapacitorKey.SOUL_BINDER_POWER_BUFFER;
 import static crazypants.enderio.machines.capacitor.CapacitorKey.SOUL_BINDER_POWER_INTAKE;
 import static crazypants.enderio.machines.capacitor.CapacitorKey.SOUL_BINDER_POWER_USE;
@@ -110,6 +109,11 @@ public class TileSoulBinder extends AbstractPoweredTaskEntity implements IHaveEx
     IMachineRecipe recipe = super.canStartNextTask(nextSeed);
     if (recipe == null) {
       return null;
+    }
+    if(!getStackInSlot(3).isEmpty()) {
+    	
+    	return null;
+    	
     }
     int xpRequired = ((ISoulBinderRecipe) recipe).getExperienceRequired();
     if (xpCont.getExperienceTotal() >= xpRequired) {


### PR DESCRIPTION
Temperary fix for the soul binder (can now only craft if the output slot is empty (prevents soul vial (bat) + broken spawner from creating a slime spawner if a slime spawner is already in that slot)).  canStartNextTask (should) check if the recipe output is equal to the item in the output slot or if the slot is empty.