### PR TITLE
Improve fallen mount with knight riding pathfollowing, fixes spinning horse

### DIFF
--- a/enderio-zoo/src/main/java/crazypants/enderio/zoo/entity/EntityFallenKnight.java
+++ b/enderio-zoo/src/main/java/crazypants/enderio/zoo/entity/EntityFallenKnight.java
@@ -12,6 +12,7 @@ import crazypants.enderio.zoo.EnderIOZoo;
 import crazypants.enderio.zoo.config.ZooConfig;
 import crazypants.enderio.zoo.entity.ai.EntityAIMountedArrowAttack;
 import crazypants.enderio.zoo.entity.ai.EntityAIMountedAttackOnCollide;
+import crazypants.enderio.zoo.entity.navigate.PathNavigateGroundMounted;
 import crazypants.enderio.zoo.entity.render.RenderFallenKnight;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLiving;
@@ -33,6 +34,7 @@ import net.minecraft.item.ItemArmor;
 import net.minecraft.item.ItemBow;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.pathfinding.PathNavigate;
 import net.minecraft.util.DamageSource;
 import net.minecraft.util.EnumHand;
 import net.minecraft.util.ResourceLocation;
@@ -95,6 +97,11 @@ public class EntityFallenKnight extends EntitySkeleton implements IEnderZooMob {
     super.applyEntityAttributes();
     getEntityAttribute(SharedMonsterAttributes.FOLLOW_RANGE).setBaseValue(ZooConfig.fallenKnightFollowRange.get());
     applyAttributes(this, ZooConfig.fallenKnightHealth, ZooConfig.fallenKnightAttackDamage);
+  }
+
+  @Override
+  protected PathNavigate createNavigator(World worldIn) {
+    return new PathNavigateGroundMounted(this, worldIn);
   }
 
   // This is called from the super constructor and so is completely useless

--- a/enderio-zoo/src/main/java/crazypants/enderio/zoo/entity/navigate/PathNavigateGroundMounted.java
+++ b/enderio-zoo/src/main/java/crazypants/enderio/zoo/entity/navigate/PathNavigateGroundMounted.java
@@ -1,0 +1,60 @@
+package crazypants.enderio.zoo.entity.navigate;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityLiving;
+import net.minecraft.pathfinding.PathNavigateGround;
+import net.minecraft.util.math.MathHelper;
+import net.minecraft.util.math.Vec3d;
+import net.minecraft.world.World;
+
+public class PathNavigateGroundMounted extends PathNavigateGround {
+
+  public PathNavigateGroundMounted(EntityLiving entitylivingIn, World worldIn) {
+    super(entitylivingIn, worldIn);
+  }
+
+  /**
+   * Based off of PathNavigateGround.pathFollow() with 1 small modification mentioned below
+   */
+  @Override
+  protected void pathFollow() {
+    Vec3d vec3d = this.getEntityPosition();
+    int i = this.currentPath.getCurrentPathLength();
+
+    for (int j = this.currentPath.getCurrentPathIndex(); j < this.currentPath.getCurrentPathLength(); ++j) {
+      if ((double) this.currentPath.getPathPointFromIndex(j).y != Math.floor(vec3d.y)) {
+        i = j;
+        break;
+      }
+    }
+
+    this.maxDistanceToWaypoint = this.entity.width > 0.75F ? entity.width / 2.0F : 0.75F - entity.width / 2.0F;
+    Vec3d vec3d1 = this.currentPath.getCurrentPos();
+
+    /**
+     * Adjust the maximum height difference to allow the mob riding the other mob to step down a block correctly
+     * - only when detected it is riding the mob
+     * - only for pathing downwards as it can interfere with pathing upwards
+     */
+    double maxHeightDifference = 1D;
+    if (this.entity.isRiding() && this.entity.posY - vec3d1.y > 0) {
+      maxHeightDifference = 2D;
+    }
+    if (MathHelper.abs((float) (this.entity.posX - (vec3d1.x + 0.5D))) < this.maxDistanceToWaypoint && MathHelper.abs((float) (this.entity.posZ - (vec3d1.z + 0.5D))) < this.maxDistanceToWaypoint && Math.abs(this.entity.posY - vec3d1.y) < maxHeightDifference) {
+      this.currentPath.setCurrentPathIndex(this.currentPath.getCurrentPathIndex() + 1);
+    }
+
+    int k = MathHelper.ceil(this.entity.width);
+    int l = MathHelper.ceil(this.entity.height);
+    int i1 = k;
+
+    for (int j1 = i - 1; j1 >= this.currentPath.getCurrentPathIndex(); --j1) {
+      if (this.isDirectPathBetweenPoints(vec3d, this.currentPath.getVectorFromIndex(this.entity, j1), k, l, i1)) {
+        this.currentPath.setCurrentPathIndex(j1);
+        break;
+      }
+    }
+
+    this.checkForStuck(vec3d);
+  }
+}


### PR DESCRIPTION
So mounted pathfinding is a tricky thing. The entity on top does the pathfinding work, and also runs the pathfollowing code but instead the entity on the bottom follows the path, in this case, a larger horse/mount. This can cause some... issues. This PR isn't perfect and should definitely be tested to see if it feels like it helps overall (I suggest testing with my other PRs to so the pathing is much faster)

My primary goal was to fix horses/mounts spinning with the fallen knight on top of them when they are trying to drop down a block. Most often when its a diagonal drop down from an upper L shape of blocks is when it happens.

This makes the y difference more relaxed when it detects the right conditions, as best I can tell this doesn't introduce any side affects, but you guys might spot some I didn't.

Other potential issues I should bring up in case its worth looking into in the future:
- Since the fallen knight does the pathfinding and the mount does the path following as best I can tell. Since the mount is much larger it might have issues following a path designed for a zombie shaped entity.

I tried to fix this by adjusting the pathfinding requests to use the mount as the source entity, but then give the path to the knight to control the mount with, and then also have the knights pathfollowing code adjust to use the mounts width where needed. But in practice this didn't yield much promising results, found the y value adjustment mentioned above was the most potent fix and might be enough of a fix for now.

Not sure if there's a better way to override pathing behavior than what I have done, but this works.