### PR TITLE
Updated Japanese translations

### DIFF
--- a/enderio-base/src/main/resources/assets/enderio/lang/ja_jp.lang
+++ b/enderio-base/src/main/resources/assets/enderio/lang/ja_jp.lang
@@ -80,12 +80,7 @@ item.item_conduit_facade.transparent.hardened.tooltip.detailed.line1=透過：�
 item.item_conduit_facade.transparent.hardened.tooltip.detailed.line2=強化：破壊や爆発に耐性を持つ
 
 item.item_conduit_probe.name=導管調査機
-item.item_conduit_probe.tooltip.detailed.line1=調査モードで導管を右クリックすると
-item.item_conduit_probe.tooltip.detailed.line2=ネットワーク内の詳細を表示。
-item.item_conduit_probe.tooltip.detailed.line3=コピー・ペーストモードで導管を
-item.item_conduit_probe.tooltip.detailed.line4=Shift 右クリックすると接続設定のコピーが可能。
-item.item_conduit_probe.tooltip.detailed.line5=コピー内容は右クリックでペーストが可能。
-item.item_conduit_probe.tooltip.detailed.line6=マウスホイールか「Y」キーでモードを変更。
+item.item_conduit_probe.tooltip.detailed=調査モードで導管を右クリックすると|ネットワーク内の詳細を表示。|コピー・ペーストモードで導管を|Shift 右クリックすると接続設定のコピーが可能。|コピー内容は右クリックでペーストが可能。|マウスホイールか「Y」キーでモードを変更。
 
 item.item_coord_selector.name=座標指定機
 item.item_coord_selector.tooltip.detailed.line1=ブロックの座標を紙に印刷。
@@ -396,11 +391,13 @@ tile.block_infinity_fog.tooltip.detailed.line1=インフィニティの粒が破
 tile.block_infinity_fog.tooltip.detailed.line2=空気中に放出されれば、即座に粉塵雲を形成し蔓延してしまう。形態は非常に不規則。触れることは、少なくとも健康に害を及ぼす危険があり、その影響は計り知れない。
 tile.block_infinity_fog.tooltip.detailed.line3=粉が降り積もろうものなら、その地は悪に侵されるであろう。§6§lエンダーマン§r§6を中心としたモンスターが現れ始めたらそれが最後だ。
 
-tile.block_holy_fog.name=グロウストーンナノ粒子
-tile.block_holy_fog.tooltip.common.line1=（PM2.5）
-tile.block_holy_fog.tooltip.detailed.line1=グロウストーンをナノレベルにまで粉砕することで、永続的に空中に存在させることが可能となる。
-tile.block_holy_fog.tooltip.detailed.line2=片手一杯の量で１６ブロックの範囲を覆う。
-tile.block_holy_fog.tooltip.detailed.line3=§lアンデッド§rに対して有効な場合がある。
+tile.block_holy_fog.name=グロウストーンナノ粒子（旧）
+
+tile.block_holier_fog.name=グロウストーンナノ粒子
+tile.block_holier_fog.tooltip.common.line1=（PM2.5）
+tile.block_holier_fog.tooltip.detailed.line1=グロウストーンをナノレベルにまで粉砕することで、永続的に空中に存在させることが可能となる。
+tile.block_holier_fog.tooltip.detailed.line2=片手一杯の量で広範囲を覆う。
+tile.block_holier_fog.tooltip.detailed.line3=§lアンデッド§rに対して有効な場合があるが、液体や雨に当たると流れてしまう。
 
 tile.block_infinity_0.name=インフィニティダストブロック
 tile.block_infinity_0.tooltip.common.line1=今にも崩れそうだ。
@@ -646,6 +643,7 @@ tile.block_painted_packed_ice_solid.name=塗装した氷塊
 tile.block_painted_slab.name=塗装したハーフブロック
 tile.block_painted_stair.name=塗装した階段
 tile.block_painted_stone.name=塗装した丸石
+tile.block_painted_sand.name=塗装した砂
 tile.block_painted_stone_double_slab.name=塗装した石のハーフブロック
 tile.block_painted_stone_fence.name=塗装した石のフェンス
 tile.block_painted_stone_slab.name=塗装した石のハーフブロック
@@ -689,19 +687,19 @@ enderio.block.tooltip.blastResistant=爆発耐性
 enderio.block.tooltip.lightEmitter=発光
 enderio.block.tooltip.lightBlocker=遮光
 
-enderio.block.tooltip.allowPlayers=Not solid for players
-enderio.block.tooltip.allowMonsters=Not solid for monsters
-enderio.block.tooltip.allowAnimals=Not solid for animals
-enderio.block.tooltip.disallowPlayers=Solid only for players
-enderio.block.tooltip.disallowMonsters=Solid only for monsters
-enderio.block.tooltip.disallowAnimals=Solid only for animals
+enderio.block.tooltip.allowPlayers=プレイヤー通過可
+enderio.block.tooltip.allowMonsters=モンスター通過可
+enderio.block.tooltip.allowAnimals=動物通過可
+enderio.block.tooltip.disallowPlayers=プレイヤーのみ通過不可
+enderio.block.tooltip.disallowMonsters=モンスターのみ通過不可
+enderio.block.tooltip.disallowAnimals=動物のみ通過不可
 
 
 enderio.grindingball.tooltip.line1=%s準自生粉砕機の粉砕用ボール
-enderio.grindingball.tooltip.line2=%s出力：%s％
-enderio.grindingball.tooltip.line3=%s副産出力：%s％
-enderio.grindingball.tooltip.line4=%s消費電力：%s％
-enderio.grindingball.gui.durability=残量：%s％
+enderio.grindingball.tooltip.line2=%s出力：%s%%
+enderio.grindingball.tooltip.line3=%s副産出力：%s%%
+enderio.grindingball.tooltip.line4=%s消費電力：%s%%
+enderio.grindingball.gui.durability=残量：%s%%
 
 enderio.gui.permission.denied=アクセス権がありません
 
@@ -723,7 +721,7 @@ enderio.config.personal.tooltip=案ずるな、口は堅い方だ
 #enderio.config.anchor=トラベルアンカー
 #enderio.config.anchor.tooltip=どこまでも続く
 #enderio.config.staff=トラベルスタッフ
-#enderio.config.staff.tooltip=いいか、使い方をちゃんと守るんだ 顔が吹っ飛ぶぞ
+#enderio.config.staff.tooltip=いいか、使い方をちゃんと守るんだ 顔だけ飛ぶぞ
 enderio.config.darksteel=ダークスチール
 enderio.config.darksteel.tooltip=スチールと§oダーク§r§eスチールは全くの別物だとなんども・・・
 enderio.config.aesthetic=外観設定
@@ -838,7 +836,7 @@ enderio.power.format.details=エネルギーの単位
 
 enderio.temperature.format.deg_c=%s ℃
 
-enderio.format.percent_efficiency=効率：%s％
+enderio.format.percent_efficiency=効率：%s%%
 
 enderio.fluid.millibucket.format=%s mB
 enderio.fluid.millibucket.format.name=%s mB / %s
@@ -884,8 +882,8 @@ enderio.darksteel.upgrade.spoon.tooltip.detailed.line1=スプーンがあれば�
 enderio.darksteel.upgrade.hoe.name=フォーク
 enderio.darksteel.upgrade.hoe.tooltip.detailed.line1=フォークがあれば、耕すのに苦労しないだろう。
 
-enderio.darksteel.upgrade.tnt.enabled=爆破を起動しました
-enderio.darksteel.upgrade.tnt.disabled=爆破を停止しました
+enderio.darksteel.upgrade.tnt.0.enabled=爆破を起動しました
+enderio.darksteel.upgrade.tnt.0.disabled=爆破を停止しました
 
 enderio.darksteel.upgrade.tnt.0.name=爆破 Ⅰ
 enderio.darksteel.upgrade.tnt.0.tooltip.detailed.line1=ツルハシに爆発性を加え、採掘時に周囲のブロックを巻き込む。
@@ -924,9 +922,6 @@ enderio.darksteel.upgrade.anvil.1.tooltip.detailed.line2=ホットキーまた�
 enderio.darksteel.upgrade.anvil.2.name=携帯金床
 enderio.darksteel.upgrade.anvil.2.tooltip.detailed.line1=金床同様の機能が扱え、全アイテムのアップグレード着脱が可能になる。
 enderio.darksteel.upgrade.anvil.2.tooltip.detailed.line2=ホットキーまたはアップグレードを持って Shift 右クリックすることで GUI を開く。
-
-enderio.darksteel.upgrade.step_assist.name=ステップアシスト
-enderio.darksteel.upgrade.step_assist.tooltip.detailed.line1=ブロックを階段のように乗り越えられるようになる。
 
 item.item_dark_steel_upgrade.name=ダークスチールアップグレードの型
 item.item_dark_steel_upgrade.with=ダークスチールアップグレード（%s）
@@ -1021,13 +1016,15 @@ enderio.darksteel.upgrade.thaumaturge_robes.legs.tooltip.detailed.line1=Vis 軽�
 enderio.darksteel.upgrade.thaumaturge_robes.feet.name=魔道士のブーツ
 enderio.darksteel.upgrade.thaumaturge_robes.feet.tooltip.detailed.line1=Vis 軽減：2%
 
-enderio.darksteel.upgrade.jump.enabled=跳躍を起動しました
-enderio.darksteel.upgrade.jump.disabled=跳躍を停止しました
-
 enderio.darksteel.upgrade.jump_one.name=跳躍
 enderio.darksteel.upgrade.jump_one.tooltip.detailed.line1=段差超えが可能になり、ジャンプ力が増加。
-enderio.darksteel.upgrade.stepAssist.enabled=ステップアシストを起動しました
-enderio.darksteel.upgrade.stepAssist.disabled=ステップアシストを停止しました
+enderio.darksteel.upgrade.jump_one.enabled=跳躍を起動しました
+enderio.darksteel.upgrade.jump_one.disabled=跳躍を停止しました
+
+enderio.darksteel.upgrade.step_assist.name=ステップアシスト
+enderio.darksteel.upgrade.step_assist.tooltip.detailed.line1=ブロックを階段のように乗り越えられるようになる。
+enderio.darksteel.upgrade.step_assist.enabled=ステップアシストを起動しました
+enderio.darksteel.upgrade.step_assist.disabled=ステップアシストを停止しました
 
 enderio.gui.step_assis_unavailable=ステップアシストは他の Mod により制限されている可能性があります
 
@@ -1041,8 +1038,8 @@ enderio.darksteel.upgrade.jump_three.tooltip.detailed.line2=三段ジャンプ�
 
 enderio.darksteel.upgrade.speed_one.name=俊足
 enderio.darksteel.upgrade.speed_one.tooltip.detailed.line1=移動速度が増加。
-enderio.darksteel.upgrade.speed.enabled=俊足を起動しました
-enderio.darksteel.upgrade.speed.disabled=俊足を停止しました
+enderio.darksteel.upgrade.speed_one.enabled=俊足を起動しました
+enderio.darksteel.upgrade.speed_one.disabled=俊足を停止しました
 
 enderio.darksteel.upgrade.speed_two.name=俊足 Ⅱ
 enderio.darksteel.upgrade.speed_two.tooltip.detailed.line1=移動速度が増加。
@@ -1057,6 +1054,8 @@ enderio.darksteel.upgrade.nightVision.enabled=暗視を起動しました
 enderio.darksteel.upgrade.nightVision.disabled=暗視を停止しました
 
 enderio.darksteel.upgrade.top.name=The One Probe
+enderio.darksteel.upgrade.top.enabled=The One Probe を起動しました
+enderio.darksteel.upgrade.top.disabled=The One Probe を停止しました
 
 # These are used for the "The One Probe" integration
 enderio.top.action.header.pre=§e
@@ -1174,7 +1173,7 @@ enderio.item_item_filter_upgrade.clear_config_warning=%sフィルターの設定
 
 enderio.gui.generic.max=最大発電・消費電力：%s
 enderio.gui.generic.loss=減衰：%s
-enderio.gui.generic.progress=進捗状況：%s ％
+enderio.gui.generic.progress=進捗状況：%s%%
 enderio.gui.generic.ioMode.overlay.tooltip=搬入出設定
 enderio.gui.generic.ioMode.overlay.tooltip.visible.line1=搬入出設定
 enderio.gui.generic.ioMode.overlay.tooltip.visible.line2=Shift クリックすると
@@ -1288,7 +1287,7 @@ enderio.loot.capacitor.entry.3=強いてこれを言い表すなら、「%s」�
 enderio.loot.capacitor.entry.4=強いてこれを言い表すなら、「%s」という名前にするのが精一杯だろう。
 enderio.loot.capacitor.entry.5=この「%s」は修繕屋ランドルフのものだ。安易に捨てることは許されないだろう。
 enderio.loot.capacitor.entry.6=この「%s」は元修繕屋ランドルフのものだ。捨てても問題ないだろう。
-enderio.loot.capacitor.entry.7=「%s」から Capacitor 1 への無償アップグレードが可能になりました。OK を押すか、キャンセルしてください。
+enderio.loot.capacitor.entry.7=「%s」から Capacitor１への無償アップグレードが可能になりました。OK を押すか、キャンセルしてください。
 enderio.loot.capacitor.entry.8=この「%s」を別の機械に入れて、どう機能するのか探るといい。Google 先生に頼るのも悪くないだろう。
 
 enderio.loot.capacitor.title.count=24
@@ -1315,12 +1314,12 @@ enderio.loot.capacitor.title.19=物体
 enderio.loot.capacitor.title.20=何か
 enderio.loot.capacitor.title.21=つまらない物
 enderio.loot.capacitor.title.22=助けて！ゲームに閉じ込められちゃったの！
-enderio.loot.capacitor.title.23=助けて！ゲーム工場に閉じ込められちゃったの！                                                         
+enderio.loot.capacitor.title.23=助けて！ゲーム工場に閉じ込められちゃったの！
 
 enderio.keybind.inventory=防具収納の開閉
 enderio.keybind.inventory.none_equipped=収納可能な防具を装備していません
 enderio.keybind.dsu=ダークスチールアップグレードインベントリの開閉
-enderio.keybind.glidertoggle=グライダー/エリトラの切り替え
+enderio.keybind.glidertoggle=グライダー/エリトラ
 enderio.keybind.soundlocator=音響探知
 enderio.keybind.nightvision=暗視
 enderio.keybind.gogglesofrevealing=洞察の眼鏡
@@ -1328,16 +1327,23 @@ enderio.keybind.stepassist=ステップアシスト
 enderio.keybind.speed=俊足
 enderio.keybind.jump=跳躍
 enderio.keybind.tnt=爆破
-enderio.keybind.top=The One Probe の切り替え（ヘルメットアップグレード）
+enderio.keybind.top=The One Probe（ヘルメットアップグレード）
 enderio.keybind.yetawrenchmode=イェタレンチのモード切り替え
 enderio.keybind.magnet=電磁石の切り替え
-enderio.keybind.fovplus=カメラのズームアウト
-enderio.keybind.fovminus=カメラのズームイン
-enderio.keybind.fovplusfast=カメラの高速ズームアウト
-enderio.keybind.fovminusfast=カメラの高速ズームイン
-enderio.keybind.fovreset=カメラのズームリセット
+enderio.keybind.fovplus=ズームアウト
+enderio.keybind.fovminus=ズームイン
+enderio.keybind.fovplusfast=高速ズームアウト
+enderio.keybind.fovminusfast=高速ズームイン
+enderio.keybind.fovreset=ズームリセット
+enderio.keybind.fovunreset=ズームの差し戻し（リセットの取り消し）
+enderio.keybind.fovstore=ズーム率の保存
+enderio.keybind.fovrecall=ズーム率の復元
+
+enderio.keybind.zoom.stored=ズーム率を保存しました
+
 key.category.darksteelarmor=ダークスチール防具
 key.category.tools=Ender IO 道具
+key.category.camera=カメラ操作
 
 enderio.gui.probe.copied=導管の設定をコピーしました
 enderio.gui.probe.pasted=導管の設定をペーストしました
@@ -1375,12 +1381,12 @@ enderio.advancement.gear.g5_vibrant_gear.desc=ヴァイブラントバイメタ�
 
 # Filters
 enderio.gui.item_filter.damage.disabled=耐久消耗無視
-enderio.gui.item_filter.damage.damage_00_25=２５％以下耐久消耗
-enderio.gui.item_filter.damage.damage_25_00=２６％以上耐久消耗
-enderio.gui.item_filter.damage.damage_00_50=５０％以下耐久消耗
-enderio.gui.item_filter.damage.damage_50_00=５１％以上耐久消耗
-enderio.gui.item_filter.damage.damage_00_75=７５％以下耐久消耗
-enderio.gui.item_filter.damage.damage_75_00=７６％以上耐久消耗
+enderio.gui.item_filter.damage.damage_00_25=２５%%以下耐久消耗
+enderio.gui.item_filter.damage.damage_25_00=２６%%以上耐久消耗
+enderio.gui.item_filter.damage.damage_00_50=５０%%以下耐久消耗
+enderio.gui.item_filter.damage.damage_50_00=５１%%以上耐久消耗
+enderio.gui.item_filter.damage.damage_00_75=７５%%以下耐久消耗
+enderio.gui.item_filter.damage.damage_75_00=７６%%以上耐久消耗
 enderio.gui.item_filter.damage.damage_00_00=耐久消耗なし
 enderio.gui.item_filter.damage.damage_01_00=耐久消耗あり
 enderio.gui.item_filter.damage.damage_yes=耐久消耗する
@@ -1497,7 +1503,7 @@ entity.enderio.enderio.owl_egg.name=フクロウの卵
 entity.enderio.primed_charge.name=着火した爆薬
 entity.enderio.enderio.primed_charge.name=着火した爆薬
 
-enderio.tooltip.inventory_charger.need_upgrade=§4エネルギークリスタルが設置されていません
+enderio.tooltip.inventory_charger.need_upgrade=§4エンパワーアップグレードが適用されていません
 enderio.tooltip.inventory_charger.enabled=アイテム充電器を起動しました
 enderio.tooltip.inventory_charger.disabled=アイテム充電器を停止しました
 
@@ -1514,3 +1520,17 @@ enderio.network.bad_config=エラー：Ender IO 設定の "%s.%s" の値は接�
 enderio.network.autosync.connected=§4§l以下の値はサーバー側で固定されています。\u000a§e%s
 enderio.network.autosync.offline=%s\u000a§o以上の値はサーバー側と同様に設定してください。
 enderio.network.manusync=%s\u000a§o以上の値はサーバー側で固定されています。
+
+enderio.jei.notSimple.line1=このレシピは簡易型機械では
+enderio.jei.notSimple.line2=扱えない。
+enderio.jei.notNormal.line1=このレシピは簡易型および
+enderio.jei.notNormal.line2=通常型の機械では扱えない。
+
+enderio.gui.travel_accessable.skip.locked=ロックされたアンカーをスキップしました
+enderio.gui.travel_accessable.skip.private=塞がれたアンカーをスキップしました
+enderio.gui.travel_accessable.skip.obstructed=非公開アンカーをスキップしました
+enderio.gui.travel_accessable.unauthorized=このブロックへのアクセスは許可されていません
+enderio.gui.travel_accessable.outofrange=目的地は範囲外です
+enderio.gui.travel_accessable.invalidtarget=目的地は塞がれています
+
+enderio.gui.too_many_levels=レベル２１８６２以上となる所持経験値量では多すぎます

--- a/enderio-conduits-mekanism/src/main/resources/assets/gasconduits/lang/ja_jp.lang
+++ b/enderio-conduits-mekanism/src/main/resources/assets/gasconduits/lang/ja_jp.lang
@@ -1,0 +1,29 @@
+#PARSE_ESCAPES
+# ^ having this in the first line allows us to use "\uXXXX" escapes in this file
+
+enderio.item_gas_conduit.name=ガス導管
+enderio.item_gas_conduit_advanced.name=加圧式ガス導管
+enderio.item_gas_conduit_ender.name=エンダーガス導管
+gasconduits.item_gas_conduit.locked_type=ガスの種類を %s にロックしました
+gasconduits.item_gas_conduit.unlocked_type=ガスの種類のロックを解除しました
+gasconduits.item_gas_conduit.locked_waila=%s にロック中
+
+gasconduits.gas.millibuckets_tick=mB/t
+gasconduits.item_gas_conduit.tooltip.max_extract=最大搬出：
+gasconduits.item_gas_conduit.tooltip.max_io=最大入出力：
+
+
+gasconduits.gas.millibuckets_tick=mB/t
+
+gasconduits.gui.gas_auto_extract=自動搬出
+gasconduits.gui.gas_filter=ガスフィルター
+gasconduits.gui.gas_whitelist=ホワイトリスト
+gasconduits.gui.gas_blacklist=ブラックリスト
+
+
+
+gasconduits.gui.conduit_gas.header=ガス導管
+gasconduits.config.condit.gas=ガス導管
+
+
+item.item_gas_filter.name=ガスフィルター

--- a/enderio-conduits/src/main/resources/assets/enderio/lang/ja_jp.lang
+++ b/enderio-conduits/src/main/resources/assets/enderio/lang/ja_jp.lang
@@ -80,7 +80,7 @@ enderio.gui.power_monitor.engine_control=エンジン制御
 enderio.gui.power_monitor.emit=Emit
 enderio.gui.power_monitor.engine_section1=ストレージが以下より少ない際に信号を
 enderio.gui.power_monitor.engine_section2=出力：
-enderio.gui.power_monitor.engine_section3=％
+enderio.gui.power_monitor.engine_section3=%%
 enderio.gui.power_monitor.engine_section4=ストレージが以下の割合以上で停止：
 enderio.gui.power_monitor.engine_section5=
 enderio.gui.power_monitor.of=/
@@ -175,7 +175,7 @@ enderio.gui.liquid_filter=フィルター
 enderio.gui.liquid_whitelist=ホワイトリスト
 enderio.gui.liquid_blacklist=ブラックリスト
 enderio.gui.liquid_function_upgrade.details=出力量：
-enderio.gui.liquid_function_upgrade.details2=一度に %s％ / %s
+enderio.gui.liquid_function_upgrade.details2=一度に %s%% / %s
 
 enderio.gui.redstone_signal_strength=強信号
 

--- a/enderio-integration-forestry/src/main/resources/assets/enderio/lang/ja_jp.lang
+++ b/enderio-integration-forestry/src/main/resources/assets/enderio/lang/ja_jp.lang
@@ -26,3 +26,7 @@ enderio.darksteel.upgrade.apiarist_armor.feet.tooltip.detailed.line1=蜂の攻�
 enderio.config.items.darksteel.upgrades.forestry=Forestry アップグレード
 
 item.item_species_item_filter.name=品種アイテムフィルター
+
+enderio.gui.conduit.item.species.primary_icon=上段でフィルタリング
+enderio.gui.conduit.item.species.secondary_icon=下段でフィルタリング
+enderio.gui.conduit.item.species.both_icon=両方でフィルタリング

--- a/enderio-invpanel/src/main/resources/assets/enderio/lang/ja_jp.lang
+++ b/enderio-invpanel/src/main/resources/assets/enderio/lang/ja_jp.lang
@@ -1,10 +1,11 @@
 // Inv Panel
 tile.block_inventory_panel.name=インベントリパネル
 tile.block_inventory_panel.tooltip.basic.line1=ストレージの遠隔操作とクラフトが可能。
-tile.block_inventory_panel.tooltip.detailed.line1=遠隔認識アップグレードが搭載されたアイテム導管に
+tile.block_inventory_panel.tooltip.detailed.line1=データまたはアイテムの導管に
 tile.block_inventory_panel.tooltip.detailed.line2=接続されたストレージへのアクセスが可能。
 tile.block_inventory_panel.tooltip.detailed.line3=稼働には栄養蒸留液が必要。
 tile.block_inventory_panel.tooltip.detailed.line4=クラフト枠が付属。
+tile.block_inventory_panel.tooltip.detailed.line5=染料で Shift クリックすると着色可能。
 
 enderio.item_data_conduit.name=データ導管
 
@@ -13,7 +14,8 @@ enderio.gui.inventorypanel.header.crafting=クラフト枠
 enderio.gui.inventorypanel.header.return=返送物置き場
 enderio.gui.inventorypanel.header.storage=保存物置き場
 enderio.gui.inventorypanel.info.filter=<アイテム検索>
-enderio.gui.inventorypanel.info.offline=<オフライン>
+enderio.gui.inventorypanel.info.offline=<燃料不足>
+enderio.gui.inventorypanel.info.noconnection=<接続なし>
 enderio.gui.inventorypanel.tooltip.return.line1=アイテムの返送場所。
 enderio.gui.inventorypanel.tooltip.return.line2=ここに置かれたアイテムは
 enderio.gui.inventorypanel.tooltip.return.line3=アイテム導管へ輸送されるが、
@@ -54,10 +56,13 @@ enderio.gui.inventorypanel.tooltip.addrecipe.line5=Shift 左クリックでク�
 enderio.gui.inventorypanel.tooltip.addrecipe.line6=必要なアイテムを可能な限り配置。
 enderio.gui.inventorypanel.tooltip.addrecipe.line7=登録レシピは右クリックで削除可能。
 enderio.gui.inventorypanel.tooltip.sync=NEI/JEI と同期
-enderio.gui.inventorypanel.tooltip.sync.nei=NEI と同期
 enderio.gui.inventorypanel.tooltip.sync.jei=JEI と同期
 enderio.gui.inventorypanel.tooltip.sync.jei.line1=検索窓に入力した文字を反映
 enderio.gui.inventorypanel.tooltip.sync.jei.line2=JEI の検索窓に入力した文字を非反映
+enderio.gui.inventorypanel.tooltip.recipe.store=クリックでレシピ保存
+enderio.gui.inventorypanel.tooltip.recipe.load=クリックでレシピ読み込み
+enderio.gui.inventorypanel.tooltip.recipe.loadstacks=Shift クリックでレシピ読み込み（スタック）
+enderio.gui.inventorypanel.tooltip.recipe.delete=Ctrl + Shift 右クリックでレシピ削除
 
 // Sensor
 tile.block_inventory_panel_sensor.name=インベントリセンサー
@@ -85,12 +90,12 @@ item.item_inventory_remote_basic.tooltip.detailed.line2=パネルを Shift 右�
 item.item_inventory_remote_basic.tooltip.detailed.line3=稼働には{FLUIDNAME}と電力が必要。
 
 item.item_inventory_remote_advanced.name=遠隔型強化インベントリパネル
-item.item_inventory_remote_advanced.tooltip.detailed.line1=同じディメンション内のどこからでもインベントリパネルにアクセスが可能。
+item.item_inventory_remote_advanced.tooltip.detailed.line1=同じディメンション内のどこからでもインベントリパネルにアクセスが可能（要チャンクロード）。
 item.item_inventory_remote_advanced.tooltip.detailed.line2=パネルを Shift 右クリックすると登録が可能。
 item.item_inventory_remote_advanced.tooltip.detailed.line3=稼働には{FLUIDNAME}と電力が必要。
 
 item.item_inventory_remote_ender.name=遠隔型エンダーインベントリパネル
-item.item_inventory_remote_ender.tooltip.detailed.line1=どこからでもインベントリパネルへのアクセスが可能。
+item.item_inventory_remote_ender.tooltip.detailed.line1=どこからでもインベントリパネルへのアクセスが可能（要チャンクロード）。
 item.item_inventory_remote_ender.tooltip.detailed.line2=パネルを Shift 右クリックすると登録が可能。
 item.item_inventory_remote_ender.tooltip.detailed.line3=稼働には{FLUIDNAME}と電力が必要。
 

--- a/enderio-machines/src/main/resources/assets/enderio/lang/ja_jp.lang
+++ b/enderio-machines/src/main/resources/assets/enderio/lang/ja_jp.lang
@@ -28,7 +28,7 @@ enderio.gui.ranged.hideRange=範囲を非表示
 enderio.gui.ranged.range=範囲：%s
 
 enderio.gui.stirling_generator.output=発電中：%s
-enderio.gui.stirling_generator.efficiency=燃焼効率：%s％
+enderio.gui.stirling_generator.efficiency=燃焼効率：%s%%
 enderio.gui.stirling_generator.upgradeslot=アップグレードスロット
 enderio.gui.stirling_generator.upgrades={0}：{2}{1,number,#.#}x{3} 効率上昇
 enderio.gui.stirling_generator.remaining=残り {0,number,percent}|{1,choice,0#|0<{1} 分 }{2,number} 秒|{3,number,#,###} µI
@@ -220,6 +220,8 @@ tile.block_attractor_obelisk.name=魅惑のオベリスク
 tile.block_attractor_obelisk.tooltip.detailed.line1=Mob を引き寄せる。
 tile.block_attractor_obelisk.tooltip.detailed.line2=内部に魂を配置すると、対象となる Mob を指定可能。
 
+enderio.status.attractor_obelisk.unknown_mob=魅惑のオベリスク（%s）：%s の引き寄せ方が不明です
+
 tile.block_aversion_obelisk.name=憎悪のオベリスク
 tile.block_aversion_obelisk.tooltip.detailed.line1=効果範囲内での Mob のスポーンを阻止。
 
@@ -271,6 +273,9 @@ tile.block_solar_panel.simple.name=簡易型太陽電池
 tile.block_solar_panel.name=太陽電池
 tile.block_solar_panel.advanced.name=改良型太陽電池
 tile.block_solar_panel.vibrant.name=ヴァイブラント太陽電池
+tile.block_solar_panel.compressed.name=結晶性太陽電池
+tile.block_solar_panel.concentrated.name=メロディック太陽電池
+tile.block_solar_panel.ultimate.name=ステラ太陽電池
 tile.block_solar_panel.tooltip.common.line1=Solar Power!
 tile.block_solar_panel.tooltip.detailed.line1=日中に電力を発電。
 tile.block_solar_panel.tooltip.detailed.line2=上空に遮るものがあると発電不可。
@@ -387,7 +392,7 @@ tile.block_niard.tooltip.detailed.line2=このアイテム（The Niard）の改�
 # green=Farming Station area, red=Stirling Generator power generation, mobby=spawner speedup,
 # crushed=sag mill speed, cleancut=slice'n'splice speed, tight=soul binder speed, aa=painter,
 # wet=vat, kaboom=combustion gen power gen, fatman=codename for the atomic bomb that was
-# detonated over Nagasaki 
+# detonated over Nagasaki
 enderio.loot.capacitor.smelting=焼けた%s
 enderio.loot.capacitor.area=大きな%s
 enderio.loot.capacitor.green=栽培家の%s
@@ -401,7 +406,7 @@ enderio.loot.capacitor.wet=料理用の%s
 enderio.loot.capacitor.kaboom=短気な%s
 enderio.loot.capacitor.fatman=原子力的%s
 
-enderio.jei.sagmill.outputchance=副産確率：{0,choice,0#'<1'|0<{0,number}}％
+enderio.jei.sagmill.outputchance=副産確率：{0,choice,0#'<1'|0<{0,number}}%%
 enderio.jei.sagmill.outputchance.ball=%s（粉砕ボールにより変動）
 enderio.jei.sagmill.nomains=レシピにより副産無効化中。100
 enderio.jei.combustion_generator.range.line1=発電量はコンデンサと発電機のグレードに依存
@@ -412,10 +417,8 @@ enderio.jei.stirling_generator.range.line1=実際の発電量は、コンデン�
 enderio.jei.stirling_generator.range.line2=
 enderio.jei.stirling_generator.notSimple.line1=この燃料は、簡易型スターリング発電機では使用できない。
 enderio.jei.stirling_generator.notSimple.line2=
-enderio.jei.alloy_smelter.notSimple.line1=このレシピは、簡易型合金精錬機では扱えない。
-enderio.jei.alloy_smelter.notSimple.line2=
 enderio.jei.grinding_ball.main.line1=粉砕したアイテムを確率で増加させる。
-enderio.jei.grinding_ball.bonus.line1=副産確率を増加させるが、１００％を上回る、すなわち個数が増加することはない。
+enderio.jei.grinding_ball.bonus.line1=副産確率を増加させるが、１００%%を上回る、すなわち個数が増加することはない。
 enderio.jei.grinding_ball.bonus.line2=元の確率 * 副産確率（この値）で計算される。
 enderio.jei.grinding_ball.power.line1=稼働時の消費電力に影響を与え、粉砕速度も伴って増減する。
 enderio.jei.recipe=レシピ："%s"
@@ -434,6 +437,14 @@ enderio.darksteel.upgrade.solar_2.tooltip.detailed.line1=太陽光から発電�
 enderio.darksteel.upgrade.solar_3.name=ソーラー Ⅲ
 enderio.darksteel.upgrade.solar_3.tooltip.detailed.line1=太陽光から発電。
 
+enderio.darksteel.upgrade.solar_4.name=ソーラー Ⅳ
+enderio.darksteel.upgrade.solar_4.tooltip.detailed.line1=太陽光から発電。
+
+enderio.darksteel.upgrade.solar_5.name=ソーラー Ⅴ
+enderio.darksteel.upgrade.solar_5.tooltip.detailed.line1=太陽光から発電。
+
+enderio.darksteel.upgrade.solar_6.name=ソーラー Ⅵ
+enderio.darksteel.upgrade.solar_6.tooltip.detailed.line1=太陽光から発電。
 enderio.config.capacitor=コンデンサの値
 enderio.config.client=クライアント設定
 

--- a/enderio-zoo/src/main/resources/assets/enderio/lang/ja_jp.lang
+++ b/enderio-zoo/src/main/resources/assets/enderio/lang/ja_jp.lang
@@ -1,8 +1,8 @@
 
 entity.enderiozoo.enderminy.name=エンダーミニー
 entity.enderiozoo.concussioncreeper.name=震動クリーパー
-entity.enderiozoo.fallenknight.name=堕落騎士
-entity.enderiozoo.fallenmount.name=堕落馬
+entity.enderiozoo.fallenknight.name=堕落した騎士
+entity.enderiozoo.fallenmount.name=堕落した馬
 entity.enderiozoo.witherwitch.name=ウィザーウィッチ
 entity.enderiozoo.withercat.name=ウィザーキャット
 entity.enderiozoo.direwolf.name=ダイアーウルフ
@@ -10,4 +10,4 @@ entity.enderiozoo.direslime.name=ケンドレルケート
 entity.enderiozoo.owl.name=フクロウ
 entity.enderiozoo.lovechild.name=エンダー感染ゾンビ
 entity.enderiozoo.epicsquid.name=スゴいイカ
-
+entity.enderiozoo.voidslime.name=インフィニティスポーン


### PR DESCRIPTION
Update summary:

- Translated new strings<br>新規追加分を翻訳しました
- Changed the percent sign from full-width to half-width based on the official translation<br>公式翻訳に則り、パーセント記号を全角から半角に変更しました
- Changed the following translations<br>以下の翻訳を改訳しました
  - "堕落騎士" (Fallen Knight) -> "堕落した騎士"
  - "堕落馬" (Fallen Steed) -> "堕落した馬"