### PR TITLE
Don't manually register the DefaultConduitRenderer

### DIFF
--- a/enderio-conduits-appliedenergistics/src/main/java/crazypants/enderio/conduits/me/conduit/ItemMEConduit.java
+++ b/enderio-conduits-appliedenergistics/src/main/java/crazypants/enderio/conduits/me/conduit/ItemMEConduit.java
@@ -48,13 +48,6 @@ public class ItemMEConduit extends AbstractItemConduit {
   }
 
   @Override
-  @SideOnly(Side.CLIENT)
-  public void registerRenderers(@Nonnull IModObject modObject) {
-    super.registerRenderers(modObject);
-    ConduitBundleRenderManager.instance.getConduitBundleRenderer().registerRenderer(new DefaultConduitRenderer());
-  }
-
-  @Override
   public @Nonnull Class<? extends IConduit> getBaseConduitType() {
     return IMEConduit.class;
   }

--- a/enderio-conduits-opencomputers/src/main/java/crazypants/enderio/conduits/oc/conduit/ItemOCConduit.java
+++ b/enderio-conduits-opencomputers/src/main/java/crazypants/enderio/conduits/oc/conduit/ItemOCConduit.java
@@ -42,13 +42,6 @@ public class ItemOCConduit extends AbstractItemConduit {
             .setUUID(new ResourceLocation(EnderIO.DOMAIN, "opencomputers_conduit")).setClass(OCConduit.class).build().finish());
         ConduitDisplayMode.registerDisplayMode(new ConduitDisplayMode(getBaseConduitType(), IconEIO.WRENCH_OVERLAY_OC, IconEIO.WRENCH_OVERLAY_OC_OFF));
   }
-
-  @Override
-  @SideOnly(Side.CLIENT)
-  public void registerRenderers(@Nonnull IModObject modObject) {
-    super.registerRenderers(modObject);
-    ConduitBundleRenderManager.instance.getConduitBundleRenderer().registerRenderer(new DefaultConduitRenderer());
-  }
   
   @Override
   public @Nonnull Class<? extends IConduit> getBaseConduitType() {

--- a/enderio-conduits-refinedstorage/src/main/java/crazypants/enderio/conduits/refinedstorage/conduit/ItemRefinedStorageConduit.java
+++ b/enderio-conduits-refinedstorage/src/main/java/crazypants/enderio/conduits/refinedstorage/conduit/ItemRefinedStorageConduit.java
@@ -36,13 +36,6 @@ public class ItemRefinedStorageConduit extends AbstractItemConduit {
   }
 
   @Override
-  @SideOnly(Side.CLIENT)
-  public void registerRenderers(@Nonnull IModObject modObject) {
-    super.registerRenderers(modObject);
-    ConduitBundleRenderManager.instance.getConduitBundleRenderer().registerRenderer(new DefaultConduitRenderer());
-  }
-
-  @Override
   @Nonnull
   public Class<? extends IConduit> getBaseConduitType() {
     return IRefinedStorageConduit.class;


### PR DESCRIPTION
This change saves a small amount of memory space in the conduitRenderers list as there are not 3 more instances of the DefaultConduitRenderer object in memory. [ConduitBundleRenderer#getRendererForConduit()](https://github.com/SleepyTrousers/EnderIO/blob/master/enderio-conduits/src/main/java/crazypants/enderio/conduits/render/ConduitBundleRenderer.java#L298) already defaults to the DefaultConduitRenderer. 

More importantly however, it makes it easier/cleaner for addons adding their own Conduit Rendering as they do not have to add `before:enderioconduitsappliedenergistics;before:enderioconduitsopencomputers;before:enderioconduitsrefinedstorage;` to their dependency list just to ensure their renderer gets used. The reason that the loading before is currently required is because the DefaultConduitRenderer returns true in all cases for `isRenderForConduit`. This means that when it gets manually added by the ME, RS, or OC conduit integration it uses the default renderer instead of getting to and finding the customized one.