### PR TITLE
Update items.xml

### DIFF
--- a/enderio-base/src/main/resources/assets/enderio/config/recipes/items.xml
+++ b/enderio-base/src/main/resources/assets/enderio/config/recipes/items.xml
@@ -724,7 +724,7 @@ XML editor will display that as tooltips when editing this file.
     <crafting>
       <grid>
         <item /><item name="oredict:paper, paperBlack" /><item />
-        <item name="oredict:paper, paperBlack" /><item name="blockHopper" /><item name="oredict:paper, paperBlack" />
+        <item name="oredict:paper, paperBlack" /><item name="Hopper" /><item name="oredict:paper, paperBlack" />
         <item /><item name="oredict:paper, paperBlack" /><item/>
       </grid>
       <output name="enderio:item_basic_item_filter" />


### PR DESCRIPTION
In mc1.12.2 Hopper is not "blockHopper" but only "Hopper". that throw error on startup dw20(2.8.0 pack).