### PR TITLE
Revert "Satisfy Mcjty's lazy compat code"

### DIFF
--- a/enderio-base/src/main/java/crazypants/enderio/power/IPowerStorage.java
+++ b/enderio-base/src/main/java/crazypants/enderio/power/IPowerStorage.java
@@ -1,7 +1,0 @@
-package crazypants.enderio.power;
-
-// MCJTY PLZ
-public interface IPowerStorage {
-  long getEnergyStoredL();
-  long getMaxEnergyStoredL();
-}


### PR DESCRIPTION
McJtyLib now uses the correct location of this.

This reverts commit c4f78ba67eb8ad5b81306b26310e83a539b3fefb.