### PR TITLE
Fix fallen knight not tracking player tightly enough

### DIFF
--- a/enderio-zoo/src/main/java/crazypants/enderio/zoo/entity/ai/EntityAIMountedAttackOnCollide.java
+++ b/enderio-zoo/src/main/java/crazypants/enderio/zoo/entity/ai/EntityAIMountedAttackOnCollide.java
@@ -123,7 +123,7 @@ public class EntityAIMountedAttackOnCollide extends EntityAIBase {
       targetPosX = target.posX;
       targetPosY = target.getEntityBoundingBox().minY;
       targetPosZ = target.posZ;
-      pathUpdateTimer = failedPathFindingPenalty + 4 + attacker.getRNG().nextInt(7);
+      pathUpdateTimer = 4 + attacker.getRNG().nextInt(7);
 
       final Path path = getNavigator().getPath();
       if (path != null) {

--- a/enderio-zoo/src/main/java/crazypants/enderio/zoo/entity/ai/EntityAIMountedAttackOnCollide.java
+++ b/enderio-zoo/src/main/java/crazypants/enderio/zoo/entity/ai/EntityAIMountedAttackOnCollide.java
@@ -78,7 +78,8 @@ public class EntityAIMountedAttackOnCollide extends EntityAIBase {
   /**
    * Returns whether an in-progress EntityAIBase should continue executing
    */
-  public boolean continueExecuting() {
+  @Override
+  public boolean shouldContinueExecuting() {
     EntityLivingBase entitylivingbase = attacker.getAttackTarget();
     return entitylivingbase == null ? false
         : (!entitylivingbase.isEntityAlive() ? false : (!longMemory ? !getNavigator().noPath() : attacker.isWithinHomeDistanceCurrentPosition()));


### PR DESCRIPTION
First commit fixes a clear bug from porting, shouldContinueExecuting was never executing. This stopped the knight from standing still for 3-4 seconds before continuing to chase you.

Second commit puts the pathing delays more in line with vanilla. Fast enough to track well, but delayed enough to make it not thrash the pathfinder. This resulted in the knight continuing to track you instead of pathing to where you previously were.

I left the path penalty code in shouldExecute because its a good improvement that IMO vanilla zombies should have as well.

Note this doesnt fix the mounted knight spinning in a circle bug, that's a different issue I will do in a different PR.