### PR TITLE
Fixed selection of travel anchor locations when rendered behind the player

### DIFF
--- a/enderio-base/src/main/java/crazypants/enderio/base/teleport/TravelController.java
+++ b/enderio-base/src/main/java/crazypants/enderio/base/teleport/TravelController.java
@@ -525,8 +525,8 @@ public class TravelController {
         double distance = distanceAndAngle[0];
         double angle = distanceAndAngle[1];
 
-        if (angle < getCandidateHitAngle()) {
-          // Valid hit, sort by distance now.
+        if (distance < closestDistance && angle < getCandidateHitAngle()) {
+          // Valid hit, sorted by distance.
           selectedCoord = bc;
           closestDistance = distance;
         }

--- a/enderio-base/src/main/java/crazypants/enderio/base/teleport/TravelController.java
+++ b/enderio-base/src/main/java/crazypants/enderio/base/teleport/TravelController.java
@@ -545,7 +545,7 @@ public class TravelController {
     if (selectedCoord != null) {
 
       Vector3d blockCenter = new Vector3d(selectedCoord.getX() + 0.5, selectedCoord.getY() + 0.5, selectedCoord.getZ() + 0.5);
-      Vector3d blockCenterScreenSpace = currentView.getScreenPoint(blockCenter);
+      Vector3d blockCenterScreenSpace = currentView.getScreenPoint3D(blockCenter);
       Vector2d blockCenterPixel = new Vector2d(blockCenterScreenSpace.x, blockCenterScreenSpace.y);
 
       Vector2d screenMidPixel = new Vector2d(Minecraft.getMinecraft().displayWidth, Minecraft.getMinecraft().displayHeight);
@@ -639,11 +639,12 @@ public class TravelController {
   }
 
   private double addRatio(@Nonnull BlockPos bc) {
-    Vector3d sp = currentView.getScreenPoint(new Vector3d(bc.getX() + 0.5, bc.getY() + 0.5, bc.getZ() + 0.5));
-    // If the point is behind the player (z > 0), return Double.MAX_VALUE to indicate this.
-    // Also don't add the candidate and its ratio, as it can otherwise result in points
-    // behind the screen plane being preferred before actual visible points.
-    if (sp.z > 0) {
+    Vector3d sp = currentView.getScreenPoint3D(new Vector3d(bc.getX() + 0.5, bc.getY() + 0.5, bc.getZ() + 0.5));
+    // For visible points (points beginning after the zNear plane, the projected z coordinate is [0,1].
+	// All other points (behind) have values in (1,inf). We return Double.MAX_VALUE to indicate this.
+    // Also we don't add the candidate and its ratio, as it can otherwise result in points
+    // behind the screen plane being preferred over actual visible points.
+    if (sp.z > 1) {
       return Double.MAX_VALUE;
     }
     Vector2d sp2d = new Vector2d(sp.x, sp.y);


### PR DESCRIPTION
Fixes #4773 

Requires change in EnderCore, which is in this related [pull request #109 for EnderCore](https://github.com/SleepyTrousers/EnderCore/pull/109)

When Optifine or other graphics mods are installed, Tileentities may be rendered even when not in the current frustum. This causes us to be able to teleport to travel anchors that are behind the player, which makes travelling with them really cumbersome.
This PR fixes this by manually culling points by their projected Z coordinate.

Disclaimer:
Unfortunately I could not test this change locally, as some unrelated parts of EnderIO fail to compile on my machine (my java "OpenJDK IcedTea 3.11.0" is more strict about several things like abstract classes etc.). While this is a small change, I could possibly have mistaken +Z and -Z for culling the points, which can be tested easily. If someone can compile EnderIO for me I am happy to test it.

For more information why i propose this change, have a look at the related [issue](https://github.com/SleepyTrousers/EnderIO/issues/4773).
