### PR TITLE
Made unconnected conduit bundles be in one plane

### DIFF
--- a/enderio-conduits-appliedenergistics/src/main/java/crazypants/enderio/conduits/me/conduit/ItemMEConduit.java
+++ b/enderio-conduits-appliedenergistics/src/main/java/crazypants/enderio/conduits/me/conduit/ItemMEConduit.java
@@ -42,7 +42,7 @@ public class ItemMEConduit extends AbstractItemConduit {
         new ItemConduitSubtype(modObject.getUnlocalisedName() + "_dense", modObject.getRegistryName().toString() + "_dense"));
 
     ConduitRegistry.register(ConduitBuilder.start().setUUID(new ResourceLocation(EnderIO.DOMAIN, "appliedenergistics")).setClass(getBaseConduitType())
-        .setOffsets(Offset.SOUTH_UP, Offset.SOUTH_UP, Offset.NORTH_EAST, Offset.EAST_UP).build()
+        .setOffsets(Offset.EAST_UP, Offset.SOUTH_UP, Offset.NORTH_EAST, Offset.EAST_UP).build()
         .setUUID(new ResourceLocation(EnderIO.DOMAIN, "appliedenergistics_conduit")).setClass(MEConduit.class).build().finish());
     ConduitDisplayMode.registerDisplayMode(new ConduitDisplayMode(getBaseConduitType(), IconEIO.WRENCH_OVERLAY_ME, IconEIO.WRENCH_OVERLAY_ME_OFF));
   }

--- a/enderio-conduits-opencomputers/src/main/java/crazypants/enderio/conduits/oc/conduit/ItemOCConduit.java
+++ b/enderio-conduits-opencomputers/src/main/java/crazypants/enderio/conduits/oc/conduit/ItemOCConduit.java
@@ -38,7 +38,7 @@ public class ItemOCConduit extends AbstractItemConduit {
   protected ItemOCConduit(@Nonnull IModObject mo) {
     super(mo, subtypes);
     ConduitRegistry.register(ConduitBuilder.start().setUUID(new ResourceLocation(EnderIO.DOMAIN, "opencomputers")).setClass(getBaseConduitType())
-            .setOffsets(Offset.NORTH_DOWN, Offset.NORTH_DOWN, Offset.SOUTH_WEST, Offset.WEST_DOWN).build()
+            .setOffsets(Offset.WEST_DOWN, Offset.NORTH_DOWN, Offset.SOUTH_WEST, Offset.WEST_DOWN).build()
             .setUUID(new ResourceLocation(EnderIO.DOMAIN, "opencomputers_conduit")).setClass(OCConduit.class).build().finish());
         ConduitDisplayMode.registerDisplayMode(new ConduitDisplayMode(getBaseConduitType(), IconEIO.WRENCH_OVERLAY_OC, IconEIO.WRENCH_OVERLAY_OC_OFF));
   }

--- a/enderio-conduits-refinedstorage/src/main/java/crazypants/enderio/conduits/refinedstorage/conduit/ItemRefinedStorageConduit.java
+++ b/enderio-conduits-refinedstorage/src/main/java/crazypants/enderio/conduits/refinedstorage/conduit/ItemRefinedStorageConduit.java
@@ -30,7 +30,7 @@ public class ItemRefinedStorageConduit extends AbstractItemConduit {
   protected ItemRefinedStorageConduit(@Nonnull IModObject modObject) {
     super(modObject, new ItemConduitSubtype(modObject.getUnlocalisedName(), modObject.getRegistryName().toString()));
     ConduitRegistry.register(ConduitBuilder.start().setUUID(new ResourceLocation(EnderIO.DOMAIN, "refinedstorage")).setClass(getBaseConduitType())
-        .setOffsets(Offset.NORTH_UP, Offset.NORTH_UP, Offset.NORTH_WEST, Offset.WEST_UP).build()
+        .setOffsets(Offset.WEST_UP, Offset.NORTH_UP, Offset.NORTH_WEST, Offset.WEST_UP).build()
         .setUUID(new ResourceLocation(EnderIO.DOMAIN, "refinedstorage_conduit")).setClass(RefinedStorageConduit.class).build().finish());
     ConduitDisplayMode.registerDisplayMode(new ConduitDisplayMode(getBaseConduitType(), IconEIO.WRENCH_OVERLAY_RS, IconEIO.WRENCH_OVERLAY_RS_OFF));
   }


### PR DESCRIPTION
When all the conduits are placed in the same bundle without any of them connecting to another spot the 3 non default conduits (ME, RS, and OC) positioning looks off due to being in a different plane than the 4 base ones.

How it is currently: https://i.gyazo.com/b5be7ef20d5fc0a08f5c638049ebb34e.png
How it looks after these changes: https://i.gyazo.com/450dd22da070d784b8b2f30d57019969.png

All bundle rendering looks the same as it is currently is, this just changes how it appears when they have no connectors.