### PR TITLE
Make cheaty_spawner.xml Example Usable

### DIFF
--- a/enderio-machines/src/main/resources/assets/enderio/config/recipes/examples/cheaty_spawner.xml
+++ b/enderio-machines/src/main/resources/assets/enderio/config/recipes/examples/cheaty_spawner.xml
@@ -1,13 +1,68 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <enderio:recipes xmlns:enderio="http://enderio.com/recipes" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://enderio.com/recipes recipes.xsd ">
 
-  <recipe name="Spawner, overrides" required="true">
+<!--
+
+Enables all possible vanilla mobs.  The normally disabled mobs (Elder Guardian,
+Evoker, Snow Golem, Villager, Iron Golem, and Wither) have extremely high
+power requirements.  You are able to edit these values below.
+
+The Ender Dragon can't be captured in a Soul Vial due to technincal reasons.
+
+Copy this file into the enderio/config/recipes/user folder to activate it.
+
+-->
+
+  <recipe name="Spawner, defaults" required="true">
     <spawning>
+      <entity name="*"                             costMultiplier="1.0" disabled="false"/> <!-- default -->
+      <entity name="*boss*"                        soulvial="false"/> <!-- all modded bosses -->
+      <entity name="minecraft:bat"                 costMultiplier="0.5" disabled="false"/> <!-- Bat -->
+      <entity name="minecraft:blaze"               costMultiplier="5.0" disabled="false"/> <!-- Blaze -->
+      <entity name="minecraft:cave_spider"         costMultiplier="1.0" disabled="false"/> <!-- Cave Spider -->
+      <entity name="minecraft:chicken"             costMultiplier="0.5" disabled="false"/> <!-- Chicken -->
+      <entity name="minecraft:cow"                 costMultiplier="0.5" disabled="false"/> <!-- Cow -->
+      <entity name="minecraft:creeper"             costMultiplier="1.5" disabled="false"/> <!-- Creeper -->
+      <entity name="minecraft:donkey"              costMultiplier="1.0" disabled="false"/> <!-- Donkey -->
       <entity name="minecraft:elder_guardian"      costMultiplier="100" disabled="false"/> <!-- Elder Guardian -->
+      <entity name="minecraft:enderman"            costMultiplier="10"  disabled="false"/> <!-- Enderman -->
+      <entity name="minecraft:endermite"           costMultiplier="0.3" disabled="false"/> <!-- Endermite -->
       <entity name="minecraft:evocation_illager"   costMultiplier="250" disabled="false"/> <!-- Evoker -->
+      <entity name="minecraft:ghast"               costMultiplier="10"  disabled="false"/> <!-- Ghast -->
+      <entity name="minecraft:giant"               costMultiplier="100" disabled="false"/> <!-- Giant -->
+      <entity name="minecraft:guardian"            costMultiplier="5.0" disabled="false"/> <!-- Guardian -->
+      <entity name="minecraft:horse"               costMultiplier="1.0" disabled="false"/> <!-- Horse -->
+      <entity name="minecraft:husk"                costMultiplier="2.0" disabled="false"/> <!-- Husk -->
+      <entity name="minecraft:llama"               costMultiplier="1.0" disabled="false"/> <!-- Llama -->
+      <entity name="minecraft:magma_cube"          costMultiplier="2.0" disabled="false"/> <!-- Magma Cube -->
+      <entity name="minecraft:mooshroom"           costMultiplier="1.0" disabled="false"/> <!-- Mooshroom -->
+      <entity name="minecraft:mule"                costMultiplier="1.0" disabled="false"/> <!-- Mule -->
+      <entity name="minecraft:ocelot"              costMultiplier="1.0" disabled="false"/> <!-- Ocelot -->
+      <entity name="minecraft:pig"                 costMultiplier="0.5" disabled="false"/> <!-- Pig -->
+      <entity name="minecraft:polar_bear"          costMultiplier="2.0" disabled="false"/> <!-- Polar Bear -->
+      <entity name="minecraft:rabbit"              costMultiplier="0.1" disabled="false"/> <!-- Rabbit -->
+      <entity name="minecraft:sheep"               costMultiplier="0.5" disabled="false"/> <!-- Sheep -->
+      <entity name="minecraft:shulker"             costMultiplier="10"  disabled="false"/> <!-- Shulker -->
+      <entity name="minecraft:silverfish"          costMultiplier="1.0" disabled="false"/> <!-- Silverfish -->
+      <entity name="minecraft:skeleton"            costMultiplier="2.0" disabled="false"/> <!-- Skeleton -->
+      <entity name="minecraft:skeleton_horse"      costMultiplier="2.0" disabled="false"/> <!-- Skeleton Horse -->
+      <entity name="minecraft:slime"               costMultiplier="5.0" disabled="false"/> <!-- Slime -->
+      <entity name="minecraft:snowman"             costMultiplier="100" disabled="false"/> <!-- Snow Golem -->
+      <entity name="minecraft:spider"              costMultiplier="1.0" disabled="false"/> <!-- Spider -->
+      <entity name="minecraft:squid"               costMultiplier="0.5" disabled="false"/> <!-- Squid -->
+      <entity name="minecraft:stray"               costMultiplier="3.0" disabled="false"/> <!-- Stray -->
+      <entity name="minecraft:vex"                 costMultiplier="1.0" disabled="false"/> <!-- Vex -->
       <entity name="minecraft:villager"            costMultiplier="100" disabled="false"/> <!-- Villager -->
       <entity name="minecraft:villager_golem"      costMultiplier="100" disabled="false"/> <!-- Iron Golem -->
+      <entity name="minecraft:vindication_illager" costMultiplier="15"  disabled="false"/> <!-- Vindicator -->
+      <entity name="minecraft:witch"               costMultiplier="5.0" disabled="false"/> <!-- Witch -->
       <entity name="minecraft:wither"              costMultiplier="500" disabled="false"/> <!-- Wither -->
+      <entity name="minecraft:wither_skeleton"     costMultiplier="20"  disabled="false"/> <!-- Wither Skeleton -->
+      <entity name="minecraft:wolf"                costMultiplier="1.0" disabled="false"/> <!-- Wolf -->
+      <entity name="minecraft:zombie"              costMultiplier="1.0" disabled="false"/> <!-- Zombie -->
+      <entity name="minecraft:zombie_horse"        costMultiplier="2.0" disabled="false"/> <!-- Zombie Horse -->
+      <entity name="minecraft:zombie_pigman"       costMultiplier="5.0" disabled="false"/> <!-- Zombie Pigman -->
+      <entity name="minecraft:zombie_villager"     costMultiplier="2.5" disabled="false"/> <!-- Zombie Villager -->
     </spawning>
   </recipe>
 


### PR DESCRIPTION
Overhauled cheaty_spawner.xml to work with the current recipe system.

Added Snow Golem spawners with a cost multiplier of 100 to match Villagers and Iron Golems.

Added comments to the top explaining what the example does, pointing out that the Ender Dragon isn't possible, and the normal activation instructions.