### PR TITLE
Allow conduits to decide what items they can accept as filters/upgrades

### DIFF
--- a/enderio-base/src/main/java/crazypants/enderio/base/filter/capability/IFilterHolder.java
+++ b/enderio-base/src/main/java/crazypants/enderio/base/filter/capability/IFilterHolder.java
@@ -61,4 +61,14 @@ public interface IFilterHolder<T extends IFilter> {
 
   int getOutputFilterIndex();
 
+  /**
+   *Defaults to <code>false</code>.
+   *
+   * @param stack The stack to check for being a valid filter.
+   * @param isInput <code>true</code> if the slot is the input slot, <code>false</code> if it is the output slot.
+   * @return <code>true</code> if the conduit can accept the given ItemStack as a filter.
+   */
+  default boolean isFilterUpgradeAccepted(@Nonnull ItemStack stack, boolean isInput) {
+    return false;
+  }
 }

--- a/enderio-conduits-refinedstorage/src/main/java/crazypants/enderio/conduits/refinedstorage/conduit/RefinedStorageConduit.java
+++ b/enderio-conduits-refinedstorage/src/main/java/crazypants/enderio/conduits/refinedstorage/conduit/RefinedStorageConduit.java
@@ -27,8 +27,10 @@ import crazypants.enderio.base.conduit.geom.CollidableComponent;
 import crazypants.enderio.base.filter.FilterRegistry;
 import crazypants.enderio.base.filter.IFilter;
 import crazypants.enderio.base.filter.capability.CapabilityFilterHolder;
+import crazypants.enderio.base.filter.fluid.items.IItemFilterFluidUpgrade;
 import crazypants.enderio.base.filter.item.IItemFilter;
 import crazypants.enderio.base.filter.item.ItemFilter;
+import crazypants.enderio.base.filter.item.items.ItemBasicItemFilter;
 import crazypants.enderio.base.render.registry.TextureRegistry;
 import crazypants.enderio.base.tool.ToolUtil;
 import crazypants.enderio.conduits.capability.CapabilityUpgradeHolder;
@@ -551,5 +553,10 @@ public class RefinedStorageConduit extends AbstractConduit implements IRefinedSt
   @Override
   public int getOutputFilterIndex() {
     return INDEX_OUTPUT_REFINED_STROAGE;
+  }
+
+  @Override
+  public boolean isFilterUpgradeAccepted(@Nonnull ItemStack stack, boolean isInput) {
+    return stack.getItem() instanceof IItemFilterFluidUpgrade || stack.getItem() instanceof ItemBasicItemFilter;
   }
 }

--- a/enderio-conduits/src/main/java/crazypants/enderio/conduits/capability/IUpgradeHolder.java
+++ b/enderio-conduits/src/main/java/crazypants/enderio/conduits/capability/IUpgradeHolder.java
@@ -15,4 +15,13 @@ public interface IUpgradeHolder {
 
   void setUpgradeStack(int param1, @Nonnull ItemStack stack);
 
+  /**
+   * Defaults to <code>true</code>.
+   *
+   * @param stack Is an instance of ItemFunctionUpgrade. Passed in case more detailed checking wants to be performed by the conduit.
+   * @return <code>true</code> if this conduit can accept the given ItemStack as a function upgrade.
+   */
+  default boolean isFunctionUpgradeAccepted(@Nonnull ItemStack stack) {
+    return true;
+  }
 }

--- a/enderio-conduits/src/main/java/crazypants/enderio/conduits/conduit/item/ItemConduit.java
+++ b/enderio-conduits/src/main/java/crazypants/enderio/conduits/conduit/item/ItemConduit.java
@@ -39,6 +39,7 @@ import crazypants.enderio.base.filter.capability.IFilterHolder;
 import crazypants.enderio.base.filter.gui.FilterGuiUtil;
 import crazypants.enderio.base.filter.item.IItemFilter;
 import crazypants.enderio.base.filter.item.ItemFilter;
+import crazypants.enderio.base.filter.item.items.IItemFilterItemUpgrade;
 import crazypants.enderio.base.item.conduitprobe.PacketConduitProbe;
 import crazypants.enderio.base.machine.modes.RedstoneControlMode;
 import crazypants.enderio.base.render.registry.TextureRegistry;
@@ -864,6 +865,11 @@ public class ItemConduit extends AbstractConduit implements IItemConduit, ICondu
   @Override
   public int getOutputFilterIndex() {
     return FilterGuiUtil.INDEX_OUTPUT_ITEM;
+  }
+
+  @Override
+  public boolean isFilterUpgradeAccepted(@Nonnull ItemStack stack, boolean isInput) {
+    return stack.getItem() instanceof IItemFilterItemUpgrade;
   }
 
   @Override

--- a/enderio-conduits/src/main/java/crazypants/enderio/conduits/conduit/liquid/EnderLiquidConduit.java
+++ b/enderio-conduits/src/main/java/crazypants/enderio/conduits/conduit/liquid/EnderLiquidConduit.java
@@ -31,6 +31,7 @@ import crazypants.enderio.base.filter.capability.CapabilityFilterHolder;
 import crazypants.enderio.base.filter.capability.IFilterHolder;
 import crazypants.enderio.base.filter.fluid.FluidFilter;
 import crazypants.enderio.base.filter.fluid.IFluidFilter;
+import crazypants.enderio.base.filter.fluid.items.IItemFilterFluidUpgrade;
 import crazypants.enderio.base.filter.gui.FilterGuiUtil;
 import crazypants.enderio.base.machine.modes.RedstoneControlMode;
 import crazypants.enderio.base.render.registry.TextureRegistry;
@@ -624,6 +625,11 @@ public class EnderLiquidConduit extends AbstractLiquidConduit implements ICondui
   @Override
   public int getOutputFilterIndex() {
     return FilterGuiUtil.INDEX_OUTPUT_FLUID;
+  }
+
+  @Override
+  public boolean isFilterUpgradeAccepted(@Nonnull ItemStack stack, boolean isInput) {
+    return stack.getItem() instanceof IItemFilterFluidUpgrade;
   }
 
   // ------------------------------------------------

--- a/enderio-conduits/src/main/java/crazypants/enderio/conduits/conduit/redstone/InsulatedRedstoneConduit.java
+++ b/enderio-conduits/src/main/java/crazypants/enderio/conduits/conduit/redstone/InsulatedRedstoneConduit.java
@@ -40,6 +40,8 @@ import crazypants.enderio.base.filter.redstone.DefaultOutputSignalFilter;
 import crazypants.enderio.base.filter.redstone.IInputSignalFilter;
 import crazypants.enderio.base.filter.redstone.IOutputSignalFilter;
 import crazypants.enderio.base.filter.redstone.IRedstoneSignalFilter;
+import crazypants.enderio.base.filter.redstone.items.IItemInputSignalFilterUpgrade;
+import crazypants.enderio.base.filter.redstone.items.IItemOutputSignalFilterUpgrade;
 import crazypants.enderio.base.render.registry.TextureRegistry;
 import crazypants.enderio.base.tool.ToolUtil;
 import crazypants.enderio.conduits.conduit.AbstractConduit;
@@ -907,5 +909,14 @@ public class InsulatedRedstoneConduit extends AbstractConduit implements IRedsto
   @Override
   public int getOutputFilterIndex() {
     return FilterGuiUtil.INDEX_OUTPUT_REDSTONE;
+  }
+
+  @Override
+  public boolean isFilterUpgradeAccepted(@Nonnull ItemStack stack, boolean isInput) {
+    if (!isInput) {
+      return stack.getItem() instanceof IItemInputSignalFilterUpgrade;
+    } else {
+      return stack.getItem() instanceof IItemOutputSignalFilterUpgrade;
+    }
   }
 }

--- a/enderio-conduits/src/main/java/crazypants/enderio/conduits/gui/InventoryUpgrades.java
+++ b/enderio-conduits/src/main/java/crazypants/enderio/conduits/gui/InventoryUpgrades.java
@@ -6,17 +6,7 @@ import crazypants.enderio.base.conduit.IConduit;
 import crazypants.enderio.base.conduit.item.ItemFunctionUpgrade;
 import crazypants.enderio.base.filter.IFilter;
 import crazypants.enderio.base.filter.capability.IFilterHolder;
-import crazypants.enderio.base.filter.fluid.items.IItemFilterFluidUpgrade;
-import crazypants.enderio.base.filter.item.items.IItemFilterItemUpgrade;
-import crazypants.enderio.base.filter.item.items.ItemBasicItemFilter;
-import crazypants.enderio.base.filter.redstone.items.IItemInputSignalFilterUpgrade;
-import crazypants.enderio.base.filter.redstone.items.IItemOutputSignalFilterUpgrade;
 import crazypants.enderio.conduits.capability.IUpgradeHolder;
-import crazypants.enderio.conduits.conduit.item.IItemConduit;
-import crazypants.enderio.conduits.conduit.liquid.AbstractTankConduit;
-import crazypants.enderio.conduits.conduit.liquid.EnderLiquidConduit;
-import crazypants.enderio.conduits.conduit.power.IPowerConduit;
-import crazypants.enderio.conduits.conduit.redstone.IRedstoneConduit;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.EnumFacing;
 import net.minecraftforge.items.IItemHandlerModifiable;
@@ -120,7 +110,10 @@ public class InventoryUpgrades implements IItemHandlerModifiable {
     }
     switch (slot) {
     case 0:
-      return isFunctionUpgradeAccepted(stack, con);
+      if (stack.getItem() instanceof ItemFunctionUpgrade && con instanceof IUpgradeHolder) {
+        return ((IUpgradeHolder) con).isFunctionUpgradeAccepted(stack);
+      }
+      return false;
     case 2:
       return isFilterUpgradeAccepted(stack, con, true);
     case 3:
@@ -129,25 +122,11 @@ public class InventoryUpgrades implements IItemHandlerModifiable {
     return false;
   }
 
-  // TODO make a way to do this based on the conduit
   private boolean isFilterUpgradeAccepted(@Nonnull ItemStack stack, IConduit con, boolean isInput) {
-    if (con instanceof IItemConduit) {
-      return stack.getItem() instanceof IItemFilterItemUpgrade;
-    } else if (con instanceof EnderLiquidConduit) {
-      return stack.getItem() instanceof IItemFilterFluidUpgrade;
-    } else if (con instanceof IRedstoneConduit) {
-      if (!isInput) {
-        return stack.getItem() instanceof IItemInputSignalFilterUpgrade;
-      } else {
-        return stack.getItem() instanceof IItemOutputSignalFilterUpgrade;
-      }
+    if (con instanceof IFilterHolder) {
+      return ((IFilterHolder) con).isFilterUpgradeAccepted(stack, isInput);
     }
-    return stack.getItem() instanceof IItemFilterFluidUpgrade || stack.getItem() instanceof ItemBasicItemFilter;
-  }
-
-  private boolean isFunctionUpgradeAccepted(@Nonnull ItemStack stack, IConduit con) {
-    // Hacky work around to avoid liquid conduits accepting upgrades
-    return stack.getItem() instanceof ItemFunctionUpgrade && !(con instanceof AbstractTankConduit || con instanceof IPowerConduit);
+    return false;
   }
 
   @Override


### PR DESCRIPTION
Implements the TODO about isFilterUpgradeAccepted in InventoryUpgrades
I ran into some issues while attempting to make a custom filter for a new set of conduits I am implementing and tracked it down to [this](https://github.com/SleepyTrousers/EnderIO/blob/master/enderio-conduits/src/main/java/crazypants/enderio/conduits/gui/InventoryUpgrades.java#L132) in InventoryUpgrades.java
```java
// TODO make a way to do this based on the conduit
private boolean isFilterUpgradeAccepted(@Nonnull ItemStack stack, IConduit con, boolean isInput) {
```

I decided to implement the TODO so that custom conduits can decide for themselves if they can accept a stack as a filter. While implementing this change I also ran into a few bugs where filters/upgrades could be voided in some conduits by shift clicking them in. For example, Redstone Conduits voiding speed upgrades, and Pressurized Liquid Conduits voiding fluid filters. This pull has the side effect of also fixing those bugs.

This pull changes InventoryUpgrades so that only classes that implement IFilterHolder can accept filters, and only classes that accept IUpgradeHolder can accept upgrades.

How it does this:
- IFilterHolder has a new default method `boolean isFilterUpgradeAccepted(@Nonnull ItemStack stack, boolean isInput)`, that allows Filter Holders to specify if they consider an ItemStack a valid filter. This method defaults to false.
- IUpgradeHolder has a new default method `boolean isFunctionUpgradeAccepted(@Nonnull ItemStack stack)`, that defaults to true. This means that any conduit that also is an Upgrade Holder can accept any upgrades, but also allows for them to be more restrictive if they choose to check additional information about the ItemFunctionUpgrade. Before this method is called InventoryUpgrades ensures that the stack is an ItemFunctionUpgrade so as to ensure that the stack is some form of Function Upgrade.