### PR TITLE
Make captured mob support spawn eggs

### DIFF
--- a/enderio-base/src/main/java/crazypants/enderio/util/CapturedMob.java
+++ b/enderio-base/src/main/java/crazypants/enderio/util/CapturedMob.java
@@ -50,6 +50,7 @@ public final class CapturedMob {
 
   public static final @Nonnull String ENTITY_KEY = "entity";
   public static final @Nonnull String ENTITY_ID_KEY = "entityId";
+  public static final @Nonnull String ENTITY_TAG_KEY = "EntityTag";
   public static final @Nonnull String CUSTOM_NAME_KEY = "customName";
 
   private final static @Nonnull NNList<ResourceLocation> blacklist = new NNList<ResourceLocation>(DRAGON);
@@ -86,6 +87,8 @@ public final class CapturedMob {
   private CapturedMob(@Nonnull NBTTagCompound nbt) {
     if (nbt.hasKey(ENTITY_KEY)) {
       entityNbt = nbt.getCompoundTag(ENTITY_KEY).copy();
+    } else if (nbt.hasKey(ENTITY_TAG_KEY)) {
+      entityNbt = nbt.getCompoundTag(ENTITY_TAG_KEY).copy();
     } else {
       entityNbt = null;
     }
@@ -166,7 +169,7 @@ public final class CapturedMob {
   }
 
   public static boolean containsSoul(@Nullable NBTTagCompound nbt) {
-    return nbt != null && (nbt.hasKey(ENTITY_KEY) || nbt.hasKey(ENTITY_ID_KEY));
+    return nbt != null && (nbt.hasKey(ENTITY_KEY) || nbt.hasKey(ENTITY_ID_KEY) || nbt.hasKey(ENTITY_TAG_KEY));
   }
 
   @SuppressWarnings("null")


### PR DESCRIPTION
This makes it possible to use Spawn Eggs to set the entity in the Soul Filter. (Including via dragging from JEI to the ghost slot as it is just a normal ItemStack)

The side effect of this change, is that you can use Spawn Eggs in place of soul vials in obelisks. (Does not change any other location.)
I believe this is fine, as there are no real recipes for Spawn eggs anyways. (Currently the obelisks support both broken spawners and soul vials.