### PR TITLE
Fixed tooltips displaying in non ender liquid conduits

### DIFF
--- a/enderio-conduits/src/main/java/crazypants/enderio/conduits/gui/LiquidSettings.java
+++ b/enderio-conduits/src/main/java/crazypants/enderio/conduits/gui/LiquidSettings.java
@@ -231,12 +231,12 @@ public class LiquidSettings extends BaseSettingsPanel {
 
   @Override
   protected boolean hasFilters() {
-    return true;
+    return isEnder;
   }
 
   @Override
   protected boolean hasUpgrades() {
-    return true;
+    return isEnder;
   }
 
 }


### PR DESCRIPTION
A fix to stop tooltips for filter / upgrade slots displaying in non-ender liquid conduit guis.  There are no filter / upgrade slots for the non ender liquid conduit varieties.