### PR TITLE
Reduce Memory pressure of UpgradePath

### DIFF
--- a/enderio-base/src/main/java/crazypants/enderio/base/handler/darksteel/DarkSteelRecipeManager.java
+++ b/enderio-base/src/main/java/crazypants/enderio/base/handler/darksteel/DarkSteelRecipeManager.java
@@ -20,7 +20,6 @@ import crazypants.enderio.api.upgrades.IDarkSteelItem;
 import crazypants.enderio.api.upgrades.IDarkSteelUpgrade;
 import crazypants.enderio.base.EnderIO;
 import crazypants.enderio.base.lang.Lang;
-import crazypants.enderio.util.StringUtil;
 import net.minecraft.enchantment.Enchantment;
 import net.minecraft.enchantment.EnchantmentHelper;
 import net.minecraft.entity.player.EntityPlayer;
@@ -188,6 +187,12 @@ public class DarkSteelRecipeManager {
     return result.isEmpty() ? "" : NullHelper.first(result.substring(1), "");
   }
 
+  public static @Nonnull NNList<IDarkSteelUpgrade> getUpgrades(@Nonnull ItemStack stack) {
+    NNList<IDarkSteelUpgrade> list =  UpgradeRegistry.getUpgrades();
+    list.removeIf(upgrade -> !upgrade.hasUpgrade(stack));
+    return list;
+  }
+
   public static NNList<ItemStack> getRecipes(@Nonnull Set<UpgradePath> list, @Nonnull NNList<ItemStack> input) {
     NNList<ItemStack> output = new NNList<ItemStack>();
     NNIterator<ItemStack> iterator = input.iterator();
@@ -222,14 +227,17 @@ public class DarkSteelRecipeManager {
   public static class UpgradePath {
     private final @Nonnull ItemStack input, upgrade, output;
     private final @Nonnull IDarkSteelUpgrade dsupgrade;
-    private final @Nonnull String id;
+    private final int hash;
 
     UpgradePath(@Nonnull IDarkSteelUpgrade dsupgrade, @Nonnull ItemStack input, @Nonnull ItemStack upgrade, @Nonnull ItemStack output) {
       this.input = input;
       this.upgrade = upgrade;
       this.output = output;
       this.dsupgrade = dsupgrade;
-      this.id = StringUtil.format("%s:%s:%s", input.getItem().getRegistryName(), getUpgradesAsString(input), getUpgradesAsString(output));
+      int hash = input.getItem().getRegistryName().hashCode();
+      hash = hash * 31 + getUpgradesAsString(input).hashCode();
+      hash = hash * 31 + getUpgradesAsString(output).hashCode();
+      this.hash = hash;
     }
 
     public @Nonnull ItemStack getInput() {
@@ -250,7 +258,7 @@ public class DarkSteelRecipeManager {
 
     @Override
     public int hashCode() {
-      return id.hashCode();
+      return hash;
     }
 
     @Override
@@ -265,7 +273,13 @@ public class DarkSteelRecipeManager {
         return false;
       }
       UpgradePath other = (UpgradePath) obj;
-      if (!id.equals(other.id)) {
+      if (input.getItem() != other.getInput().getItem()) {
+        return false;
+      }
+      if (!getUpgrades(input).equals(getUpgrades(other.input))) {
+        return false;
+      }
+      if (!getUpgrades(output).equals(getUpgrades(other.output))) {
         return false;
       }
       return true;


### PR DESCRIPTION
Hi there,
I did some memory analysis on large modpacks, trying to reduce the memory pressure.
I noticed that the HashMap in your DarkSteelUpgradeRecipeCategory is taking up around 150MB of heap space. If you look at the objects inside the map that take, you find that 45MB of the 150MB are just char arrays. This is because the String id can grow quite huge.
My solution is to simply remove the id, and cache the hashcode instead.
The equals check should not be much slower, as it fails fast for different input items

The result is that DarkSteelRecipeManager uses around 45MB less memory.
Some screenshots from eclipse MAT:
Without my changes:
![old_dominator](https://user-images.githubusercontent.com/20151702/53753813-76381b00-3eb2-11e9-9846-10054c0444e5.png)
![old_retained](https://user-images.githubusercontent.com/20151702/53753814-76381b00-3eb2-11e9-99b8-06eea9315b2b.png)
With the changes in this PR:
![new_retained](https://user-images.githubusercontent.com/20151702/53753834-83eda080-3eb2-11e9-9c84-61d9ae745d9c.png)
![new_dominator](https://user-images.githubusercontent.com/20151702/53753835-83eda080-3eb2-11e9-8d06-dca17e1de28a.png)
