### PR TITLE
Prevent a ClassCastException which is very nasty to fix once the metadata is corrupted.

### DIFF
--- a/enderio-conduits-refinedstorage/src/main/java/crazypants/enderio/conduits/refinedstorage/conduit/RefinedStorageConduit.java
+++ b/enderio-conduits-refinedstorage/src/main/java/crazypants/enderio/conduits/refinedstorage/conduit/RefinedStorageConduit.java
@@ -222,14 +222,14 @@ public class RefinedStorageConduit extends AbstractConduit implements IRefinedSt
 
     INetworkNodeManager manager = RSHelper.API.getNetworkNodeManager(world);
 
-    ConduitRefinedStorageNode node = (ConduitRefinedStorageNode) manager.getNode(pos);
+    INetworkNode node = manager.getNode(pos);
 
     if (node == null || !node.getId().equals(ConduitRefinedStorageNode.ID)) {
       manager.setNode(pos, node = new ConduitRefinedStorageNode(this));
       manager.markForSaving();
     }
 
-    return node;
+    return (ConduitRefinedStorageNode) node;
   }
 
   @Override


### PR DESCRIPTION
Hello, 

I've seen my server crash and not be able to restart more than once to a crash like this:
java.lang.ClassCastException: me.modmuss50.rebornstorage.tiles.CraftingNode cannot be cast to crazypants.enderio.conduits.refinedstorage.conduit.ConduitRefinedStorageNode
	at crazypants.enderio.conduits.refinedstorage.conduit.RefinedStorageConduit.getNode(RefinedStorageConduit.java:165)
	at crazypants.enderio.conduits.refinedstorage.conduit.RefinedStorageConduit.getNode(RefinedStorageConduit.java:42)

The problem is that the RS manager is not aware that an EnderIO RS conduit replaced another block (perhaps @RebornStorage is not de-registering from the manager. I'm not sure what is the correct process), and EnderIO is assuming that the returned entity is a conduit. It's interesting that the follow up code handles the case where the ID doesn't match and fix it.