### PR TITLE
1.12.2 zh_cnlang

### DIFF
--- a/enderio-base/src/main/java/crazypants/enderio/base/EnderIO.java
+++ b/enderio-base/src/main/java/crazypants/enderio/base/EnderIO.java
@@ -175,7 +175,7 @@ public class EnderIO implements IEnderIOAddon {
     PaintSourceValidator.instance.loadConfig();
 
     BuildcraftIntegration.init(event);
-    TEUtil.init(event);
+//    TEUtil.init(event);
 
     proxy.init(event);
 

--- a/enderio-base/src/main/java/crazypants/enderio/base/item/yetawrench/ItemYetaWrench.java
+++ b/enderio-base/src/main/java/crazypants/enderio/base/item/yetawrench/ItemYetaWrench.java
@@ -204,20 +204,20 @@ public class ItemYetaWrench extends Item implements ITool, IConduitControl, IAdv
   }
 
   @Override
-  @Optional.Method(modid = "cofhapi|item")
+  @Optional.Method(modid = "cofhcore")
   public boolean isUsable(ItemStack item, EntityLivingBase user, BlockPos pos) {
     return true;
   }
 
   @Override
-  @Optional.Method(modid = "cofhapi|item")
+  @Optional.Method(modid = "cofhcore")
   public boolean isUsable(ItemStack item, EntityLivingBase user, Entity entity) {
     return false;
   }
 
   @SuppressWarnings("null")
   @Override
-  @Optional.Method(modid = "cofhapi|item")
+  @Optional.Method(modid = "cofhcore")
   public void toolUsed(ItemStack item, EntityLivingBase user, BlockPos pos) {
     if (user instanceof EntityPlayer) {
       used(EnumHand.MAIN_HAND, (EntityPlayer) user, pos);
@@ -225,7 +225,7 @@ public class ItemYetaWrench extends Item implements ITool, IConduitControl, IAdv
   }
 
   @Override
-  @Optional.Method(modid = "cofhapi|item")
+  @Optional.Method(modid = "cofhcore")
   public void toolUsed(ItemStack item, EntityLivingBase user, Entity entity) {
   }
 

--- a/enderio-conduits/src/main/java/crazypants/enderio/conduits/render/ConduitBundleRenderer.java
+++ b/enderio-conduits/src/main/java/crazypants/enderio/conduits/render/ConduitBundleRenderer.java
@@ -2,7 +2,6 @@ package crazypants.enderio.conduits.render;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -137,7 +136,7 @@ public class ConduitBundleRenderer extends TileEntitySpecialRenderer<TileConduit
   }
   
   @Nonnull
-  private static final Vector4f CORE_UVS = new Vector4f(2, 2, 14, 14); 
+  private static final Vector4f CORE_UVS = new Vector4f(2, 14, 14, 2);
   static {
     CORE_UVS.scale(1 / 16f);
   }

--- a/enderio-machines/src/main/java/crazypants/enderio/machines/machine/obelisk/inhibitor/TileInhibitorObelisk.java
+++ b/enderio-machines/src/main/java/crazypants/enderio/machines/machine/obelisk/inhibitor/TileInhibitorObelisk.java
@@ -37,6 +37,9 @@ public class TileInhibitorObelisk extends AbstractRangedObeliskEntity {
 
   @Override
   protected boolean processTasks(boolean redstoneCheck) {
+    if (redstoneCheck) {
+      usePower();
+    }
     return false;
   }
 


### PR DESCRIPTION
i need EnderIO 1.12.2 zh_cn.lang.
At present,this version some items title is empty string for this package online.
i see the EnderIO_base dictionary,the zh_ch.guess file,more line with '#',the prev line is empty string behind '='.
where i can download the lang file? 