### PR TITLE
Fix issue with No More Recipe Conflicts

### DIFF
--- a/enderio-base/src/main/resources/assets/enderio/config/recipes/misc.xml
+++ b/enderio-base/src/main/resources/assets/enderio/config/recipes/misc.xml
@@ -32,7 +32,7 @@ XML editor will display that as tooltips when editing this file.
         <item name="logWood"/>
         <item name="logWood"/>
       </grid>
-      <output name="stickWood" amount="16" />
+      <output name="minecraft:stick" amount="16" />
     </crafting>
   </recipe>
 
@@ -43,7 +43,7 @@ XML editor will display that as tooltips when editing this file.
         <item name="logWood"/><item/><item name="logWood"/>
         <item name="logWood"/><item name="logWood"/><item name="logWood"/>
       </grid>
-      <output name="chestWood" amount="4" />
+      <output name="minecraft:chest" amount="4" />
     </crafting>
   </recipe>
  
@@ -54,7 +54,7 @@ XML editor will display that as tooltips when editing this file.
         <item name="IRON"/><item name="logWood"/><item name="IRON"/>
         <item/><item name="IRON"/><item/>
       </grid>
-      <output name="blockHopper" />
+      <output name="minecraft:hopper" />
     </crafting>
   </recipe>
 

--- a/enderio-base/src/main/resources/assets/enderio/config/recipes/misc.xml
+++ b/enderio-base/src/main/resources/assets/enderio/config/recipes/misc.xml
@@ -32,7 +32,7 @@ XML editor will display that as tooltips when editing this file.
         <item name="logWood"/>
         <item name="logWood"/>
       </grid>
-      <output name="minecraft:stick" amount="16" />
+      <output name="minecraft:stick, stickWood" amount="16" />
     </crafting>
   </recipe>
 
@@ -43,7 +43,7 @@ XML editor will display that as tooltips when editing this file.
         <item name="logWood"/><item/><item name="logWood"/>
         <item name="logWood"/><item name="logWood"/><item name="logWood"/>
       </grid>
-      <output name="minecraft:chest" amount="4" />
+      <output name="minecraft:chest, chestWood" amount="4" />
     </crafting>
   </recipe>
  
@@ -54,7 +54,7 @@ XML editor will display that as tooltips when editing this file.
         <item name="IRON"/><item name="logWood"/><item name="IRON"/>
         <item/><item name="IRON"/><item/>
       </grid>
-      <output name="minecraft:hopper" />
+      <output name="minecraft:hopper, blockHopper" />
     </crafting>
   </recipe>
 


### PR DESCRIPTION
Some mods add items like trapped chests to chestWood, so I think it's better for all the recipes to craft the vanilla items instead of an OreDict entries (for all 3, just in case), as with No More Recipe Conflicts it would be possible to craft 4 trapped chests from 8 logs or anything else added to the Ore Dictionary that we don't expect.