### PR TITLE
Fix Forge maven URL and provide instructions on how to build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ enderio-base/\.checkstyle
 
 **/Corel Auto-Preserve/
 
+## EnderCore lib
+
+/lib/EnderCore*deobf.jar

--- a/README.md
+++ b/README.md
@@ -20,3 +20,11 @@ Below sounds are used under [CC BY 3.0](https://creativecommons.org/licenses/by/
 - https://freesound.org/people/LiamG_SFX/
 - https://freesound.org/people/kuchenanderung1/
 - https://freesound.org/people/170048@virtualwindow.co.za/
+
+### How to compile
+
+1. Clone this repository.
+2. Download the matching EnderCore deobf jar from https://maven.tterrag.com/ and place it in `lib`.
+3. Duplicate `user.properties.example` and rename it to `user.properties` in the root folder of this repository.
+4. `./gradlew setupDecompWorkspace`
+5. `./gradlew build`

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
         maven {
             name = "forge"
-            url = "http://files.minecraftforge.net/maven"
+            url = "https://maven.minecraftforge.net/"
         }
         maven {
             url "https://plugins.gradle.org/m2/"
@@ -104,7 +104,7 @@ allprojects {
         maven { url = "http://maven.tterrag.com" }
         maven { url = "http://maven2.tterrag.com" }
         maven { url = "http://dvs1.progwml6.com/files/maven" }
-        maven { url = "http://files.minecraftforge.net/maven" }
+        maven { url = "https://maven.minecraftforge.net" }
         maven { url = "http://maven.cil.li/" } // OpenComputers
         maven { url = "http://maven.ic2.player.to" }
         maven { url = "https://maven.mcmoddev.com" } // ???, dead as of 2021-01-10, back as of 2021-05-24

--- a/build.gradle
+++ b/build.gradle
@@ -117,7 +117,7 @@ allprojects {
         maven { url = "https://www.cursemaven.com" } // Mekanism
         //maven { url = "https://repo.raoulvdberge.com/" } // Refined Storage (new)
         //maven { url = "https://repo.refinedmods.com/" } // Refined Storage (double-plus new)
-        maven { url = "https://maven.hypherionmc.me/" } // our backups for vanished sources
+        maven { url = "https://maven.hypherionmc.me/releases" } // our backups for vanished sources
         // maven { url = "https://modmaven.dev/" } // appeng etc. but mostly 1.16 stuff
         mavenLocal()
     }


### PR DESCRIPTION
Without the Maven change, builds will fail because `forgeSrc.jar` is unavailable.

I've also added the EnderCore JAR to `.gitignore` so it doesn't show up as an untracked file.