### PR TITLE
Tanks consider containers of zero-sized fluid stacks as empty

### DIFF
--- a/enderio-machines/src/main/java/crazypants/enderio/machines/machine/tank/TileTank.java
+++ b/enderio-machines/src/main/java/crazypants/enderio/machines/machine/tank/TileTank.java
@@ -131,7 +131,8 @@ public class TileTank extends AbstractInventoryMachineEntity implements ITankAcc
       return false;
     }
     if (i == 0) {
-      return (FluidUtil.getFluidTypeFromItem(item) != null) || isValidInputItem(item, false);
+      FluidStack fluidType = FluidUtil.getFluidTypeFromItem(item);
+      return (fluidType != null && fluidType.amount > 0) || isValidInputItem(item, false);
     } else if (i == 1) {
       return FluidUtil.hasEmptyCapacity(item) || canBeMended(item) || isValidInputItem(item, true);
     } else if (i == 2 && canVoidItems()) {


### PR DESCRIPTION
Fixes an issue where ThermalCultivation's Watering Cans, when empty, go into the "drain" slot both via automation and GUI shift-click, preventing the can from being automatically refilled. (It remains in that slot forever.)