### PR TITLE
Re-add ComputerCraft bundled cable integration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -95,6 +95,7 @@ allprojects {
         maven { url = "http://mod-buildcraft.com/maven/" }
         maven { url = "https://maven.latmod.com" } // FTBLib
         maven { url = "http://maven.covers1624.net/" } // CoFHCore
+        maven { url = "http://cc.crzd.me/maven/" } // ComputerCraft
         ivy {
             url "http://ae-mod.info/builds"
             layout "pattern", {
@@ -354,6 +355,7 @@ curseforge {
             optionalLibrary 'botania'
             optionalLibrary 'buildcraft'
             optionalLibrary 'chisels-bits'
+            optionalLibrary 'computercraft'
             optionalLibrary 'extra-utilities'
             optionalLibrary 'immersive-engineering'
             optionalLibrary 'industrial-craft'

--- a/enderio-conduits/enderio-conduits.gradle
+++ b/enderio-conduits/enderio-conduits.gradle
@@ -1,3 +1,4 @@
 dependencies {
 	compile project(":enderio-base")
+	deobfCompile "dan200.computercraft:ComputerCraft:${computercraft_version}"
 }

--- a/enderio-conduits/enderio-conduits.gradle
+++ b/enderio-conduits/enderio-conduits.gradle
@@ -1,4 +1,4 @@
 dependencies {
 	compile project(":enderio-base")
-	deobfCompile "dan200.computercraft:ComputerCraft:${computercraft_version}"
+	compile "dan200.computercraft:ComputerCraft:${computercraft_version}"
 }

--- a/enderio-conduits/gradle.properties
+++ b/enderio-conduits/gradle.properties
@@ -6,3 +6,5 @@ include_in_combjar=true
 
 publish_api=false
 publish_source=true
+
+computercraft_version=1.80pr1-build5

--- a/enderio-conduits/src/main/java/crazypants/enderio/conduits/init/CommonProxy.java
+++ b/enderio-conduits/src/main/java/crazypants/enderio/conduits/init/CommonProxy.java
@@ -3,6 +3,7 @@ package crazypants.enderio.conduits.init;
 import javax.annotation.Nonnull;
 
 import crazypants.enderio.conduits.capability.CapabilityUpgradeHolder;
+import crazypants.enderio.conduits.integration.computercraft.CCUtil;
 import net.minecraftforge.fml.common.event.FMLInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLPostInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
@@ -14,6 +15,7 @@ public class CommonProxy {
   }
 
   public void init(@Nonnull FMLInitializationEvent event) {
+    CCUtil.init(event);
   }
 
   public void init(@Nonnull FMLPostInitializationEvent event) {

--- a/enderio-conduits/src/main/java/crazypants/enderio/conduits/integration/computercraft/CCUtil.java
+++ b/enderio-conduits/src/main/java/crazypants/enderio/conduits/integration/computercraft/CCUtil.java
@@ -1,0 +1,19 @@
+package crazypants.enderio.conduits.integration.computercraft;
+
+import dan200.computercraft.api.ComputerCraftAPI;
+import net.minecraftforge.fml.common.Loader;
+import net.minecraftforge.fml.common.Optional;
+import net.minecraftforge.fml.common.event.FMLInitializationEvent;
+
+import javax.annotation.Nonnull;
+
+public class CCUtil {
+  public static void init(@Nonnull FMLInitializationEvent event) {
+    if (Loader.isModLoaded("computercraft")) register();
+  }
+
+  @Optional.Method(modid = "computercraft")
+  private static void register() {
+    ComputerCraftAPI.registerBundledRedstoneProvider(new ConduitBundledRedstoneProvider());
+  }
+}

--- a/enderio-conduits/src/main/java/crazypants/enderio/conduits/integration/computercraft/ConduitBundledRedstoneProvider.java
+++ b/enderio-conduits/src/main/java/crazypants/enderio/conduits/integration/computercraft/ConduitBundledRedstoneProvider.java
@@ -1,0 +1,30 @@
+package crazypants.enderio.conduits.integration.computercraft;
+
+import crazypants.enderio.base.conduit.IConduitBundle;
+import crazypants.enderio.base.conduit.redstone.signals.Signal;
+import crazypants.enderio.conduits.conduit.redstone.IRedstoneConduit;
+import dan200.computercraft.api.redstone.IBundledRedstoneProvider;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.EnumFacing;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+
+import javax.annotation.Nonnull;
+
+public class ConduitBundledRedstoneProvider implements IBundledRedstoneProvider {
+  @Override
+  public int getBundledRedstoneOutput(@Nonnull World world, @Nonnull BlockPos blockPos, @Nonnull EnumFacing enumFacing) {
+    TileEntity te = world.getTileEntity(blockPos);
+    if (!(te instanceof IConduitBundle)) return -1;
+
+    IConduitBundle bundle = (IConduitBundle) te;
+    IRedstoneConduit conduit = bundle.getConduit(IRedstoneConduit.class);
+    if (conduit == null) return -1;
+
+    int out = 0;
+    for (Signal output : conduit.getNetworkOutputs(null)) {
+      out |= (output.getStrength() == 0 ? 0 : 1) << (15 - output.getColor().ordinal());
+    }
+    return out;
+  }
+}


### PR DESCRIPTION
Effectively cherry-picked from #1208. I'm not sure if this is a) wanted and b) how mod integration is meant to be handled, so feel free to close it :).

One thing worth noting is that `IRedstoneConduit.getNetworkOutputs` has the side parameter annotated as `@Nonnull`, but handles `null` arguments (which is required here in order to return the signal for all colours).